### PR TITLE
fix: resolve Docker startup failures and admin Select errors

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,10 +28,10 @@ COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
 
 EXPOSE 3000
 
-# Start: migrate schema, seed initial data (all upserts — safe to re-run), then serve
-CMD npx prisma migrate deploy && \
-    npx ts-node --compiler-options '{"module":"CommonJS"}' --transpile-only prisma/seed.ts && \
-    npm run start:prod
+# Start: migrate schema (with P3005 baseline handling), seed initial data, then serve
+CMD ["sh", "docker-entrypoint.sh"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+
+# Resolve any previously failed migrations so deploy can proceed
+npx prisma migrate resolve --rolled-back "20260328000002_fix_schema_drift" 2>/dev/null || true
+
+# Attempt migrate deploy; if P3005 (non-empty DB with no migration history), baseline first
+if ! deploy_output=$(npx prisma migrate deploy 2>&1); then
+  echo "$deploy_output"
+  if echo "$deploy_output" | grep -q "P3005"; then
+    echo "Detected P3005 — baselining existing migrations..."
+    npx prisma migrate resolve --applied "20260308122554_init"
+    npx prisma migrate resolve --applied "20260317150938_add_analytics_training"
+    npx prisma migrate resolve --applied "20260321032903_flashcards_init"
+    npx prisma migrate resolve --applied "20260326144134_add_timer_mode_and_trap_question"
+    npx prisma migrate resolve --applied "20260328000000_ai_question_bank"
+    npx prisma migrate resolve --applied "20260328000001_add_user_status"
+    npx prisma migrate resolve --applied "20260328000002_fix_schema_drift"
+    npx prisma migrate resolve --applied "20260328000003_add_question_soft_delete"
+    echo "Baseline complete. Running migrate deploy..."
+    npx prisma migrate deploy
+  else
+    exit 1
+  fi
+else
+  echo "$deploy_output"
+fi
+
+echo "Seeding database..."
+npx ts-node --compiler-options '{"module":"CommonJS"}' --transpile-only prisma/seed.ts
+
+echo "Starting application..."
+exec npm run start:prod

--- a/backend/prisma/migrations/20260328000001_add_user_status/migration.sql
+++ b/backend/prisma/migrations/20260328000001_add_user_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'BANNED');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "status" "UserStatus" NOT NULL DEFAULT 'ACTIVE';

--- a/backend/prisma/migrations/20260328000002_fix_schema_drift/migration.sql
+++ b/backend/prisma/migrations/20260328000002_fix_schema_drift/migration.sql
@@ -1,0 +1,100 @@
+-- =========================================================
+-- Idempotent migration: reconcile schema.prisma with prior
+-- migration SQL that was written against an older schema.
+-- Safe to run on both fresh and pre-existing databases.
+-- =========================================================
+
+-- 1. Create providers table (was never in any migration)
+CREATE TABLE IF NOT EXISTS "providers" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "logo_url" TEXT,
+    "website" TEXT,
+    "description" TEXT,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "providers_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "providers_name_key" ON "providers"("name");
+CREATE UNIQUE INDEX IF NOT EXISTS "providers_slug_key" ON "providers"("slug");
+
+-- 2. Handle certifications table:
+--    - The init migration created it with "provider TEXT NOT NULL" (old design).
+--    - The current schema uses "provider_id TEXT" FK to providers.
+--    - We need to: make old "provider" column nullable (so Prisma inserts don't fail),
+--      add "provider_id" column, and add the FK constraint.
+DO $$
+BEGIN
+    -- Make legacy "provider" column nullable if it still exists
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'certifications' AND column_name = 'provider'
+    ) THEN
+        ALTER TABLE "certifications" ALTER COLUMN "provider" DROP NOT NULL;
+    END IF;
+
+    -- Add provider_id column if missing
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'certifications' AND column_name = 'provider_id'
+    ) THEN
+        ALTER TABLE "certifications" ADD COLUMN "provider_id" TEXT;
+    END IF;
+
+    -- Add FK constraint if missing
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'certifications_provider_id_fkey'
+          AND table_name = 'certifications'
+    ) THEN
+        ALTER TABLE "certifications"
+            ADD CONSTRAINT "certifications_provider_id_fkey"
+            FOREIGN KEY ("provider_id") REFERENCES "providers"("id")
+            ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- 3. Add missing columns to users table
+--    Also cover "status" in case migration 00001 was baselined (not run) on an existing DB.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'UserStatus') THEN
+        CREATE TYPE "UserStatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'BANNED');
+    END IF;
+END $$;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "status" "UserStatus" NOT NULL DEFAULT 'ACTIVE';
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "suspended_until" TIMESTAMP(3);
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "ban_reason" TEXT;
+
+-- 4. Create audit_logs table (was never in any migration)
+CREATE TABLE IF NOT EXISTS "audit_logs" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "target_type" TEXT NOT NULL,
+    "target_id" TEXT NOT NULL,
+    "metadata" JSONB,
+    "ip_address" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "audit_logs_action_idx" ON "audit_logs"("action");
+CREATE INDEX IF NOT EXISTS "audit_logs_target_type_target_id_idx" ON "audit_logs"("target_type", "target_id");
+CREATE INDEX IF NOT EXISTS "audit_logs_created_at_idx" ON "audit_logs"("created_at");
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'audit_logs_user_id_fkey'
+          AND table_name = 'audit_logs'
+    ) THEN
+        ALTER TABLE "audit_logs"
+            ADD CONSTRAINT "audit_logs_user_id_fkey"
+            FOREIGN KEY ("user_id") REFERENCES "users"("id")
+            ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/backend/prisma/migrations/20260328000003_add_question_soft_delete/migration.sql
+++ b/backend/prisma/migrations/20260328000003_add_question_soft_delete/migration.sql
@@ -1,0 +1,2 @@
+-- Add soft-delete column to questions table
+ALTER TABLE "questions" ADD COLUMN IF NOT EXISTS "deleted_at" TIMESTAMP(3);

--- a/src/pages/admin/AiGenerationTab.tsx
+++ b/src/pages/admin/AiGenerationTab.tsx
@@ -25,14 +25,14 @@ const CONTENT_TYPE_ICON: Record<string, React.ReactNode> = {
 export function AiGenerationTab() {
   const qc = useQueryClient();
   const [tab, setTab] = useState<'jobs' | 'materials'>('jobs');
-  const [statusFilter, setStatusFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
   const [jobPage, setJobPage] = useState(1);
   const [matPage, setMatPage] = useState(1);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
   const { data: jobsData, isLoading: jobsLoading } = useQuery({
     queryKey: ['admin-generation-jobs', statusFilter, jobPage],
-    queryFn: () => getAdminGenerationJobs({ status: statusFilter || undefined, page: jobPage }),
+    queryFn: () => getAdminGenerationJobs({ status: statusFilter === 'all' ? undefined : statusFilter, page: jobPage }),
   });
 
   const { data: matsData, isLoading: matsLoading } = useQuery({
@@ -66,7 +66,7 @@ export function AiGenerationTab() {
             <Select value={statusFilter} onValueChange={v => { setStatusFilter(v); setJobPage(1); }}>
               <SelectTrigger className="w-40 font-mono text-xs"><SelectValue placeholder="All statuses" /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="">All statuses</SelectItem>
+                <SelectItem value="all">All statuses</SelectItem>
                 <SelectItem value="PENDING">Pending</SelectItem>
                 <SelectItem value="PROCESSING">Processing</SelectItem>
                 <SelectItem value="COMPLETED">Completed</SelectItem>

--- a/src/pages/admin/DomainsTab.tsx
+++ b/src/pages/admin/DomainsTab.tsx
@@ -12,14 +12,14 @@ import { getCertifications } from '@/services/certifications';
 
 export function DomainsTab() {
   const qc = useQueryClient();
-  const [certFilter, setCertFilter] = useState('');
+  const [certFilter, setCertFilter] = useState('all');
   const [dialog, setDialog] = useState<{ mode: 'create' | 'edit'; id?: string; name: string; certificationId: string; description: string; weight: string } | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
   const { data: certs = [] } = useQuery({ queryKey: ['certifications', true], queryFn: () => getCertifications(true) });
   const { data, isLoading } = useQuery({
     queryKey: ['admin-domains', certFilter],
-    queryFn: () => getAdminDomains({ certificationId: certFilter || undefined, limit: 100 }),
+    queryFn: () => getAdminDomains({ certificationId: certFilter === 'all' ? undefined : certFilter, limit: 100 }),
   });
 
   const saveMutation = useMutation({
@@ -49,13 +49,13 @@ export function DomainsTab() {
               <SelectValue placeholder="All certifications" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">All certifications</SelectItem>
+              <SelectItem value="all">All certifications</SelectItem>
               {certs.map(c => <SelectItem key={c.id} value={c.id}>{c.code} – {c.name}</SelectItem>)}
             </SelectContent>
           </Select>
           <span className="text-xs text-muted-foreground font-mono">{domains.length} domains</span>
         </div>
-        <Button size="sm" className="font-mono text-xs" onClick={() => setDialog({ mode: 'create', name: '', certificationId: certFilter, description: '', weight: '' })}>
+        <Button size="sm" className="font-mono text-xs" onClick={() => setDialog({ mode: 'create', name: '', certificationId: certFilter === 'all' ? '' : certFilter, description: '', weight: '' })}>
           <Plus className="h-3 w-3 mr-1" /> Add Domain
         </Button>
       </div>

--- a/src/pages/admin/ExamsTab.tsx
+++ b/src/pages/admin/ExamsTab.tsx
@@ -21,12 +21,12 @@ const VISIBILITY_ICONS: Record<string, React.ReactNode> = {
 
 export function ExamsTab() {
   const qc = useQueryClient();
-  const [visFilter, setVisFilter] = useState('');
+  const [visFilter, setVisFilter] = useState('all');
   const [page, setPage] = useState(1);
 
   const { data, isLoading } = useQuery({
     queryKey: ['admin-exams', visFilter, page],
-    queryFn: () => getAdminExams({ visibility: visFilter || undefined, page }),
+    queryFn: () => getAdminExams({ visibility: visFilter === 'all' ? undefined : visFilter, page }),
   });
 
   const visMutation = useMutation({
@@ -43,7 +43,7 @@ export function ExamsTab() {
         <Select value={visFilter} onValueChange={v => { setVisFilter(v); setPage(1); }}>
           <SelectTrigger className="w-40 font-mono text-xs"><SelectValue placeholder="All visibility" /></SelectTrigger>
           <SelectContent>
-            <SelectItem value="">All visibility</SelectItem>
+            <SelectItem value="all">All visibility</SelectItem>
             <SelectItem value="PUBLIC">Public</SelectItem>
             <SelectItem value="PRIVATE">Private</SelectItem>
             <SelectItem value="LINK">Link only</SelectItem>

--- a/src/pages/admin/TagsTab.tsx
+++ b/src/pages/admin/TagsTab.tsx
@@ -13,7 +13,7 @@ import { getCertifications } from '@/services/certifications';
 
 export function TagsTab() {
   const qc = useQueryClient();
-  const [certFilter, setCertFilter] = useState('');
+  const [certFilter, setCertFilter] = useState('all');
   const [search, setSearch] = useState('');
   const [dialog, setDialog] = useState<{ mode: 'create' | 'edit'; id?: string; name: string; certificationId: string } | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
@@ -24,7 +24,7 @@ export function TagsTab() {
   const { data: certs = [] } = useQuery({ queryKey: ['certifications', true], queryFn: () => getCertifications(true) });
   const { data: tags = [], isLoading } = useQuery({
     queryKey: ['admin-tags', certFilter],
-    queryFn: () => getAdminTags(certFilter || undefined),
+    queryFn: () => getAdminTags(certFilter === 'all' ? undefined : certFilter),
   });
 
   const filtered = tags.filter((t: any) => t.name.toLowerCase().includes(search.toLowerCase()));
@@ -70,7 +70,7 @@ export function TagsTab() {
               <SelectValue placeholder="All certifications" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">All certifications</SelectItem>
+              <SelectItem value="all">All certifications</SelectItem>
               {certs.map(c => <SelectItem key={c.id} value={c.id}>{c.code} – {c.name}</SelectItem>)}
             </SelectContent>
           </Select>
@@ -82,7 +82,7 @@ export function TagsTab() {
               <Merge className="h-3 w-3 mr-1" /> Merge ({selected.size})
             </Button>
           )}
-          <Button size="sm" className="font-mono text-xs" onClick={() => setDialog({ mode: 'create', name: '', certificationId: certFilter })}>
+          <Button size="sm" className="font-mono text-xs" onClick={() => setDialog({ mode: 'create', name: '', certificationId: certFilter === 'all' ? '' : certFilter })}>
             <Plus className="h-3 w-3 mr-1" /> Add Tag
           </Button>
         </div>
@@ -140,10 +140,10 @@ export function TagsTab() {
             {dialog?.mode === 'create' && (
               <div>
                 <label className="text-xs font-mono text-muted-foreground mb-1 block">Certification (optional)</label>
-                <Select value={dialog?.certificationId ?? ''} onValueChange={v => setDialog(d => d ? { ...d, certificationId: v } : d)}>
+                <Select value={dialog?.certificationId || 'global'} onValueChange={v => setDialog(d => d ? { ...d, certificationId: v === 'global' ? '' : v } : d)}>
                   <SelectTrigger className="font-mono text-xs"><SelectValue placeholder="Global tag" /></SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Global</SelectItem>
+                    <SelectItem value="global">Global</SelectItem>
                     {certs.map(c => <SelectItem key={c.id} value={c.id}>{c.code} – {c.name}</SelectItem>)}
                   </SelectContent>
                 </Select>


### PR DESCRIPTION
## Summary

- **Docker P3005 baseline handling**: Added `docker-entrypoint.sh` that detects when a pre-existing database has no migration history and baselines all existing migrations before deploying new ones — preventing container crash-loops on first start against a pre-populated DB
- **Schema drift migrations**: Added 3 migrations to close the gap between `schema.prisma` and the migration SQL history:
  - `20260328000001_add_user_status` — `UserStatus` enum + `users.status` column
  - `20260328000002_fix_schema_drift` — `providers` table, `certifications.provider_id` FK, `users.suspended_until/ban_reason`, `audit_logs` table (all idempotent via `IF NOT EXISTS`)
  - `20260328000003_add_question_soft_delete` — `questions.deleted_at` column
- **Admin Select fix**: Replaced `value=""` on `<SelectItem>` "All" options with sentinel strings (`"all"`, `"global"`) across `AiGenerationTab`, `ExamsTab`, `DomainsTab`, and `TagsTab` — Radix UI prohibits empty-string values as they conflict with the clear-selection mechanism

## Test plan

- [ ] `docker compose up --build` against a fresh DB (no volumes) — all migrations apply cleanly and seed completes
- [ ] `docker compose up --build` against a pre-existing DB with no migration history — P3005 baseline runs, migrations deploy, seed completes
- [ ] Open Admin → AI Generate tab — no Select error in console
- [ ] Open Admin → Exams, Domains, Tags tabs — filters work and show all items by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)