### PR TITLE
fix: address frontend security, correctness and maintainability issues

### DIFF
--- a/src/components/exam/ExamSession.tsx
+++ b/src/components/exam/ExamSession.tsx
@@ -2,6 +2,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Clock, Flag, ChevronLeft, ChevronRight, Zap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { AttemptQuestion, StartAttemptResponse, TimerMode } from '@/types/api-types';
+import { formatTime } from '@/lib/time';
 
 interface ExamSessionProps {
   attemptData: StartAttemptResponse;
@@ -44,12 +45,6 @@ export function ExamSession({
 }: ExamSessionProps) {
   const currentQuestion = questions[currentIndex];
   const timerMode = attemptData?.timerMode;
-
-  const formatTime = (seconds: number) => {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
-  };
 
   if (!currentQuestion) return null;
 

--- a/src/components/questions/LivePreview.tsx
+++ b/src/components/questions/LivePreview.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { CheckCircle2, Eye, BookOpen } from 'lucide-react';
-import { Difficulty, QuestionType } from '@/types/api-types';
+import { Certification, Difficulty, Domain, QuestionType } from '@/types/api-types';
+import { difficultyColor } from '@/lib/question-utils';
 
 interface ChoiceInput {
   label: string;
@@ -10,9 +11,9 @@ interface ChoiceInput {
 
 interface LivePreviewProps {
   difficulty: Difficulty | '';
-  selectedCert: any;
+  selectedCert: Certification | null;
   domainId: string;
-  domains: any[];
+  domains: Domain[];
   questionType: QuestionType;
   isScenario?: boolean;
   title: string;
@@ -37,12 +38,6 @@ export function LivePreview({
   referenceUrl,
   tags
 }: LivePreviewProps) {
-  const difficultyColor = (d: string) => {
-    if (d === 'EASY') return 'bg-accent/10 text-accent';
-    if (d === 'MEDIUM') return 'bg-warning/10 text-[hsl(var(--warning))]';
-    return 'bg-destructive/10 text-destructive';
-  };
-
   return (
     <div className="hidden lg:block">
       <div className="sticky top-20 space-y-4">

--- a/src/lib/question-utils.ts
+++ b/src/lib/question-utils.ts
@@ -1,0 +1,21 @@
+export function difficultyColor(difficulty: string): string {
+  if (difficulty === 'EASY') return 'bg-accent/10 text-accent';
+  if (difficulty === 'MEDIUM') return 'bg-warning/10 text-[hsl(var(--warning))]';
+  return 'bg-destructive/10 text-destructive';
+}
+
+/**
+ * Returns a safe https/http URL string, or null if the URL is invalid or uses
+ * a dangerous scheme (e.g. javascript:, data:, vbscript:).
+ */
+export function sanitizeUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+      return url;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,5 @@
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+}

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -135,6 +135,7 @@ export default function AuthPage() {
                                     name="password"
                                     type="password"
                                     required
+                                    minLength={8}
                                     value={formData.password}
                                     onChange={handleChange}
                                     className="appearance-none block w-full px-3 py-2.5 border border-gray-700 bg-gray-900/80 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent sm:text-sm transition-all"

--- a/src/pages/QuestionForm.tsx
+++ b/src/pages/QuestionForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { difficultyColor } from '@/lib/question-utils';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getCertifications } from '@/services/certifications';
@@ -138,16 +139,10 @@ export default function QuestionForm() {
       toast({ title: '✅ Saved!', description: 'Question submitted successfully for review.' });
       navigate('/questions');
     } catch (err: any) {
-      toast({ title: 'Lỗi', description: err.response?.data?.message || 'Không thể tạo câu hỏi.', variant: 'destructive' });
+      toast({ title: 'Error', description: err.response?.data?.message || 'Failed to create question.', variant: 'destructive' });
     } finally {
       setIsSubmitting(false);
     }
-  };
-
-  const difficultyColor = (d: string) => {
-    if (d === 'EASY') return 'bg-accent/10 text-accent';
-    if (d === 'MEDIUM') return 'bg-warning/10 text-[hsl(var(--warning))]';
-    return 'bg-destructive/10 text-destructive';
   };
 
   return (

--- a/src/pages/admin/AiGenerationTab.tsx
+++ b/src/pages/admin/AiGenerationTab.tsx
@@ -30,12 +30,12 @@ export function AiGenerationTab() {
   const [matPage, setMatPage] = useState(1);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const { data: jobsData, isLoading: jobsLoading } = useQuery({
+  const { data: jobsData, isLoading: jobsLoading, isError: jobsError } = useQuery({
     queryKey: ['admin-generation-jobs', statusFilter, jobPage],
     queryFn: () => getAdminGenerationJobs({ status: statusFilter === 'all' ? undefined : statusFilter, page: jobPage }),
   });
 
-  const { data: matsData, isLoading: matsLoading } = useQuery({
+  const { data: matsData, isLoading: matsLoading, isError: matsError } = useQuery({
     queryKey: ['admin-source-materials', matPage],
     queryFn: () => getAdminSourceMaterials({ page: matPage }),
   });
@@ -94,6 +94,8 @@ export function AiGenerationTab() {
               <TableBody>
                 {jobsLoading ? (
                   <TableRow><TableCell colSpan={7} className="text-center text-muted-foreground font-mono text-xs py-8">Loading...</TableCell></TableRow>
+                ) : jobsError ? (
+                  <TableRow><TableCell colSpan={7} className="text-center text-destructive font-mono text-xs py-8">Failed to load generation jobs. Try refreshing.</TableCell></TableRow>
                 ) : jobs.length === 0 ? (
                   <TableRow><TableCell colSpan={7} className="text-center text-muted-foreground font-mono text-xs py-8">No jobs found</TableCell></TableRow>
                 ) : (jobs as any[]).map((j) => (
@@ -141,6 +143,8 @@ export function AiGenerationTab() {
               <TableBody>
                 {matsLoading ? (
                   <TableRow><TableCell colSpan={7} className="text-center text-muted-foreground font-mono text-xs py-8">Loading...</TableCell></TableRow>
+                ) : matsError ? (
+                  <TableRow><TableCell colSpan={7} className="text-center text-destructive font-mono text-xs py-8">Failed to load source materials. Try refreshing.</TableCell></TableRow>
                 ) : mats.length === 0 ? (
                   <TableRow><TableCell colSpan={7} className="text-center text-muted-foreground font-mono text-xs py-8">No materials found</TableCell></TableRow>
                 ) : (mats as any[]).map((m) => (

--- a/src/pages/admin/ProvidersTab.tsx
+++ b/src/pages/admin/ProvidersTab.tsx
@@ -12,6 +12,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Building2, Plus, Edit2, Trash2, Loader2, ExternalLink } from 'lucide-react';
 import { toast } from 'sonner';
+import { sanitizeUrl } from '@/lib/question-utils';
 
 export default function ProvidersTab() {
   const queryClient = useQueryClient();
@@ -113,8 +114,8 @@ export default function ProvidersTab() {
                     <TableCell className="font-medium text-sm">{p.name}</TableCell>
                     <TableCell className="text-xs font-mono text-muted-foreground">{p.slug}</TableCell>
                     <TableCell className="text-sm">
-                      {p.website && (
-                        <a href={p.website} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline inline-flex items-center gap-1 text-xs">
+                      {p.website && sanitizeUrl(p.website) && (
+                        <a href={sanitizeUrl(p.website)!} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline inline-flex items-center gap-1 text-xs">
                           {new URL(p.website).hostname} <ExternalLink className="h-3 w-3" />
                         </a>
                       )}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,8 @@ import { useAuthStore } from '../stores/auth.store';
 
 // Create an Axios instance
 const api = axios.create({
-    baseURL: '/api/v1',
+    baseURL: import.meta.env.VITE_API_BASE_URL || '/api/v1',
+    timeout: 30000,
     headers: {
         'Content-Type': 'application/json',
     },

--- a/src/services/exams.ts
+++ b/src/services/exams.ts
@@ -35,7 +35,7 @@ export const getExamByShareCode = async (shareCode: string) => {
 };
 
 export const getMyExams = async (page = 1, limit = 10): Promise<PaginatedExams> => {
-    const response = await api.get<PaginatedExams>(`/exams/me?page=${page}&limit=${limit}`);
+    const response = await api.get<PaginatedExams>('/exams/me', { params: { page, limit } });
     return response.data;
 };
 


### PR DESCRIPTION
## Summary

- **Security**: Sanitize provider website URLs to block `javascript:` URI injection; add axios request timeout; make API base URL configurable via `VITE_API_BASE_URL`
- **Correctness**: Use axios `params` object in `getMyExams`; add `minLength=8` to password input; fix Vietnamese error message in `QuestionForm`; add error states to `AiGenerationTab` tables
- **Maintainability**: Extract `formatTime` and `difficultyColor` into shared `src/lib/` utilities (removing duplicates across 3 files); replace `any` prop types in `LivePreview` with `Certification | null` and `Domain[]`

## Changes

| File | What changed |
|------|-------------|
| `src/lib/time.ts` _(new)_ | Shared `formatTime(seconds)` |
| `src/lib/question-utils.ts` _(new)_ | Shared `difficultyColor`, `sanitizeUrl` |
| `src/services/api.ts` | `timeout: 30000`, env-configurable `baseURL` |
| `src/services/exams.ts` | `params` object instead of string interpolation |
| `src/pages/admin/ProvidersTab.tsx` | Block `javascript:` URIs via `sanitizeUrl` |
| `src/pages/admin/AiGenerationTab.tsx` | Error rows when queries fail |
| `src/pages/Auth.tsx` | `minLength={8}` on password input |
| `src/pages/QuestionForm.tsx` | English error message, shared `difficultyColor` |
| `src/components/exam/ExamSession.tsx` | Use shared `formatTime` |
| `src/components/questions/LivePreview.tsx` | Typed props, shared `difficultyColor` |

## Test plan

- [ ] Log in with a password shorter than 8 chars — browser should block submission
- [ ] Add a provider with `website = javascript:alert(1)` — link should not render
- [ ] Add a provider with a valid HTTPS URL — link renders correctly
- [ ] Set `VITE_API_BASE_URL=http://localhost:3000/api/v1` in `.env` and verify API calls use it
- [ ] Open Admin → AI Generation tab with network offline — tables show error message instead of empty state
- [ ] Create a question — error toast appears in English on failure
- [ ] Start and complete an exam — timer displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)