### PR TITLE
feat: add organization analytics dashboard (Phase 5)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { OrganizationsModule } from './organizations/organizations.module';
 import { OrgQuestionsModule } from './org-questions/org-questions.module';
 import { ExamCatalogModule } from './exam-catalog/exam-catalog.module';
 import { AssessmentsModule } from './assessments/assessments.module';
+import { OrgAnalyticsModule } from './org-analytics/org-analytics.module';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { AssessmentsModule } from './assessments/assessments.module';
     OrgQuestionsModule,
     ExamCatalogModule,
     AssessmentsModule,
+    OrgAnalyticsModule,
   ],
   providers: [
     {

--- a/backend/src/org-analytics/org-analytics.controller.ts
+++ b/backend/src/org-analytics/org-analytics.controller.ts
@@ -1,0 +1,71 @@
+import { Controller, Get, Param, Query, UseGuards, Req } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { OrgAnalyticsService } from './org-analytics.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
+import { OrgRoles } from '../common/decorators/org-roles.decorator';
+import { OrgRole } from '@prisma/client';
+
+@ApiTags('org-analytics')
+@Controller('organizations/:orgId/analytics')
+export class OrgAnalyticsController {
+  constructor(private readonly orgAnalyticsService: OrgAnalyticsService) {}
+
+  @Get('overview')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get team overview KPIs' })
+  getOverview(@Param('orgId') orgId: string) {
+    return this.orgAnalyticsService.getOverview(orgId);
+  }
+
+  @Get('readiness')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get per-certification readiness across team' })
+  getReadiness(@Param('orgId') orgId: string) {
+    return this.orgAnalyticsService.getReadiness(orgId);
+  }
+
+  @Get('skill-gaps')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get domain-level weakness analysis' })
+  getSkillGaps(@Param('orgId') orgId: string) {
+    return this.orgAnalyticsService.getSkillGaps(orgId);
+  }
+
+  @Get('progress')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get week-over-week progress trends' })
+  @ApiQuery({ name: 'weeks', required: false, type: Number })
+  getProgress(@Param('orgId') orgId: string, @Query('weeks') weeks?: string) {
+    return this.orgAnalyticsService.getProgress(orgId, weeks ? +weeks : 12);
+  }
+
+  @Get('engagement')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get engagement metrics' })
+  getEngagement(@Param('orgId') orgId: string) {
+    return this.orgAnalyticsService.getEngagement(orgId);
+  }
+
+  @Get('member/:userId')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get individual member deep-dive analytics' })
+  getMemberAnalytics(
+    @Param('orgId') orgId: string,
+    @Param('userId') userId: string,
+  ) {
+    return this.orgAnalyticsService.getMemberAnalytics(orgId, userId);
+  }
+}

--- a/backend/src/org-analytics/org-analytics.module.ts
+++ b/backend/src/org-analytics/org-analytics.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { OrgAnalyticsController } from './org-analytics.controller';
+import { OrgAnalyticsService } from './org-analytics.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [OrgAnalyticsController],
+  providers: [OrgAnalyticsService],
+  exports: [OrgAnalyticsService],
+})
+export class OrgAnalyticsModule {}

--- a/backend/src/org-analytics/org-analytics.service.ts
+++ b/backend/src/org-analytics/org-analytics.service.ts
@@ -1,0 +1,424 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AttemptStatus, CandidateAttemptStatus } from '@prisma/client';
+
+@Injectable()
+export class OrgAnalyticsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private async getOrgMemberUserIds(orgId: string): Promise<string[]> {
+    const members = await this.prisma.orgMember.findMany({
+      where: { orgId, isActive: true },
+      select: { userId: true },
+    });
+    return members.map((m) => m.userId);
+  }
+
+  private async resolveOrgId(orgIdOrSlug: string): Promise<string> {
+    const org = await this.prisma.organization.findFirst({
+      where: {
+        OR: [{ id: orgIdOrSlug }, { slug: orgIdOrSlug }],
+      },
+      select: { id: true },
+    });
+    if (!org) throw new NotFoundException('Organization not found');
+    return org.id;
+  }
+
+  async getOverview(orgIdOrSlug: string) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+    const userIds = await this.getOrgMemberUserIds(orgId);
+
+    if (userIds.length === 0) {
+      return {
+        memberCount: 0,
+        activeUsersLast7d: 0,
+        totalExamsTaken: 0,
+        avgScore: 0,
+        passRate: 0,
+        totalAssessments: 0,
+        totalCandidatesInvited: 0,
+      };
+    }
+
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const [attempts, activeUsers, assessmentStats] = await Promise.all([
+      this.prisma.examAttempt.findMany({
+        where: { userId: { in: userIds }, status: AttemptStatus.SUBMITTED },
+        select: { score: true },
+      }),
+      this.prisma.examAttempt.findMany({
+        where: {
+          userId: { in: userIds },
+          status: AttemptStatus.SUBMITTED,
+          submittedAt: { gte: sevenDaysAgo },
+        },
+        select: { userId: true },
+        distinct: ['userId'],
+      }),
+      this.prisma.assessment.findMany({
+        where: { orgId },
+        select: {
+          id: true,
+          _count: { select: { candidateInvites: true } },
+        },
+      }),
+    ]);
+
+    const scores = attempts.map((a) => Number(a.score ?? 0));
+    const avgScore = scores.length > 0
+      ? Math.round(scores.reduce((s, v) => s + v, 0) / scores.length)
+      : 0;
+    const totalPassed = scores.filter((s) => s >= 70).length;
+
+    return {
+      memberCount: userIds.length,
+      activeUsersLast7d: activeUsers.length,
+      totalExamsTaken: attempts.length,
+      avgScore,
+      passRate: scores.length > 0 ? Math.round((totalPassed / scores.length) * 100) : 0,
+      totalAssessments: assessmentStats.length,
+      totalCandidatesInvited: assessmentStats.reduce(
+        (sum, a) => sum + a._count.candidateInvites,
+        0,
+      ),
+    };
+  }
+
+  async getReadiness(orgIdOrSlug: string) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+    const userIds = await this.getOrgMemberUserIds(orgId);
+
+    if (userIds.length === 0) return [];
+
+    const attempts = await this.prisma.examAttempt.findMany({
+      where: { userId: { in: userIds }, status: AttemptStatus.SUBMITTED },
+      select: {
+        userId: true,
+        score: true,
+        submittedAt: true,
+        exam: {
+          select: {
+            certification: { select: { id: true, name: true, code: true } },
+          },
+        },
+      },
+    });
+
+    // Group by certification
+    const certMap: Record<
+      string,
+      {
+        certName: string;
+        certCode: string;
+        members: Record<string, { scores: number[]; latestDate: Date }>;
+      }
+    > = {};
+
+    for (const a of attempts) {
+      const cert = a.exam.certification;
+      if (!cert) continue;
+
+      if (!certMap[cert.id]) {
+        certMap[cert.id] = { certName: cert.name, certCode: cert.code, members: {} };
+      }
+
+      if (!certMap[cert.id].members[a.userId]) {
+        certMap[cert.id].members[a.userId] = { scores: [], latestDate: new Date(0) };
+      }
+
+      const memberData = certMap[cert.id].members[a.userId];
+      memberData.scores.push(Number(a.score ?? 0));
+      if (a.submittedAt && a.submittedAt > memberData.latestDate) {
+        memberData.latestDate = a.submittedAt;
+      }
+    }
+
+    return Object.entries(certMap).map(([certId, data]) => {
+      const memberEntries = Object.values(data.members);
+      const allScores = memberEntries.flatMap((m) => m.scores);
+      const avgScore = allScores.length > 0
+        ? Math.round(allScores.reduce((s, v) => s + v, 0) / allScores.length)
+        : 0;
+      const passedMembers = memberEntries.filter(
+        (m) => Math.max(...m.scores) >= 70,
+      ).length;
+
+      return {
+        certificationId: certId,
+        certificationName: data.certName,
+        certificationCode: data.certCode,
+        membersAttempted: memberEntries.length,
+        totalMembers: userIds.length,
+        avgScore,
+        passedMembers,
+        passRate:
+          memberEntries.length > 0
+            ? Math.round((passedMembers / memberEntries.length) * 100)
+            : 0,
+      };
+    });
+  }
+
+  async getSkillGaps(orgIdOrSlug: string) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+    const userIds = await this.getOrgMemberUserIds(orgId);
+
+    if (userIds.length === 0) return [];
+
+    const attempts = await this.prisma.examAttempt.findMany({
+      where: { userId: { in: userIds }, status: AttemptStatus.SUBMITTED },
+      select: { domainScores: true },
+    });
+
+    const agg: Record<string, { correct: number; total: number }> = {};
+    for (const a of attempts) {
+      const ds = a.domainScores as Record<string, { correct: number; total: number }> | null;
+      if (!ds) continue;
+      for (const [domain, { correct, total }] of Object.entries(ds)) {
+        if (!agg[domain]) agg[domain] = { correct: 0, total: 0 };
+        agg[domain].correct += correct;
+        agg[domain].total += total;
+      }
+    }
+
+    return Object.entries(agg)
+      .map(([domain, { correct, total }]) => ({
+        domain,
+        correct,
+        total,
+        percentage: total > 0 ? Math.round((correct / total) * 100) : 0,
+      }))
+      .sort((a, b) => a.percentage - b.percentage);
+  }
+
+  async getProgress(orgIdOrSlug: string, weeks = 12) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+    const userIds = await this.getOrgMemberUserIds(orgId);
+
+    if (userIds.length === 0) return [];
+
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - weeks * 7);
+
+    const attempts = await this.prisma.examAttempt.findMany({
+      where: {
+        userId: { in: userIds },
+        status: AttemptStatus.SUBMITTED,
+        submittedAt: { gte: startDate },
+      },
+      select: { userId: true, score: true, submittedAt: true },
+      orderBy: { submittedAt: 'asc' },
+    });
+
+    // Group by ISO week
+    const weekMap: Record<
+      string,
+      { examsTaken: number; scoreSum: number; activeUsers: Set<string> }
+    > = {};
+
+    for (const a of attempts) {
+      if (!a.submittedAt) continue;
+      const d = new Date(a.submittedAt);
+      const yearWeek = getISOWeekLabel(d);
+
+      if (!weekMap[yearWeek]) {
+        weekMap[yearWeek] = { examsTaken: 0, scoreSum: 0, activeUsers: new Set() };
+      }
+
+      weekMap[yearWeek].examsTaken++;
+      weekMap[yearWeek].scoreSum += Number(a.score ?? 0);
+      weekMap[yearWeek].activeUsers.add(a.userId);
+    }
+
+    return Object.entries(weekMap)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([week, data]) => ({
+        week,
+        examsTaken: data.examsTaken,
+        avgScore:
+          data.examsTaken > 0
+            ? Math.round(data.scoreSum / data.examsTaken)
+            : 0,
+        activeUsers: data.activeUsers.size,
+      }));
+  }
+
+  async getEngagement(orgIdOrSlug: string) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+    const userIds = await this.getOrgMemberUserIds(orgId);
+
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const [activeUsersLast7d, totalAttempts, assessmentFunnel] =
+      await Promise.all([
+        userIds.length > 0
+          ? this.prisma.examAttempt.findMany({
+              where: {
+                userId: { in: userIds },
+                submittedAt: { gte: sevenDaysAgo },
+              },
+              select: { userId: true },
+              distinct: ['userId'],
+            })
+          : Promise.resolve([]),
+        userIds.length > 0
+          ? this.prisma.examAttempt.count({
+              where: {
+                userId: { in: userIds },
+                status: AttemptStatus.SUBMITTED,
+              },
+            })
+          : Promise.resolve(0),
+        this.prisma.candidateInvite.findMany({
+          where: { assessment: { orgId } },
+          select: { status: true },
+        }),
+      ]);
+
+    const funnelCounts = {
+      invited: assessmentFunnel.length,
+      started: assessmentFunnel.filter(
+        (c) => c.status !== CandidateAttemptStatus.INVITED,
+      ).length,
+      submitted: assessmentFunnel.filter(
+        (c) => c.status === CandidateAttemptStatus.SUBMITTED,
+      ).length,
+      expired: assessmentFunnel.filter(
+        (c) => c.status === CandidateAttemptStatus.EXPIRED,
+      ).length,
+    };
+
+    return {
+      totalMembers: userIds.length,
+      activeUsersLast7d: activeUsersLast7d.length,
+      activeRate:
+        userIds.length > 0
+          ? Math.round((activeUsersLast7d.length / userIds.length) * 100)
+          : 0,
+      totalExamsTaken: totalAttempts,
+      avgExamsPerMember:
+        userIds.length > 0
+          ? parseFloat((totalAttempts / userIds.length).toFixed(1))
+          : 0,
+      assessmentFunnel: funnelCounts,
+    };
+  }
+
+  async getMemberAnalytics(orgIdOrSlug: string, userId: string) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+
+    // Verify user is a member
+    const membership = await this.prisma.orgMember.findFirst({
+      where: { orgId, userId, isActive: true },
+      include: {
+        user: { select: { id: true, displayName: true, email: true, avatarUrl: true } },
+        group: { select: { id: true, name: true } },
+      },
+    });
+
+    if (!membership) {
+      throw new NotFoundException('Member not found in this organization');
+    }
+
+    const attempts = await this.prisma.examAttempt.findMany({
+      where: { userId, status: AttemptStatus.SUBMITTED },
+      select: {
+        id: true,
+        score: true,
+        totalCorrect: true,
+        totalQuestions: true,
+        timeSpent: true,
+        domainScores: true,
+        submittedAt: true,
+        exam: {
+          select: {
+            title: true,
+            certification: { select: { id: true, name: true, code: true } },
+          },
+        },
+      },
+      orderBy: { submittedAt: 'desc' },
+    });
+
+    const scores = attempts.map((a) => Number(a.score ?? 0));
+    const totalPassed = scores.filter((s) => s >= 70).length;
+
+    // Domain aggregation
+    const domainAgg: Record<string, { correct: number; total: number }> = {};
+    for (const a of attempts) {
+      const ds = a.domainScores as Record<string, { correct: number; total: number }> | null;
+      if (!ds) continue;
+      for (const [domain, { correct, total }] of Object.entries(ds)) {
+        if (!domainAgg[domain]) domainAgg[domain] = { correct: 0, total: 0 };
+        domainAgg[domain].correct += correct;
+        domainAgg[domain].total += total;
+      }
+    }
+
+    const domains = Object.entries(domainAgg)
+      .map(([domain, { correct, total }]) => ({
+        domain,
+        correct,
+        total,
+        percentage: total > 0 ? Math.round((correct / total) * 100) : 0,
+      }))
+      .sort((a, b) => a.percentage - b.percentage);
+
+    return {
+      member: {
+        userId: membership.user.id,
+        displayName: membership.user.displayName,
+        email: membership.user.email,
+        avatarUrl: membership.user.avatarUrl,
+        role: membership.role,
+        group: membership.group,
+        joinedAt: membership.joinedAt,
+      },
+      summary: {
+        totalExams: attempts.length,
+        totalPassed,
+        passRate:
+          attempts.length > 0
+            ? Math.round((totalPassed / attempts.length) * 100)
+            : 0,
+        avgScore:
+          scores.length > 0
+            ? Math.round(scores.reduce((s, v) => s + v, 0) / scores.length)
+            : 0,
+        bestScore: scores.length > 0 ? Math.round(Math.max(...scores)) : 0,
+      },
+      domains,
+      recentAttempts: attempts.slice(0, 10).map((a) => ({
+        id: a.id,
+        examTitle: a.exam.title,
+        certification: a.exam.certification,
+        score: Math.round(Number(a.score ?? 0)),
+        totalCorrect: a.totalCorrect ?? 0,
+        totalQuestions: a.totalQuestions ?? 0,
+        passed: Number(a.score ?? 0) >= 70,
+        timeSpent: a.timeSpent ?? 0,
+        submittedAt: a.submittedAt,
+      })),
+    };
+  }
+}
+
+function getISOWeekLabel(date: Date): string {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + 3 - ((d.getDay() + 6) % 7));
+  const week1 = new Date(d.getFullYear(), 0, 4);
+  const weekNum =
+    1 +
+    Math.round(
+      ((d.getTime() - week1.getTime()) / 86400000 -
+        3 +
+        ((week1.getDay() + 6) % 7)) /
+        7,
+    );
+  return `${d.getFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ const OrgLearningTracks = lazy(() => import("./pages/org/OrgLearningTracks"));
 const OrgAssessments = lazy(() => import("./pages/org/OrgAssessments"));
 const AssessmentBuilder = lazy(() => import("./pages/org/AssessmentBuilder"));
 const AssessmentResults = lazy(() => import("./pages/org/AssessmentResults"));
+const OrgAnalytics = lazy(() => import("./pages/org/OrgAnalytics"));
 const CandidateExam = lazy(() => import("./pages/CandidateExam"));
 const CandidateResult = lazy(() => import("./pages/CandidateResult"));
 
@@ -119,6 +120,7 @@ const AnimatedRoutes = () => {
           <Route path="assessments/create" element={<AssessmentBuilder />} />
           <Route path="assessments/:aid" element={<AssessmentResults />} />
           <Route path="assessments/:aid/edit" element={<AssessmentBuilder />} />
+          <Route path="analytics" element={<OrgAnalytics />} />
           <Route path="settings" element={<OrgSettings />} />
         </Route>
 

--- a/src/components/org/EngagementChart.tsx
+++ b/src/components/org/EngagementChart.tsx
@@ -1,0 +1,90 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, BarChart, Bar } from 'recharts';
+import { TrendingUp } from 'lucide-react';
+import type { WeeklyProgress } from '@/services/org-analytics';
+
+interface Props {
+  data: WeeklyProgress[];
+}
+
+const chartConfig = {
+  examsTaken: { label: 'Exams Taken', color: 'hsl(var(--primary))' },
+  avgScore: { label: 'Avg Score', color: 'hsl(142 76% 36%)' },
+  activeUsers: { label: 'Active Users', color: 'hsl(217 91% 60%)' },
+};
+
+const EngagementChart = ({ data }: Props) => {
+  if (data.length === 0) {
+    return (
+      <Card className="bg-card border-border">
+        <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+          <TrendingUp className="h-8 w-8 text-muted-foreground/30 mb-3" />
+          <p className="text-sm text-muted-foreground">
+            No progress data yet. Members need to complete exams first.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Format week labels (e.g. "2026-W14" → "W14")
+  const chartData = data.map((d) => ({
+    ...d,
+    label: d.week.replace(/^\d{4}-/, ''),
+  }));
+
+  return (
+    <div className="space-y-4">
+      {/* Exams + Active Users bar chart */}
+      <Card className="bg-card border-border">
+        <CardHeader className="pb-3">
+          <CardTitle className="font-mono text-sm flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-primary" /> Weekly Activity
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={chartConfig} className="h-[240px] w-full">
+            <BarChart data={chartData} margin={{ top: 8, right: 12, bottom: 0, left: -16 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis dataKey="label" tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }} />
+              <YAxis tick={{ fill: 'hsl(var(--muted-foreground))' }} />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Bar dataKey="examsTaken" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="activeUsers" fill="hsl(217 91% 60%)" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      {/* Avg Score trend line */}
+      <Card className="bg-card border-border">
+        <CardHeader className="pb-3">
+          <CardTitle className="font-mono text-sm flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-emerald-400" /> Average Score Trend
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={chartConfig} className="h-[200px] w-full">
+            <LineChart data={chartData} margin={{ top: 8, right: 12, bottom: 0, left: -16 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis dataKey="label" tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }} />
+              <YAxis domain={[0, 100]} tick={{ fill: 'hsl(var(--muted-foreground))' }} />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Line
+                type="monotone"
+                dataKey="avgScore"
+                stroke="hsl(142 76% 36%)"
+                strokeWidth={2.5}
+                dot={{ fill: 'hsl(142 76% 36%)', r: 4 }}
+                activeDot={{ r: 6 }}
+              />
+            </LineChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default EngagementChart;

--- a/src/components/org/MemberAnalyticsCard.tsx
+++ b/src/components/org/MemberAnalyticsCard.tsx
@@ -1,0 +1,126 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { User, TrendingUp, Award, Clock } from 'lucide-react';
+import type { MemberAnalytics } from '@/services/org-analytics';
+
+interface Props {
+  data: MemberAnalytics;
+}
+
+const MemberAnalyticsCard = ({ data }: Props) => {
+  const { member, summary, domains, recentAttempts } = data;
+
+  return (
+    <div className="space-y-4">
+      {/* Member Header */}
+      <Card className="bg-card border-border">
+        <CardContent className="p-4">
+          <div className="flex items-center gap-4">
+            <div className="h-12 w-12 rounded-full bg-muted border border-border flex items-center justify-center">
+              {member.avatarUrl ? (
+                <img src={member.avatarUrl} alt="" className="h-12 w-12 rounded-full" />
+              ) : (
+                <User className="h-5 w-5 text-muted-foreground" />
+              )}
+            </div>
+            <div className="flex-1">
+              <p className="font-mono font-bold text-lg">{member.displayName}</p>
+              <p className="text-xs text-muted-foreground font-mono">{member.email}</p>
+              <div className="flex gap-2 mt-1">
+                <Badge variant="outline" className="text-[10px] font-mono">{member.role}</Badge>
+                {member.group && (
+                  <Badge variant="outline" className="text-[10px] font-mono">{member.group.name}</Badge>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Summary Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Exams Taken', value: summary.totalExams, icon: TrendingUp, color: 'text-primary' },
+          { label: 'Pass Rate', value: `${summary.passRate}%`, icon: Award, color: 'text-emerald-400' },
+          { label: 'Avg Score', value: `${summary.avgScore}%`, icon: TrendingUp, color: 'text-amber-400' },
+          { label: 'Best Score', value: `${summary.bestScore}%`, icon: Award, color: 'text-violet-400' },
+        ].map((stat) => (
+          <Card key={stat.label} className="bg-card border-border">
+            <CardContent className="p-3 text-center">
+              <stat.icon className={`h-4 w-4 mx-auto mb-1 ${stat.color}`} />
+              <p className="text-xl font-mono font-bold">{stat.value}</p>
+              <p className="text-[10px] text-muted-foreground font-mono">{stat.label}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Domain Performance */}
+      {domains.length > 0 && (
+        <Card className="bg-card border-border">
+          <CardContent className="p-4">
+            <p className="font-mono text-sm font-medium mb-3">Domain Performance</p>
+            <div className="space-y-2">
+              {domains.map((d) => (
+                <div key={d.domain} className="flex items-center justify-between gap-3">
+                  <span className="text-xs font-mono text-muted-foreground truncate flex-1">
+                    {d.domain}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <div className="w-20 h-1.5 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${
+                          d.percentage >= 70 ? 'bg-emerald-500' : d.percentage >= 50 ? 'bg-amber-500' : 'bg-red-500'
+                        }`}
+                        style={{ width: `${d.percentage}%` }}
+                      />
+                    </div>
+                    <span className="text-xs font-mono font-medium w-8 text-right">{d.percentage}%</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Recent Attempts */}
+      {recentAttempts.length > 0 && (
+        <Card className="bg-card border-border">
+          <CardContent className="p-4">
+            <p className="font-mono text-sm font-medium mb-3">Recent Exams</p>
+            <div className="space-y-2">
+              {recentAttempts.map((attempt) => (
+                <div
+                  key={attempt.id}
+                  className="flex items-center justify-between py-2 px-3 rounded-lg bg-muted/30"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-mono truncate">{attempt.examTitle}</p>
+                    <p className="text-[10px] text-muted-foreground font-mono">
+                      {attempt.certification?.code || 'N/A'} · {attempt.totalCorrect}/{attempt.totalQuestions}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 ml-3">
+                    <Badge
+                      variant="outline"
+                      className={`font-mono text-[10px] ${
+                        attempt.passed
+                          ? 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30'
+                          : 'bg-red-500/20 text-red-400 border-red-500/30'
+                      }`}
+                    >
+                      {attempt.score}%
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default MemberAnalyticsCard;

--- a/src/components/org/OrgSidebar.tsx
+++ b/src/components/org/OrgSidebar.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useOrgStore } from '@/stores/org.store';
 import {
   LayoutDashboard, Users, Settings, Shield, BookOpen,
-  GraduationCap, Library, BookMarked, ClipboardList,
+  GraduationCap, Library, BookMarked, ClipboardList, BarChart3,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { OrgRole } from '@/types/org-types';
@@ -28,6 +28,7 @@ const OrgSidebar = () => {
     { label: 'Manage Catalog', href: `/org/${slug}/catalog/manage`, icon: Library, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
     { label: 'Tracks', href: `/org/${slug}/tracks`, icon: BookMarked, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
     { label: 'Assessments', href: `/org/${slug}/assessments`, icon: ClipboardList, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
+    { label: 'Analytics', href: `/org/${slug}/analytics`, icon: BarChart3, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
     { label: 'Settings', href: `/org/${slug}/settings`, icon: Settings, roles: ['OWNER', 'ADMIN'] as OrgRole[] },
   ];
 

--- a/src/components/org/ReadinessHeatmap.tsx
+++ b/src/components/org/ReadinessHeatmap.tsx
@@ -1,0 +1,86 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Target } from 'lucide-react';
+import type { CertReadiness } from '@/services/org-analytics';
+
+interface Props {
+  data: CertReadiness[];
+}
+
+const getScoreColor = (score: number) => {
+  if (score >= 80) return 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30';
+  if (score >= 60) return 'bg-amber-500/20 text-amber-400 border-amber-500/30';
+  return 'bg-red-500/20 text-red-400 border-red-500/30';
+};
+
+const ReadinessHeatmap = ({ data }: Props) => {
+  if (data.length === 0) {
+    return (
+      <Card className="bg-card border-border">
+        <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+          <Target className="h-8 w-8 text-muted-foreground/30 mb-3" />
+          <p className="text-sm text-muted-foreground">
+            No certification data yet. Members need to take exams first.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-card border-border">
+      <CardHeader className="pb-3">
+        <CardTitle className="font-mono text-sm flex items-center gap-2">
+          <Target className="h-4 w-4 text-primary" /> Certification Readiness
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left font-mono text-xs text-muted-foreground py-2 pr-4">Certification</th>
+                <th className="text-center font-mono text-xs text-muted-foreground py-2 px-3">Attempted</th>
+                <th className="text-center font-mono text-xs text-muted-foreground py-2 px-3">Avg Score</th>
+                <th className="text-center font-mono text-xs text-muted-foreground py-2 px-3">Passed</th>
+                <th className="text-center font-mono text-xs text-muted-foreground py-2 px-3">Pass Rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((cert) => (
+                <tr key={cert.certificationId} className="border-b border-border/50 hover:bg-muted/30">
+                  <td className="py-3 pr-4">
+                    <div>
+                      <p className="font-mono font-medium text-sm">{cert.certificationCode}</p>
+                      <p className="text-xs text-muted-foreground">{cert.certificationName}</p>
+                    </div>
+                  </td>
+                  <td className="text-center py-3 px-3">
+                    <span className="font-mono text-sm">
+                      {cert.membersAttempted}/{cert.totalMembers}
+                    </span>
+                  </td>
+                  <td className="text-center py-3 px-3">
+                    <Badge variant="outline" className={`font-mono text-xs ${getScoreColor(cert.avgScore)}`}>
+                      {cert.avgScore}%
+                    </Badge>
+                  </td>
+                  <td className="text-center py-3 px-3">
+                    <span className="font-mono text-sm">{cert.passedMembers}</span>
+                  </td>
+                  <td className="text-center py-3 px-3">
+                    <Badge variant="outline" className={`font-mono text-xs ${getScoreColor(cert.passRate)}`}>
+                      {cert.passRate}%
+                    </Badge>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ReadinessHeatmap;

--- a/src/components/org/SkillGapChart.tsx
+++ b/src/components/org/SkillGapChart.tsx
@@ -1,0 +1,93 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis } from 'recharts';
+import { AlertTriangle } from 'lucide-react';
+import type { DomainGap } from '@/services/org-analytics';
+
+interface Props {
+  data: DomainGap[];
+}
+
+const chartConfig = {
+  percentage: { label: 'Score %', color: 'hsl(var(--primary))' },
+};
+
+const SkillGapChart = ({ data }: Props) => {
+  if (data.length === 0) {
+    return (
+      <Card className="bg-card border-border">
+        <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+          <AlertTriangle className="h-8 w-8 text-muted-foreground/30 mb-3" />
+          <p className="text-sm text-muted-foreground">
+            No domain data available yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Truncate long domain names for the radar chart
+  const chartData = data.map((d) => ({
+    ...d,
+    shortDomain: d.domain.length > 20 ? d.domain.slice(0, 18) + '...' : d.domain,
+  }));
+
+  return (
+    <Card className="bg-card border-border">
+      <CardHeader className="pb-3">
+        <CardTitle className="font-mono text-sm flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-amber-400" /> Skill Gaps by Domain
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length >= 3 ? (
+          <ChartContainer config={chartConfig} className="h-[320px] w-full">
+            <RadarChart data={chartData} margin={{ top: 8, right: 32, bottom: 8, left: 32 }}>
+              <PolarGrid className="stroke-border" />
+              <PolarAngleAxis
+                dataKey="shortDomain"
+                tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
+              />
+              <PolarRadiusAxis
+                domain={[0, 100]}
+                tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
+              />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Radar
+                name="Score %"
+                dataKey="percentage"
+                stroke="hsl(var(--primary))"
+                fill="hsl(var(--primary))"
+                fillOpacity={0.2}
+                strokeWidth={2}
+              />
+            </RadarChart>
+          </ChartContainer>
+        ) : (
+          <div className="space-y-3">
+            {data.map((d) => (
+              <div key={d.domain} className="flex items-center justify-between">
+                <span className="text-sm font-mono text-muted-foreground truncate max-w-[60%]">
+                  {d.domain}
+                </span>
+                <div className="flex items-center gap-2">
+                  <div className="w-24 h-2 rounded-full bg-muted overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-primary"
+                      style={{ width: `${d.percentage}%` }}
+                    />
+                  </div>
+                  <span className="text-sm font-mono font-medium w-10 text-right">
+                    {d.percentage}%
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SkillGapChart;

--- a/src/pages/org/OrgAnalytics.tsx
+++ b/src/pages/org/OrgAnalytics.tsx
@@ -1,0 +1,245 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Input } from '@/components/ui/input';
+import {
+  BarChart3, Users, TrendingUp, Target, Award, Activity, Search,
+} from 'lucide-react';
+import { useOrgStore } from '@/stores/org.store';
+import { getMembers } from '@/services/organizations';
+import {
+  getOrgOverview,
+  getOrgReadiness,
+  getOrgSkillGaps,
+  getOrgProgress,
+  getOrgEngagement,
+  getMemberAnalytics,
+} from '@/services/org-analytics';
+import ReadinessHeatmap from '@/components/org/ReadinessHeatmap';
+import SkillGapChart from '@/components/org/SkillGapChart';
+import EngagementChart from '@/components/org/EngagementChart';
+import MemberAnalyticsCard from '@/components/org/MemberAnalyticsCard';
+import AssessmentFunnel from '@/components/org/AssessmentFunnel';
+
+const OrgAnalytics = () => {
+  const currentOrg = useOrgStore((s) => s.currentOrg);
+  const slug = currentOrg?.slug || '';
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [memberSearch, setMemberSearch] = useState('');
+
+  const { data: overview, isLoading: loadingOverview } = useQuery({
+    queryKey: ['org-analytics-overview', slug],
+    queryFn: () => getOrgOverview(slug),
+    enabled: !!slug,
+  });
+
+  const { data: readiness } = useQuery({
+    queryKey: ['org-analytics-readiness', slug],
+    queryFn: () => getOrgReadiness(slug),
+    enabled: !!slug,
+  });
+
+  const { data: skillGaps } = useQuery({
+    queryKey: ['org-analytics-skill-gaps', slug],
+    queryFn: () => getOrgSkillGaps(slug),
+    enabled: !!slug,
+  });
+
+  const { data: progress } = useQuery({
+    queryKey: ['org-analytics-progress', slug],
+    queryFn: () => getOrgProgress(slug),
+    enabled: !!slug,
+  });
+
+  const { data: engagement } = useQuery({
+    queryKey: ['org-analytics-engagement', slug],
+    queryFn: () => getOrgEngagement(slug),
+    enabled: !!slug,
+  });
+
+  const { data: membersData } = useQuery({
+    queryKey: ['org-members', slug, 1, 100],
+    queryFn: () => getMembers(slug, 1, 100),
+    enabled: !!slug,
+  });
+
+  const { data: memberAnalytics } = useQuery({
+    queryKey: ['org-analytics-member', slug, selectedMemberId],
+    queryFn: () => getMemberAnalytics(slug, selectedMemberId!),
+    enabled: !!slug && !!selectedMemberId,
+  });
+
+  if (!currentOrg) return null;
+
+  const members = membersData?.data || [];
+  const filteredMembers = members.filter(
+    (m) =>
+      m.user.displayName.toLowerCase().includes(memberSearch.toLowerCase()) ||
+      m.user.email.toLowerCase().includes(memberSearch.toLowerCase()),
+  );
+
+  const overviewStats = overview
+    ? [
+        { label: 'Members', value: overview.memberCount, icon: Users, color: 'text-primary' },
+        { label: 'Active (7d)', value: overview.activeUsersLast7d, icon: Activity, color: 'text-emerald-400' },
+        { label: 'Exams Taken', value: overview.totalExamsTaken, icon: BarChart3, color: 'text-amber-400' },
+        { label: 'Avg Score', value: `${overview.avgScore}%`, icon: TrendingUp, color: 'text-blue-400' },
+        { label: 'Pass Rate', value: `${overview.passRate}%`, icon: Award, color: 'text-violet-400' },
+        { label: 'Candidates', value: overview.totalCandidatesInvited, icon: Target, color: 'text-red-400' },
+      ]
+    : [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-mono font-bold flex items-center gap-2">
+          <BarChart3 className="h-6 w-6 text-primary" /> Analytics
+        </h1>
+        <p className="text-sm text-muted-foreground font-mono mt-1">
+          Team performance and engagement insights
+        </p>
+      </div>
+
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList className="bg-muted/50">
+          <TabsTrigger value="overview" className="font-mono text-xs">Overview</TabsTrigger>
+          <TabsTrigger value="readiness" className="font-mono text-xs">Readiness</TabsTrigger>
+          <TabsTrigger value="skills" className="font-mono text-xs">Skill Gaps</TabsTrigger>
+          <TabsTrigger value="members" className="font-mono text-xs">Members</TabsTrigger>
+        </TabsList>
+
+        {/* Overview Tab */}
+        <TabsContent value="overview" className="space-y-4">
+          {loadingOverview ? (
+            <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Card key={i} className="bg-card border-border animate-pulse">
+                  <CardContent className="p-4 h-20" />
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+                {overviewStats.map((stat) => (
+                  <Card key={stat.label} className="bg-card border-border">
+                    <CardContent className="p-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <stat.icon className={`h-5 w-5 ${stat.color}`} />
+                      </div>
+                      <p className="text-2xl font-mono font-bold">{stat.value}</p>
+                      <p className="text-xs text-muted-foreground font-mono">{stat.label}</p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+
+              {/* Assessment Funnel */}
+              {engagement && engagement.assessmentFunnel.invited > 0 && (
+                <div>
+                  <p className="font-mono text-sm font-medium mb-2">Assessment Pipeline</p>
+                  <AssessmentFunnel
+                    funnel={{
+                      total: engagement.assessmentFunnel.invited,
+                      started: engagement.assessmentFunnel.started,
+                      submitted: engagement.assessmentFunnel.submitted,
+                      passed: null,
+                    }}
+                  />
+                </div>
+              )}
+
+              {/* Weekly Progress Charts */}
+              <EngagementChart data={progress || []} />
+            </>
+          )}
+        </TabsContent>
+
+        {/* Readiness Tab */}
+        <TabsContent value="readiness">
+          <ReadinessHeatmap data={readiness || []} />
+        </TabsContent>
+
+        {/* Skill Gaps Tab */}
+        <TabsContent value="skills">
+          <SkillGapChart data={skillGaps || []} />
+        </TabsContent>
+
+        {/* Members Tab */}
+        <TabsContent value="members" className="space-y-4">
+          <div className="flex gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search members..."
+                value={memberSearch}
+                onChange={(e) => setMemberSearch(e.target.value)}
+                className="pl-9 font-mono text-sm"
+              />
+            </div>
+          </div>
+
+          <div className="grid lg:grid-cols-[300px_1fr] gap-4">
+            {/* Member List */}
+            <Card className="bg-card border-border">
+              <CardContent className="p-2">
+                <div className="space-y-1 max-h-[600px] overflow-y-auto">
+                  {filteredMembers.map((m) => (
+                    <button
+                      key={m.id}
+                      onClick={() => setSelectedMemberId(m.user.id)}
+                      className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors ${
+                        selectedMemberId === m.user.id
+                          ? 'bg-primary/10 text-primary'
+                          : 'hover:bg-muted text-foreground'
+                      }`}
+                    >
+                      <div className="h-8 w-8 rounded-full bg-muted border border-border flex items-center justify-center shrink-0">
+                        <span className="text-[10px] font-mono font-bold">
+                          {m.user.displayName
+                            .split(' ')
+                            .map((n) => n[0])
+                            .join('')}
+                        </span>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-mono truncate">{m.user.displayName}</p>
+                        <p className="text-[10px] text-muted-foreground font-mono truncate">
+                          {m.group?.name || m.role}
+                        </p>
+                      </div>
+                    </button>
+                  ))}
+                  {filteredMembers.length === 0 && (
+                    <p className="text-sm text-muted-foreground text-center py-8 font-mono">
+                      No members found
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Member Detail */}
+            <div>
+              {selectedMemberId && memberAnalytics ? (
+                <MemberAnalyticsCard data={memberAnalytics} />
+              ) : (
+                <Card className="bg-card border-border">
+                  <CardContent className="flex flex-col items-center justify-center py-16 text-center">
+                    <Users className="h-8 w-8 text-muted-foreground/30 mb-3" />
+                    <p className="text-sm text-muted-foreground font-mono">
+                      Select a member to view their analytics
+                    </p>
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default OrgAnalytics;

--- a/src/services/org-analytics.ts
+++ b/src/services/org-analytics.ts
@@ -1,0 +1,115 @@
+import api from './api';
+
+const base = (slug: string) => `/organizations/${slug}/analytics`;
+
+export interface OrgOverview {
+  memberCount: number;
+  activeUsersLast7d: number;
+  totalExamsTaken: number;
+  avgScore: number;
+  passRate: number;
+  totalAssessments: number;
+  totalCandidatesInvited: number;
+}
+
+export interface CertReadiness {
+  certificationId: string;
+  certificationName: string;
+  certificationCode: string;
+  membersAttempted: number;
+  totalMembers: number;
+  avgScore: number;
+  passedMembers: number;
+  passRate: number;
+}
+
+export interface DomainGap {
+  domain: string;
+  correct: number;
+  total: number;
+  percentage: number;
+}
+
+export interface WeeklyProgress {
+  week: string;
+  examsTaken: number;
+  avgScore: number;
+  activeUsers: number;
+}
+
+export interface OrgEngagement {
+  totalMembers: number;
+  activeUsersLast7d: number;
+  activeRate: number;
+  totalExamsTaken: number;
+  avgExamsPerMember: number;
+  assessmentFunnel: {
+    invited: number;
+    started: number;
+    submitted: number;
+    expired: number;
+  };
+}
+
+export interface MemberAttempt {
+  id: string;
+  examTitle: string;
+  certification: { id: string; name: string; code: string } | null;
+  score: number;
+  totalCorrect: number;
+  totalQuestions: number;
+  passed: boolean;
+  timeSpent: number;
+  submittedAt: string;
+}
+
+export interface MemberAnalytics {
+  member: {
+    userId: string;
+    displayName: string;
+    email: string;
+    avatarUrl: string | null;
+    role: string;
+    group: { id: string; name: string } | null;
+    joinedAt: string;
+  };
+  summary: {
+    totalExams: number;
+    totalPassed: number;
+    passRate: number;
+    avgScore: number;
+    bestScore: number;
+  };
+  domains: DomainGap[];
+  recentAttempts: MemberAttempt[];
+}
+
+export const getOrgOverview = async (slug: string): Promise<OrgOverview> => {
+  const res = await api.get<OrgOverview>(`${base(slug)}/overview`);
+  return res.data;
+};
+
+export const getOrgReadiness = async (slug: string): Promise<CertReadiness[]> => {
+  const res = await api.get<CertReadiness[]>(`${base(slug)}/readiness`);
+  return res.data;
+};
+
+export const getOrgSkillGaps = async (slug: string): Promise<DomainGap[]> => {
+  const res = await api.get<DomainGap[]>(`${base(slug)}/skill-gaps`);
+  return res.data;
+};
+
+export const getOrgProgress = async (slug: string, weeks = 12): Promise<WeeklyProgress[]> => {
+  const res = await api.get<WeeklyProgress[]>(`${base(slug)}/progress?weeks=${weeks}`);
+  return res.data;
+};
+
+export const getOrgEngagement = async (slug: string): Promise<OrgEngagement> => {
+  const res = await api.get<OrgEngagement>(`${base(slug)}/engagement`);
+  return res.data;
+};
+
+export const getMemberAnalytics = async (slug: string, userId: string): Promise<MemberAnalytics> => {
+  const res = await api.get<MemberAnalytics>(`${base(slug)}/member/${userId}`);
+  return res.data;
+};


### PR DESCRIPTION
## Overview
Add comprehensive organization analytics dashboard with team performance metrics, certification readiness tracking, skill gap analysis, and individual member deep-dive analytics.

## Changes

### Backend
- **New Module**: `OrgAnalyticsModule` with controller and service
- **Endpoints** (org-admin/manager only):
  - `GET /organizations/:orgId/analytics/overview` - KPI metrics
  - `GET /organizations/:orgId/analytics/readiness` - Per-certification team readiness
  - `GET /organizations/:orgId/analytics/skill-gaps` - Domain weakness analysis
  - `GET /organizations/:orgId/analytics/progress` - Week-over-week trends
  - `GET /organizations/:orgId/analytics/engagement` - Engagement metrics & assessment funnel
  - `GET /organizations/:orgId/analytics/member/:userId` - Individual member analytics

### Frontend
- **Page**: `OrgAnalytics.tsx` - Main dashboard with 4 tabs (Overview, Readiness, Skill Gaps, Members)
- **Charts**:
  - `ReadinessHeatmap` - Certification readiness matrix
  - `SkillGapChart` - Domain performance radar/bar chart
  - `EngagementChart` - Weekly activity & trend lines
  - `MemberAnalyticsCard` - Individual member summary & history
- **Service**: `org-analytics.ts` - API client with TypeScript interfaces

## Features
- Real-time KPIs: member count, active users, exams, scores, pass rates
- Certification-level readiness with pass rate tracking
- Domain-level skill gap identification (sorted by weakness)
- 12-week configurable progress visualization
- Assessment pipeline funnel (invited → submitted)
- Member search and individual analytics drill-down
- Responsive charts with recharts (bar, line, radar)

## Permissions
Owner/Admin/Manager roles only