### PR TITLE
feat: Phase 6 integration & polish — org context in auth, navbar, dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ CertGym provides curated content for popular certifications including:
 
 ---
 
+## 🚀 Changelog
+
+### Phase 6 — Integration & Polish (April 2026)
+- **Auth Enhancement**: Login and refresh token responses now include `orgMemberships` (orgId, slug, name, role) so the frontend knows the user's org context without extra API calls.
+- **Auth Store**: The Zustand `useAuthStore` user state now stores `orgMemberships`, persisted across sessions.
+- **Navbar**: The "Organization" nav link is now conditionally shown only for users with org memberships. For single-org users it links directly to `/org/:slug`; for multi-org users it links to the org selector.
+- **Bottom Tab Bar**: An "Org" tab is conditionally shown on mobile for users with org memberships.
+- **Dashboard**: An Organization card is shown on the dashboard for org members, displaying org name, role, and a quick link to the org dashboard. Multi-org users see a "View all" option.
+
+---
+
 ## 📄 License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,34 @@
   <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
   [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
 
+## CertGym Backend
+
+NestJS API server for the CertGym certification exam preparation platform.
+
+### Auth Endpoints
+
+`POST /api/v1/auth/login` and `POST /api/v1/auth/refresh` return:
+
+```json
+{
+  "accessToken": "...",
+  "refreshToken": "...",
+  "user": {
+    "id": "...",
+    "email": "...",
+    "displayName": "...",
+    "role": "...",
+    "orgMemberships": [
+      { "orgId": "...", "slug": "acme", "name": "Acme Corp", "role": "MEMBER" }
+    ]
+  }
+}
+```
+
+`orgMemberships` contains all active org memberships for the authenticated user, enabling the frontend to determine org context without additional API calls.
+
+---
+
 ## Description
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,12 +5,14 @@ import { APP_GUARD } from '@nestjs/core';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from '../users/users.module';
+import { PrismaModule } from '../prisma/prisma.module';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Module({
   imports: [
     UsersModule,
+    PrismaModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({}),
   ],

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -3,6 +3,7 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -28,6 +29,14 @@ describe('AuthService', () => {
           provide: ConfigService,
           useValue: {
             get: jest.fn(),
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            orgMember: {
+              findMany: jest.fn().mockResolvedValue([]),
+            },
           },
         },
       ],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { UserStatus } from '@prisma/client';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
 import { LoginDto } from './dto/login.dto';
 import { CreateUserDto } from '../users/dto/create-user.dto';
 import * as bcrypt from 'bcryptjs';
@@ -19,6 +20,7 @@ export class AuthService {
     private usersService: UsersService,
     private jwtService: JwtService,
     private configService: ConfigService,
+    private prisma: PrismaService,
   ) {}
 
   async validateUser(email: string, pass: string): Promise<any> {
@@ -90,11 +92,20 @@ export class AuthService {
 
     const refreshToken = await this.jwtService.signAsync(payload, {
       secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
-      expiresIn: this.configService.get<string>(
-        'JWT_REFRESH_EXPIRES_IN',
-        '7d',
-      ) as any,
+      expiresIn: this.configService.get<string>('JWT_REFRESH_EXPIRES_IN', '7d') as any,
     });
+
+    const memberships = await this.prisma.orgMember.findMany({
+      where: { userId: user.id, isActive: true },
+      include: { organization: { select: { slug: true, name: true } } },
+    });
+
+    const orgMemberships = memberships.map((m) => ({
+      orgId: m.orgId,
+      slug: m.organization.slug,
+      name: m.organization.name,
+      role: m.role,
+    }));
 
     return {
       accessToken,
@@ -104,6 +115,7 @@ export class AuthService {
         email: user.email,
         displayName: user.displayName,
         role: user.role,
+        orgMemberships,
       },
     };
   }

--- a/backend/src/auth/dto/token-response.dto.ts
+++ b/backend/src/auth/dto/token-response.dto.ts
@@ -13,5 +13,6 @@ export class TokenResponseDto {
     email: string;
     displayName: string;
     role: string;
+    orgMemberships: { orgId: string; slug: string; name: string; role: string }[];
   };
 }

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -1,7 +1,8 @@
 import { useNavigate, useLocation } from 'react-router-dom';
-import { BookOpen, Target, Dumbbell, Layers, BarChart3, Trophy } from 'lucide-react';
+import { BookOpen, Target, Dumbbell, Layers, BarChart3, Trophy, Building2 } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth.store';
 
-const tabs = [
+const staticTabs = [
   { label: 'Dashboard', href: '/dashboard', icon: BarChart3 },
   { label: 'Training', href: '/training', icon: Dumbbell },
   { label: 'Exams', href: '/exams', icon: Target },
@@ -13,6 +14,14 @@ const tabs = [
 const BottomTabBar = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const user = useAuthStore((s) => s.user);
+
+  const orgMemberships = user?.orgMemberships ?? [];
+  const orgHref = orgMemberships.length === 1 ? `/org/${orgMemberships[0].slug}` : '/org';
+
+  const tabs = orgMemberships.length > 0
+    ? [...staticTabs, { label: 'Org', href: orgHref, icon: Building2 }]
+    : staticTabs;
 
   const isActive = (href: string) =>
     location.pathname === href || location.pathname.startsWith(href + '/');

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -32,10 +32,17 @@ const Navbar = ({ title, showBack, icon: LogoIcon = Brain }: NavbarProps) => {
   const currentOrg = useOrgStore((s) => s.currentOrg);
   const [open, setOpen] = useState(false);
 
-  const orgHref = currentOrg ? `/org/${currentOrg.slug}` : '/org';
+  const orgMemberships = user?.orgMemberships ?? [];
+  const orgHref = orgMemberships.length === 1
+    ? `/org/${orgMemberships[0].slug}`
+    : currentOrg
+      ? `/org/${currentOrg.slug}`
+      : '/org';
   const navLinks = [
     ...staticNavLinks.slice(0, 7), // before Leaderboard
-    { label: 'Organization', href: orgHref, icon: Building2 },
+    ...(orgMemberships.length > 0
+      ? [{ label: 'Organization', href: orgHref, icon: Building2 }]
+      : []),
     ...staticNavLinks.slice(7), // Leaderboard
   ];
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Brain, TrendingUp, Trophy, Target, FileText } from 'lucide-react';
+import { Brain, TrendingUp, Trophy, Target, FileText, Building2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -26,7 +26,7 @@ import { ExamHistoryList } from '@/components/dashboard/ExamHistoryList';
 
 const Dashboard = () => {
   const navigate = useNavigate();
-  const { isAuthenticated } = useAuthStore();
+  const { isAuthenticated, user } = useAuthStore();
   const [certFilter, setCertFilter] = useState<string>('');
 
   const { data: certifications } = useQuery({
@@ -152,6 +152,57 @@ const Dashboard = () => {
             ))}
           </div>
         )}
+
+        {/* Organization card — visible only to org members */}
+        {user?.orgMemberships?.length > 0 && (() => {
+          const firstOrg = user.orgMemberships[0];
+          const orgHref = `/org/${firstOrg.slug}`;
+          return (
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1 }}
+            >
+              <Card className="glass-card">
+                <CardContent className="p-5 flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-4">
+                    <div className="p-2.5 rounded-lg bg-primary/10">
+                      <Building2 className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <div className="text-base font-bold font-mono">{firstOrg.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        Role: <span className="capitalize">{firstOrg.role.toLowerCase()}</span>
+                        {user.orgMemberships.length > 1 && (
+                          <span className="ml-2 text-primary">+{user.orgMemberships.length - 1} more</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Button
+                      size="sm"
+                      className="glow-cyan font-mono text-xs h-8"
+                      onClick={() => navigate(orgHref)}
+                    >
+                      Go to Org
+                    </Button>
+                    {user.orgMemberships.length > 1 && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="font-mono text-xs h-8"
+                        onClick={() => navigate('/org')}
+                      >
+                        View all
+                      </Button>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          );
+        })()}
 
         {/* Readiness + Mistake Patterns */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,11 +1,19 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+interface OrgMembership {
+    orgId: string;
+    slug: string;
+    name: string;
+    role: string;
+}
+
 interface User {
     id: string;
     email: string;
     displayName: string;
     role: string;
+    orgMemberships: OrgMembership[];
 }
 
 interface AuthState {


### PR DESCRIPTION
## Summary

Phase 6 integration and polish work connecting organization context across the full stack — from auth tokens to the frontend UI.

## Changes by Step

### 6.1 — Backend: Auth Enhancement
- `AuthService.generateTokens()` now fetches active `OrgMember` records (with org `slug` and `name`) and includes them as `orgMemberships` in the `TokenResponseDto` user object.
- `PrismaService` injected into `AuthService`; `PrismaModule` added to `AuthModule` imports.
- `token-response.dto.ts` updated to declare `orgMemberships` field.

### 6.2 — Frontend: Auth Store Enhancement
- `OrgMembership` interface added (`orgId`, `slug`, `name`, `role`).
- `User` interface in `useAuthStore` now includes `orgMemberships: OrgMembership[]`.
- Persisted via Zustand middleware — org context survives page refresh.

### 6.3 — Frontend: Navbar Integration
- Organization nav link is now conditionally rendered only when `user.orgMemberships.length > 0`.
- Single-org users link directly to `/org/:slug`; multi-org users link to `/org`.

### 6.4 — Frontend: Bottom Tab Bar Integration
- Imports `useAuthStore` and `Building2` icon.
- An "Org" tab is conditionally appended when the user has org memberships (mobile only).

### 6.5 — Frontend: Dashboard Integration
- Organization card section added below the stats grid, visible only to org members.
- Displays org name, user role, and a "Go to Org" button.
- Multi-org users also see a "View all" button linking to `/org`.

## Test Results

- Frontend: 9/9 tests passed (`npm run test -- --run`)
- Backend: 43/43 tests passed (`npm run test`)
- Frontend build: success (`npm run build`)
- Backend build: success (`npm run build`); pre-existing `mcp-server.ts` errors unrelated to Phase 6

## Notes

This PR is ready for review but should NOT be merged without code review. The pre-existing `mcp-server.ts` compile errors in the backend are unrelated to Phase 6 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)