### PR TITLE
feat(types): TypeScript strict pilot for services layer and auth store (US-102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ env:
 
 jobs:
 
+  # US-102: Strict TypeScript gate for services layer and auth store.
+  # Runs in parallel with lint so it doesn't add to the critical path.
+  type-check-strict:
+    name: Type / Strict FE Services
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run type-check:strict
+
   lint-frontend:
     name: Lint / Frontend
     runs-on: ubuntu-latest

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,12 +19,23 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-empty-object-type": "warn",
       "@typescript-eslint/no-require-imports": "warn",
       "no-empty": "warn",
+    },
+  },
+  // US-102: Strict no-any gate for the services layer and auth store.
+  // No new `any` allowed in these files — enforced as error (not warn).
+  {
+    files: ["src/services/**/*.ts", "src/stores/auth.store.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "type-check:strict": "tsc -p tsconfig.strict.json --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -1,4 +1,4 @@
-import api from './api';
+import api from "./api";
 
 // ==================== Types ====================
 
@@ -47,13 +47,24 @@ export interface AdminReport {
 
 export interface DashboardData {
   users: { total: number; newLast7d: number; newLast30d: number };
-  questions: { draft: number; pending: number; approved: number; rejected: number; total: number };
+  questions: {
+    draft: number;
+    pending: number;
+    approved: number;
+    rejected: number;
+    total: number;
+  };
   exams: { total: number };
   attempts: { total: number };
   reports: { pending: number };
   providers: { total: number };
   certifications: { total: number };
-  aiGeneration: { pending: number; processing: number; completed: number; failed: number };
+  aiGeneration: {
+    pending: number;
+    processing: number;
+    completed: number;
+    failed: number;
+  };
 }
 
 export interface Provider {
@@ -75,7 +86,7 @@ export interface AuditLogEntry {
   action: string;
   targetType: string;
   targetId: string;
-  metadata: any;
+  metadata: Record<string, unknown>;
   ipAddress: string | null;
   createdAt: string;
   user: { id: string; displayName: string; email: string };
@@ -84,18 +95,24 @@ export interface AuditLogEntry {
 // ==================== Dashboard ====================
 
 export const getDashboard = async (): Promise<DashboardData> => {
-  const response = await api.get<DashboardData>('/admin/dashboard');
+  const response = await api.get<DashboardData>("/admin/dashboard");
   return response.data;
 };
 
 // ==================== Users ====================
 
-export const getUsers = async (search?: string, page = 1, limit = 20): Promise<PaginatedResponse<AdminUser>> => {
+export const getUsers = async (
+  search?: string,
+  page = 1,
+  limit = 20,
+): Promise<PaginatedResponse<AdminUser>> => {
   const params = new URLSearchParams();
-  if (search) params.append('search', search);
-  params.append('page', page.toString());
-  params.append('limit', limit.toString());
-  const response = await api.get<PaginatedResponse<AdminUser>>(`/users?${params}`);
+  if (search) params.append("search", search);
+  params.append("page", page.toString());
+  params.append("limit", limit.toString());
+  const response = await api.get<PaginatedResponse<AdminUser>>(
+    `/users?${params}`,
+  );
   return response.data;
 };
 
@@ -104,8 +121,15 @@ export const updateUserRole = async (userId: string, role: string) => {
   return response.data;
 };
 
-export const suspendUser = async (userId: string, reason: string, suspendedUntil?: string) => {
-  const response = await api.put(`/users/${userId}/suspend`, { reason, suspendedUntil });
+export const suspendUser = async (
+  userId: string,
+  reason: string,
+  suspendedUntil?: string,
+) => {
+  const response = await api.put(`/users/${userId}/suspend`, {
+    reason,
+    suspendedUntil,
+  });
   return response.data;
 };
 
@@ -119,24 +143,39 @@ export const reactivateUser = async (userId: string) => {
   return response.data;
 };
 
-export const adjustUserPoints = async (userId: string, amount: number, reason?: string) => {
+export const adjustUserPoints = async (
+  userId: string,
+  amount: number,
+  reason?: string,
+) => {
   const response = await api.put(`/users/${userId}/points`, { amount, reason });
   return response.data;
 };
 
 // ==================== Question Moderation ====================
 
-export const getPendingQuestions = async (page = 1, limit = 20): Promise<PaginatedResponse<PendingQuestion>> => {
-  const response = await api.get<PaginatedResponse<PendingQuestion>>(`/questions/queue/pending?page=${page}&limit=${limit}`);
+export const getPendingQuestions = async (
+  page = 1,
+  limit = 20,
+): Promise<PaginatedResponse<PendingQuestion>> => {
+  const response = await api.get<PaginatedResponse<PendingQuestion>>(
+    `/questions/queue/pending?page=${page}&limit=${limit}`,
+  );
   return response.data;
 };
 
-export const updateQuestionStatus = async (questionId: string, status: string) => {
+export const updateQuestionStatus = async (
+  questionId: string,
+  status: string,
+) => {
   const response = await api.put(`/questions/${questionId}/status`, { status });
   return response.data;
 };
 
-export const adminUpdateQuestion = async (questionId: string, data: any) => {
+export const adminUpdateQuestion = async (
+  questionId: string,
+  data: Record<string, unknown>,
+) => {
   const response = await api.put(`/questions/${questionId}/admin`, data);
   return response.data;
 };
@@ -153,26 +192,33 @@ export const getAdminQuestions = async (params: {
   page?: number;
   limit?: number;
   includeDeleted?: boolean;
-}): Promise<PaginatedResponse<any>> => {
+}): Promise<PaginatedResponse<Record<string, unknown>>> => {
   const searchParams = new URLSearchParams();
-  if (params.certificationId) searchParams.append('certificationId', params.certificationId);
-  if (params.status) searchParams.append('status', params.status);
-  if (params.search) searchParams.append('search', params.search);
-  if (params.page) searchParams.append('page', params.page.toString());
-  if (params.limit) searchParams.append('limit', params.limit.toString());
-  if (params.includeDeleted) searchParams.append('includeDeleted', 'true');
+  if (params.certificationId)
+    searchParams.append("certificationId", params.certificationId);
+  if (params.status) searchParams.append("status", params.status);
+  if (params.search) searchParams.append("search", params.search);
+  if (params.page) searchParams.append("page", params.page.toString());
+  if (params.limit) searchParams.append("limit", params.limit.toString());
+  if (params.includeDeleted) searchParams.append("includeDeleted", "true");
   const response = await api.get(`/questions/admin/all?${searchParams}`);
   return response.data;
 };
 
 // ==================== Reports ====================
 
-export const getReports = async (status?: string, page = 1, limit = 20): Promise<PaginatedResponse<AdminReport>> => {
+export const getReports = async (
+  status?: string,
+  page = 1,
+  limit = 20,
+): Promise<PaginatedResponse<AdminReport>> => {
   const params = new URLSearchParams();
-  if (status) params.append('status', status);
-  params.append('page', page.toString());
-  params.append('limit', limit.toString());
-  const response = await api.get<PaginatedResponse<AdminReport>>(`/reports?${params}`);
+  if (status) params.append("status", status);
+  params.append("page", page.toString());
+  params.append("limit", limit.toString());
+  const response = await api.get<PaginatedResponse<AdminReport>>(
+    `/reports?${params}`,
+  );
   return response.data;
 };
 
@@ -183,17 +229,31 @@ export const updateReportStatus = async (reportId: string, status: string) => {
 
 // ==================== Providers ====================
 
-export const getProviders = async (includeInactive = false): Promise<Provider[]> => {
-  const response = await api.get<Provider[]>(`/providers?includeInactive=${includeInactive}`);
+export const getProviders = async (
+  includeInactive = false,
+): Promise<Provider[]> => {
+  const response = await api.get<Provider[]>(
+    `/providers?includeInactive=${includeInactive}`,
+  );
   return response.data;
 };
 
-export const createProvider = async (data: { name: string; slug: string; logoUrl?: string; website?: string; description?: string; sortOrder?: number }): Promise<Provider> => {
-  const response = await api.post<Provider>('/providers', data);
+export const createProvider = async (data: {
+  name: string;
+  slug: string;
+  logoUrl?: string;
+  website?: string;
+  description?: string;
+  sortOrder?: number;
+}): Promise<Provider> => {
+  const response = await api.post<Provider>("/providers", data);
   return response.data;
 };
 
-export const updateProvider = async (id: string, data: Partial<Provider>): Promise<Provider> => {
+export const updateProvider = async (
+  id: string,
+  data: Partial<Provider>,
+): Promise<Provider> => {
   const response = await api.put<Provider>(`/providers/${id}`, data);
   return response.data;
 };
@@ -205,22 +265,30 @@ export const deleteProvider = async (id: string): Promise<Provider> => {
 
 // ==================== Admin Exams ====================
 
-export const getAdminExams = async (params: { page?: number; limit?: number; visibility?: string }): Promise<PaginatedResponse<any>> => {
+export const getAdminExams = async (params: {
+  page?: number;
+  limit?: number;
+  visibility?: string;
+}): Promise<PaginatedResponse<Record<string, unknown>>> => {
   const searchParams = new URLSearchParams();
-  if (params.page) searchParams.append('page', params.page.toString());
-  if (params.limit) searchParams.append('limit', params.limit.toString());
-  if (params.visibility) searchParams.append('visibility', params.visibility);
+  if (params.page) searchParams.append("page", params.page.toString());
+  if (params.limit) searchParams.append("limit", params.limit.toString());
+  if (params.visibility) searchParams.append("visibility", params.visibility);
   const response = await api.get(`/admin/exams?${searchParams}`);
   return response.data;
 };
 
 // ==================== AI Generation ====================
 
-export const getAdminGenerationJobs = async (params: { page?: number; limit?: number; status?: string }): Promise<PaginatedResponse<any>> => {
+export const getAdminGenerationJobs = async (params: {
+  page?: number;
+  limit?: number;
+  status?: string;
+}): Promise<PaginatedResponse<Record<string, unknown>>> => {
   const searchParams = new URLSearchParams();
-  if (params.page) searchParams.append('page', params.page.toString());
-  if (params.limit) searchParams.append('limit', params.limit.toString());
-  if (params.status) searchParams.append('status', params.status);
+  if (params.page) searchParams.append("page", params.page.toString());
+  if (params.limit) searchParams.append("limit", params.limit.toString());
+  if (params.status) searchParams.append("status", params.status);
   const response = await api.get(`/admin/generation-jobs?${searchParams}`);
   return response.data;
 };
@@ -235,32 +303,45 @@ export const getAuditLogs = async (params: {
   limit?: number;
 }): Promise<PaginatedResponse<AuditLogEntry>> => {
   const searchParams = new URLSearchParams();
-  if (params.action) searchParams.append('action', params.action);
-  if (params.targetType) searchParams.append('targetType', params.targetType);
-  if (params.userId) searchParams.append('userId', params.userId);
-  if (params.page) searchParams.append('page', params.page.toString());
-  if (params.limit) searchParams.append('limit', params.limit.toString());
+  if (params.action) searchParams.append("action", params.action);
+  if (params.targetType) searchParams.append("targetType", params.targetType);
+  if (params.userId) searchParams.append("userId", params.userId);
+  if (params.page) searchParams.append("page", params.page.toString());
+  if (params.limit) searchParams.append("limit", params.limit.toString());
   const response = await api.get(`/admin/audit-logs?${searchParams}`);
   return response.data;
 };
 
 // ==================== Domains ====================
 
-export const getAdminDomains = async (params: { certificationId?: string; page?: number; limit?: number }): Promise<PaginatedResponse<any>> => {
+export const getAdminDomains = async (params: {
+  certificationId?: string;
+  page?: number;
+  limit?: number;
+}): Promise<PaginatedResponse<Record<string, unknown>>> => {
   const searchParams = new URLSearchParams();
-  if (params.certificationId) searchParams.append('certificationId', params.certificationId);
-  if (params.page) searchParams.append('page', params.page.toString());
-  if (params.limit) searchParams.append('limit', params.limit.toString());
+  if (params.certificationId)
+    searchParams.append("certificationId", params.certificationId);
+  if (params.page) searchParams.append("page", params.page.toString());
+  if (params.limit) searchParams.append("limit", params.limit.toString());
   const response = await api.get(`/admin/domains?${searchParams}`);
   return response.data;
 };
 
-export const createDomain = async (data: { name: string; certificationId: string; description?: string; weight?: number }) => {
-  const response = await api.post('/admin/domains', data);
+export const createDomain = async (data: {
+  name: string;
+  certificationId: string;
+  description?: string;
+  weight?: number;
+}) => {
+  const response = await api.post("/admin/domains", data);
   return response.data;
 };
 
-export const updateDomain = async (id: string, data: { name?: string; description?: string; weight?: number }) => {
+export const updateDomain = async (
+  id: string,
+  data: { name?: string; description?: string; weight?: number },
+) => {
   const response = await api.put(`/admin/domains/${id}`, data);
   return response.data;
 };
@@ -270,21 +351,32 @@ export const deleteDomain = async (id: string) => {
   return response.data;
 };
 
-export const reorderDomains = async (certificationId: string, orderedIds: string[]) => {
-  const response = await api.put('/admin/domains/reorder', { certificationId, orderedIds });
+export const reorderDomains = async (
+  certificationId: string,
+  orderedIds: string[],
+) => {
+  const response = await api.put("/admin/domains/reorder", {
+    certificationId,
+    orderedIds,
+  });
   return response.data;
 };
 
 // ==================== Tags ====================
 
-export const getAdminTags = async (certificationId?: string): Promise<any[]> => {
-  const params = certificationId ? `?certificationId=${certificationId}` : '';
+export const getAdminTags = async (
+  certificationId?: string,
+): Promise<unknown[]> => {
+  const params = certificationId ? `?certificationId=${certificationId}` : "";
   const response = await api.get(`/tags${params}`);
   return response.data;
 };
 
-export const createTag = async (data: { name: string; certificationId?: string }) => {
-  const response = await api.post('/tags', data);
+export const createTag = async (data: {
+  name: string;
+  certificationId?: string;
+}) => {
+  const response = await api.post("/tags", data);
   return response.data;
 };
 
@@ -298,24 +390,40 @@ export const deleteTag = async (id: string) => {
   return response.data;
 };
 
-export const mergeTags = async (data: { sourceIds: string[]; targetId: string }) => {
-  const response = await api.post('/tags/merge', data);
+export const mergeTags = async (data: {
+  sourceIds: string[];
+  targetId: string;
+}) => {
+  const response = await api.post("/tags/merge", data);
   return response.data;
 };
 
 // ==================== Badges ====================
 
-export const getAdminBadges = async (): Promise<any[]> => {
-  const response = await api.get('/admin/badges');
+export const getAdminBadges = async (): Promise<unknown[]> => {
+  const response = await api.get("/admin/badges");
   return response.data;
 };
 
-export const createBadge = async (data: { name: string; description?: string; iconUrl?: string; criteria?: any }) => {
-  const response = await api.post('/admin/badges', data);
+export const createBadge = async (data: {
+  name: string;
+  description?: string;
+  iconUrl?: string;
+  criteria?: Record<string, unknown>;
+}) => {
+  const response = await api.post("/admin/badges", data);
   return response.data;
 };
 
-export const updateBadge = async (id: string, data: { name?: string; description?: string; iconUrl?: string; criteria?: any }) => {
+export const updateBadge = async (
+  id: string,
+  data: {
+    name?: string;
+    description?: string;
+    iconUrl?: string;
+    criteria?: Record<string, unknown>;
+  },
+) => {
   const response = await api.put(`/admin/badges/${id}`, data);
   return response.data;
 };
@@ -331,16 +439,21 @@ export const awardBadge = async (badgeId: string, userId: string) => {
 };
 
 export const revokeBadge = async (badgeId: string, userId: string) => {
-  const response = await api.delete(`/admin/badges/${badgeId}/awards/${userId}`);
+  const response = await api.delete(
+    `/admin/badges/${badgeId}/awards/${userId}`,
+  );
   return response.data;
 };
 
 // ==================== Source Materials ====================
 
-export const getAdminSourceMaterials = async (params: { page?: number; limit?: number }): Promise<PaginatedResponse<any>> => {
+export const getAdminSourceMaterials = async (params: {
+  page?: number;
+  limit?: number;
+}): Promise<PaginatedResponse<Record<string, unknown>>> => {
   const searchParams = new URLSearchParams();
-  if (params.page) searchParams.append('page', params.page.toString());
-  if (params.limit) searchParams.append('limit', params.limit.toString());
+  if (params.page) searchParams.append("page", params.page.toString());
+  if (params.limit) searchParams.append("limit", params.limit.toString());
   const response = await api.get(`/admin/source-materials?${searchParams}`);
   return response.data;
 };
@@ -353,19 +466,27 @@ export const deleteSourceMaterial = async (id: string) => {
 // ==================== Exam Visibility ====================
 
 export const updateExamVisibility = async (id: string, visibility: string) => {
-  const response = await api.patch(`/admin/exams/${id}/visibility`, { visibility });
+  const response = await api.patch(`/admin/exams/${id}/visibility`, {
+    visibility,
+  });
   return response.data;
 };
 
 // ==================== Bulk Operations ====================
 
-export const bulkUpdateQuestionStatus = async (ids: string[], status: string) => {
-  const response = await api.post('/admin/questions/bulk-status', { ids, status });
+export const bulkUpdateQuestionStatus = async (
+  ids: string[],
+  status: string,
+) => {
+  const response = await api.post("/admin/questions/bulk-status", {
+    ids,
+    status,
+  });
   return response.data;
 };
 
 export const bulkUpdateUserRole = async (userIds: string[], role: string) => {
-  const response = await api.post('/admin/users/bulk-role', { userIds, role });
+  const response = await api.post("/admin/users/bulk-role", { userIds, role });
   return response.data;
 };
 
@@ -373,7 +494,7 @@ export const bulkUpdateUserRole = async (userIds: string[], role: string) => {
 
 const downloadCsv = (blob: Blob, filename: string) => {
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
+  const a = document.createElement("a");
   a.href = url;
   a.download = filename;
   a.click();
@@ -381,16 +502,22 @@ const downloadCsv = (blob: Blob, filename: string) => {
 };
 
 export const exportUsers = async () => {
-  const response = await api.get('/admin/export/users', { responseType: 'blob' });
-  downloadCsv(response.data, 'users.csv');
+  const response = await api.get("/admin/export/users", {
+    responseType: "blob",
+  });
+  downloadCsv(response.data, "users.csv");
 };
 
 export const exportQuestions = async () => {
-  const response = await api.get('/admin/export/questions', { responseType: 'blob' });
-  downloadCsv(response.data, 'questions.csv');
+  const response = await api.get("/admin/export/questions", {
+    responseType: "blob",
+  });
+  downloadCsv(response.data, "questions.csv");
 };
 
 export const exportAnalytics = async () => {
-  const response = await api.get('/admin/export/analytics', { responseType: 'blob' });
-  downloadCsv(response.data, 'analytics.csv');
+  const response = await api.get("/admin/export/analytics", {
+    responseType: "blob",
+  });
+  downloadCsv(response.data, "analytics.csv");
 };

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,4 +1,4 @@
-import api from './api';
+import api from "./api";
 import {
   AnalyticsSummary,
   HistoryItem,
@@ -6,53 +6,92 @@ import {
   ReadinessScore,
   MistakePatterns,
   PaginatedResponse,
-} from '@/types/api-types';
+} from "@/types/api-types";
 
-export type { AnalyticsSummary, HistoryItem, DomainPerformance, ReadinessScore, MistakePatterns };
+export type {
+  AnalyticsSummary,
+  HistoryItem,
+  DomainPerformance,
+  ReadinessScore,
+  MistakePatterns,
+};
 
 export type PaginatedHistory = PaginatedResponse<HistoryItem>;
 
-export const getAnalyticsSummary = async (certificationId?: string): Promise<AnalyticsSummary> => {
-  const params = certificationId ? `?certificationId=${certificationId}` : '';
-  const response = await api.get<AnalyticsSummary>(`/analytics/me/summary${params}`);
+export const getAnalyticsSummary = async (
+  certificationId?: string,
+): Promise<AnalyticsSummary> => {
+  const params = certificationId ? `?certificationId=${certificationId}` : "";
+  const response = await api.get<AnalyticsSummary>(
+    `/analytics/me/summary${params}`,
+  );
   return response.data;
 };
 
-export const getAnalyticsHistory = async (certificationId?: string, page = 1, limit = 20): Promise<PaginatedHistory> => {
+export const getAnalyticsHistory = async (
+  certificationId?: string,
+  page = 1,
+  limit = 20,
+): Promise<PaginatedHistory> => {
   const params = new URLSearchParams();
-  if (certificationId) params.append('certificationId', certificationId);
-  params.append('page', page.toString());
-  params.append('limit', limit.toString());
-  const response = await api.get<PaginatedHistory>(`/analytics/me/history?${params}`);
+  if (certificationId) params.append("certificationId", certificationId);
+  params.append("page", page.toString());
+  params.append("limit", limit.toString());
+  const response = await api.get<PaginatedHistory>(
+    `/analytics/me/history?${params}`,
+  );
   return response.data;
 };
 
-export const getAnalyticsDomains = async (certificationId?: string): Promise<DomainPerformance[]> => {
-  const params = certificationId ? `?certificationId=${certificationId}` : '';
-  const response = await api.get<DomainPerformance[]>(`/analytics/me/domains${params}`);
+export const getAnalyticsDomains = async (
+  certificationId?: string,
+): Promise<DomainPerformance[]> => {
+  const params = certificationId ? `?certificationId=${certificationId}` : "";
+  const response = await api.get<DomainPerformance[]>(
+    `/analytics/me/domains${params}`,
+  );
   return response.data;
 };
 
-export const getWeakTopics = async (certificationId?: string, topN = 5): Promise<DomainPerformance[]> => {
+export const getWeakTopics = async (
+  certificationId?: string,
+  topN = 5,
+): Promise<DomainPerformance[]> => {
   const params = new URLSearchParams();
-  if (certificationId) params.append('certificationId', certificationId);
-  params.append('topN', topN.toString());
-  const response = await api.get<DomainPerformance[]>(`/analytics/me/weak-topics?${params}`);
+  if (certificationId) params.append("certificationId", certificationId);
+  params.append("topN", topN.toString());
+  const response = await api.get<DomainPerformance[]>(
+    `/analytics/me/weak-topics?${params}`,
+  );
   return response.data;
 };
 
-export const getReadiness = async (certificationId: string): Promise<ReadinessScore> => {
-  const response = await api.get<ReadinessScore>(`/analytics/readiness/${certificationId}`);
+export const getReadiness = async (
+  certificationId: string,
+): Promise<ReadinessScore> => {
+  const response = await api.get<ReadinessScore>(
+    `/analytics/readiness/${certificationId}`,
+  );
   return response.data;
 };
 
-export const updateMistakeType = async (answerId: string, mistakeType: string): Promise<any> => {
-  const response = await api.patch(`/analytics/answers/${answerId}/mistake-type`, { mistakeType });
+export const updateMistakeType = async (
+  answerId: string,
+  mistakeType: string,
+): Promise<unknown> => {
+  const response = await api.patch(
+    `/analytics/answers/${answerId}/mistake-type`,
+    { mistakeType },
+  );
   return response.data;
 };
 
-export const getMistakePatterns = async (certificationId?: string): Promise<MistakePatterns> => {
-  const params = certificationId ? `?certificationId=${certificationId}` : '';
-  const response = await api.get<MistakePatterns>(`/analytics/mistake-patterns${params}`);
+export const getMistakePatterns = async (
+  certificationId?: string,
+): Promise<MistakePatterns> => {
+  const params = certificationId ? `?certificationId=${certificationId}` : "";
+  const response = await api.get<MistakePatterns>(
+    `/analytics/mistake-patterns${params}`,
+  );
   return response.data;
 };

--- a/src/services/training.ts
+++ b/src/services/training.ts
@@ -1,22 +1,36 @@
-import api from './api';
-import { ReviewSchedule } from '@/types/api-types';
+import api from "./api";
+import { ReviewSchedule } from "@/types/api-types";
 
 export type { ReviewSchedule };
 
-export const startWeaknessTraining = async (certificationId: string, questionCount = 10): Promise<any> => {
-  const response = await api.post('/training/weakness/start', { certificationId, questionCount });
+export const startWeaknessTraining = async (
+  certificationId: string,
+  questionCount = 10,
+): Promise<unknown> => {
+  const response = await api.post("/training/weakness/start", {
+    certificationId,
+    questionCount,
+  });
   return response.data;
 };
 
-export const submitReview = async (questionId: string, quality: number): Promise<any> => {
-  const response = await api.post('/training/review', { questionId, quality });
+export const submitReview = async (
+  questionId: string,
+  quality: number,
+): Promise<unknown> => {
+  const response = await api.post("/training/review", { questionId, quality });
   return response.data;
 };
 
-export const getDueReviews = async (certificationId?: string, limit?: number): Promise<ReviewSchedule[]> => {
+export const getDueReviews = async (
+  certificationId?: string,
+  limit?: number,
+): Promise<ReviewSchedule[]> => {
   const params = new URLSearchParams();
-  if (certificationId) params.append('certificationId', certificationId);
-  if (limit) params.append('limit', limit.toString());
-  const response = await api.get<ReviewSchedule[]>(`/training/due-reviews?${params}`);
+  if (certificationId) params.append("certificationId", certificationId);
+  if (limit) params.append("limit", limit.toString());
+  const response = await api.get<ReviewSchedule[]>(
+    `/training/due-reviews?${params}`,
+  );
   return response.data;
 };

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noImplicitReturns": true
+  },
+  "include": [
+    "src/vite-env.d.ts",
+    "src/services/**/*",
+    "src/stores/auth.store.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Add `tsconfig.strict.json` — extends `tsconfig.app.json` with `strict: true`, `noImplicitAny`, `strictNullChecks`, `strictFunctionTypes`, `noImplicitReturns`; scoped to `src/services/**/*` and `src/stores/auth.store.ts` only
- Add `npm run type-check:strict` script — `tsc -p tsconfig.strict.json --noEmit`
- Update `eslint.config.js` — add strict override block: `@typescript-eslint/no-explicit-any: error` for `src/services/**/*.ts` and `src/stores/auth.store.ts`
- Update CI: add `type-check-strict` job running in parallel with lint (no critical path impact)

## Why a pilot scope?

The full codebase uses loose TS (`noImplicitAny: false`). Rather than a big-bang migration, we lock down the most security-sensitive layer (API services + auth store) first. Sprint 2 can expand the scope.

## Test plan

- [ ] `npm run type-check:strict` exits 0 (currently clean)
- [ ] Introduce a deliberate `any` in `src/services/` → ESLint reports error
- [ ] CI `type-check-strict` job passes on push
- [ ] `npm run lint` still passes (strict block is additive, not breaking)

## DoD checklist

- [x] `tsconfig.strict.json` compiles to 0 errors
- [x] ESLint `no-any:error` gate on services layer
- [x] CI job parallel with lint — no added critical path
- [x] No changes to runtime code (type annotations only)