### PR TITLE
feat(api): Harden flashcard review endpoint with DTO validation, idempotency, SM-2 wiring (US-104)

### DIFF
--- a/backend/src/flashcards/dto/submit-review.dto.ts
+++ b/backend/src/flashcards/dto/submit-review.dto.ts
@@ -1,0 +1,17 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SubmitReviewDto {
+  @ApiProperty({ description: 'SM-2 quality rating', minimum: 0, maximum: 5 })
+  @IsInt()
+  @Min(0)
+  @Max(5)
+  quality: number;
+
+  @ApiPropertyOptional({
+    description: 'Client-supplied idempotency key (UUID recommended)',
+  })
+  @IsOptional()
+  @IsString()
+  idempotencyKey?: string;
+}

--- a/backend/src/flashcards/flashcards.controller.ts
+++ b/backend/src/flashcards/flashcards.controller.ts
@@ -9,6 +9,8 @@ import {
   UseGuards,
   Req,
   Query,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -21,6 +23,7 @@ import { CreateDeckDto } from './dto/create-deck.dto';
 import { UpdateDeckDto } from './dto/update-deck.dto';
 import { CreateFlashcardDto } from './dto/create-flashcard.dto';
 import { UpdateFlashcardDto } from './dto/update-flashcard.dto';
+import { SubmitReviewDto } from './dto/submit-review.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../common/interfaces/request.interface';
 
@@ -120,13 +123,14 @@ export class FlashcardsController {
 
   @Post('flashcards/:id/review')
   @ApiOperation({ summary: 'Submit SRS review for a custom flashcard' })
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
   submitReview(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
-    @Body('quality') quality: number,
+    @Body() dto: SubmitReviewDto,
   ) {
     const userId = req.user.id;
-    return this.flashcardsService.submitReview(userId, id, quality);
+    return this.flashcardsService.submitReview(userId, id, dto);
   }
 
   @Get('flashcards/srs/due')

--- a/backend/src/flashcards/flashcards.service.spec.ts
+++ b/backend/src/flashcards/flashcards.service.spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FlashcardsService } from './flashcards.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
 
 describe('FlashcardsService', () => {
   let service: FlashcardsService;
-  let prisma: PrismaService;
 
   const mockPrismaService = {
     deck: {
@@ -29,21 +29,29 @@ describe('FlashcardsService', () => {
     },
   };
 
+  const mockAuditService = {
+    log: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FlashcardsService,
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: AuditService, useValue: mockAuditService },
       ],
     }).compile();
 
     service = module.get<FlashcardsService>(FlashcardsService);
-    prisma = module.get<PrismaService>(PrismaService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  // ==================== DECKS ====================
 
   describe('createDeck', () => {
     it('should create a deck', async () => {
@@ -89,73 +97,180 @@ describe('FlashcardsService', () => {
     });
   });
 
-  describe('submitReview (SRS Logic)', () => {
+  // ==================== SRS ====================
+
+  describe('submitReview', () => {
     const flashcardId = 'card-1';
     const userId = 'user-1';
     const card = { id: flashcardId, deck: { userId } };
 
     beforeEach(() => {
       mockPrismaService.flashcard.findUnique.mockResolvedValue(card);
-    });
-
-    it('should calculate SM2 for quality 5 (Easy), first review', async () => {
       mockPrismaService.flashcardReviewSchedule.findUnique.mockResolvedValue(
         null,
       );
+    });
+
+    it('quality=4: updates ReviewSchedule with correct SM-2 output (first review)', async () => {
       mockPrismaService.flashcardReviewSchedule.upsert.mockImplementation(
-        ({ create }) => create,
+        ({ create }) => Promise.resolve({ id: 'sched-1', ...create }),
       );
 
-      const result = await service.submitReview(userId, flashcardId, 5);
+      const result = await service.submitReview(userId, flashcardId, {
+        quality: 4,
+      });
 
       expect(result.interval).toBe(1);
       expect(result.repetitions).toBe(1);
       expect(result.mastery).toBe('LEARNING');
     });
 
-    it('should calculate SM2 for quality 5 (Easy), second review', async () => {
-      const existingSchedule = {
+    it('quality=5 (Easy), first review: interval=1, repetitions=1, mastery=LEARNING', async () => {
+      mockPrismaService.flashcardReviewSchedule.upsert.mockImplementation(
+        ({ create }) => Promise.resolve({ id: 'sched-1', ...create }),
+      );
+
+      const result = await service.submitReview(userId, flashcardId, {
+        quality: 5,
+      });
+
+      expect(result.interval).toBe(1);
+      expect(result.repetitions).toBe(1);
+      expect(result.mastery).toBe('LEARNING');
+    });
+
+    it('quality=5 (Easy), second review: interval=6, repetitions=2', async () => {
+      mockPrismaService.flashcardReviewSchedule.findUnique.mockResolvedValue({
         userId,
         flashcardId,
         interval: 1,
         repetitions: 1,
         easeFactor: 2.5,
-      };
-      mockPrismaService.flashcardReviewSchedule.findUnique.mockResolvedValue(
-        existingSchedule,
-      );
+      });
       mockPrismaService.flashcardReviewSchedule.upsert.mockImplementation(
-        ({ update }) => update,
+        ({ update }) => Promise.resolve({ id: 'sched-1', ...update }),
       );
 
-      const result = await service.submitReview(userId, flashcardId, 5);
+      const result = await service.submitReview(userId, flashcardId, {
+        quality: 5,
+      });
 
       expect(result.interval).toBe(6);
       expect(result.repetitions).toBe(2);
     });
 
-    it('should reset repetitions if quality < 3 (Again)', async () => {
-      const existingSchedule = {
+    it('quality=1: lapses increment, interval resets to 1, mastery=NEW', async () => {
+      mockPrismaService.flashcardReviewSchedule.findUnique.mockResolvedValue({
         userId,
         flashcardId,
         interval: 6,
         repetitions: 2,
         easeFactor: 2.5,
-      };
-      mockPrismaService.flashcardReviewSchedule.findUnique.mockResolvedValue(
-        existingSchedule,
-      );
+      });
       mockPrismaService.flashcardReviewSchedule.upsert.mockImplementation(
-        ({ update }) => update,
+        ({ update }) => Promise.resolve({ id: 'sched-1', ...update }),
       );
 
-      const result = await service.submitReview(userId, flashcardId, 1);
+      const result = await service.submitReview(userId, flashcardId, {
+        quality: 1,
+      });
 
       expect(result.interval).toBe(1);
       expect(result.repetitions).toBe(0);
       expect(result.mastery).toBe('NEW');
     });
+
+    it('idempotency: second call with same key returns cached result without calling upsert again', async () => {
+      const scheduleId = 'sched-idem-1';
+      const cachedSchedule = {
+        id: scheduleId,
+        interval: 1,
+        repetitions: 1,
+        mastery: 'LEARNING',
+      };
+
+      // First call: upsert fires
+      mockPrismaService.flashcardReviewSchedule.upsert.mockResolvedValueOnce(
+        cachedSchedule,
+      );
+      // findUnique used on idempotency cache hit path
+      mockPrismaService.flashcardReviewSchedule.findUnique
+        .mockResolvedValueOnce(null) // no existing schedule on first call
+        .mockResolvedValueOnce(cachedSchedule); // cached lookup on second call
+
+      const idempotencyKey = `idem-key-${Date.now()}`;
+
+      const first = await service.submitReview(
+        userId,
+        `card-idem-${Date.now()}`,
+        {
+          quality: 4,
+          idempotencyKey,
+        },
+      );
+
+      // The flashcardId used must be consistent for idempotency key lookup
+      // Re-run with the same flashcardId that was used
+      const cardForIdem = `card-idem-2-${Date.now()}`;
+      mockPrismaService.flashcard.findUnique.mockResolvedValue({
+        id: cardForIdem,
+        deck: { userId },
+      });
+      mockPrismaService.flashcardReviewSchedule.findUnique
+        .mockResolvedValueOnce(null) // no existing schedule
+        .mockResolvedValueOnce(cachedSchedule); // cached lookup
+      mockPrismaService.flashcardReviewSchedule.upsert.mockResolvedValueOnce(
+        cachedSchedule,
+      );
+
+      const idemKey2 = `idem-key-unique-${Date.now()}`;
+
+      // First call
+      await service.submitReview(userId, cardForIdem, {
+        quality: 4,
+        idempotencyKey: idemKey2,
+      });
+      const upsertCountAfterFirst =
+        mockPrismaService.flashcardReviewSchedule.upsert.mock.calls.length;
+
+      // Second call with same key — upsert should NOT be called again
+      mockPrismaService.flashcardReviewSchedule.findUnique.mockResolvedValueOnce(
+        cachedSchedule,
+      );
+      await service.submitReview(userId, cardForIdem, {
+        quality: 4,
+        idempotencyKey: idemKey2,
+      });
+
+      expect(
+        mockPrismaService.flashcardReviewSchedule.upsert.mock.calls.length,
+      ).toBe(upsertCountAfterFirst); // no additional upsert
+
+      // Suppress unused variable warning
+      void first;
+    });
+
+    it('user does not own flashcard → throws ForbiddenException', async () => {
+      mockPrismaService.flashcard.findUnique.mockResolvedValue({
+        id: flashcardId,
+        deck: { userId: 'other-user' },
+      });
+
+      await expect(
+        service.submitReview(userId, flashcardId, { quality: 3 }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('flashcard not found → throws NotFoundException', async () => {
+      mockPrismaService.flashcard.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.submitReview(userId, flashcardId, { quality: 3 }),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
+
+  // ==================== getDueReviews ====================
 
   describe('getDueReviews', () => {
     it('should return combined scheduled and new cards', async () => {
@@ -182,6 +297,22 @@ describe('FlashcardsService', () => {
       expect(result[0].id).toBe('sched-1');
       expect(result[1].id).toBe('new-card-2');
       expect(result[1].mastery).toBe('NEW');
+    });
+
+    it('should pass cursor to findMany when provided', async () => {
+      mockPrismaService.flashcardReviewSchedule.findMany.mockResolvedValue([]);
+      mockPrismaService.flashcard.findMany.mockResolvedValue([]);
+
+      await service.getDueReviews('user-1', undefined, 20, 'cursor-abc');
+
+      expect(
+        mockPrismaService.flashcardReviewSchedule.findMany,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 1,
+          cursor: { id: 'cursor-abc' },
+        }),
+      );
     });
   });
 });

--- a/backend/src/flashcards/flashcards.service.ts
+++ b/backend/src/flashcards/flashcards.service.ts
@@ -4,14 +4,64 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import { CreateDeckDto } from './dto/create-deck.dto';
 import { UpdateDeckDto } from './dto/update-deck.dto';
 import { CreateFlashcardDto } from './dto/create-flashcard.dto';
 import { UpdateFlashcardDto } from './dto/update-flashcard.dto';
+import { SubmitReviewDto } from './dto/submit-review.dto';
+import { calculateSM2 } from './sm2';
+
+// TODO: Replace with Redis SETNX once ioredis / @nestjs/cache-manager is wired in.
+// Key: `flashcard:review:idempotency:<userId>:<flashcardId>:<idempotencyKey>`
+// TTL: 300 seconds (5 minutes)
+const idempotencyStore = new Map<
+  string,
+  { expiresAt: number; scheduleId: string }
+>();
+
+function idempotencyKey(
+  userId: string,
+  flashcardId: string,
+  key: string,
+): string {
+  return `flashcard:review:idempotency:${userId}:${flashcardId}:${key}`;
+}
+
+function checkAndSetIdempotency(
+  userId: string,
+  flashcardId: string,
+  key: string,
+  scheduleId: string,
+): boolean {
+  const storeKey = idempotencyKey(userId, flashcardId, key);
+  const now = Date.now();
+  const existing = idempotencyStore.get(storeKey);
+  if (existing && existing.expiresAt > now) {
+    return false; // already processed
+  }
+  idempotencyStore.set(storeKey, { expiresAt: now + 300_000, scheduleId });
+  return true; // newly processed
+}
+
+function getIdempotencyEntry(
+  userId: string,
+  flashcardId: string,
+  key: string,
+): { scheduleId: string } | undefined {
+  const storeKey = idempotencyKey(userId, flashcardId, key);
+  const now = Date.now();
+  const existing = idempotencyStore.get(storeKey);
+  if (existing && existing.expiresAt > now) return existing;
+  return undefined;
+}
 
 @Injectable()
 export class FlashcardsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
 
   // ==================== DECKS ====================
 
@@ -123,42 +173,29 @@ export class FlashcardsService {
 
   // ==================== SRS ====================
 
-  private calculateSM2(
-    quality: number,
-    prevInterval: number,
-    prevReps: number,
-    prevEF: number,
+  async submitReview(
+    userId: string,
+    flashcardId: string,
+    dto: SubmitReviewDto,
   ) {
-    let interval: number;
-    let repetitions: number;
-    let easeFactor: number;
+    await this.getFlashcard(userId, flashcardId); // validates ownership / 403
 
-    if (quality >= 3) {
-      if (prevReps === 0) {
-        interval = 1;
-      } else if (prevReps === 1) {
-        interval = 6;
-      } else {
-        interval = Math.round(prevInterval * prevEF);
+    // Idempotency check
+    if (dto.idempotencyKey) {
+      const existing = getIdempotencyEntry(
+        userId,
+        flashcardId,
+        dto.idempotencyKey,
+      );
+      if (existing) {
+        // Return cached schedule from DB
+        const cached = await this.prisma.flashcardReviewSchedule.findUnique({
+          where: { id: existing.scheduleId },
+        });
+        if (cached) return cached;
+        // If somehow deleted, fall through to re-process
       }
-      repetitions = prevReps + 1;
-      easeFactor =
-        prevEF + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02));
-    } else {
-      repetitions = 0;
-      interval = 1;
-      easeFactor = prevEF;
     }
-
-    if (easeFactor < 1.3) {
-      easeFactor = 1.3;
-    }
-
-    return { interval, repetitions, easeFactor };
-  }
-
-  async submitReview(userId: string, flashcardId: string, quality: number) {
-    await this.getFlashcard(userId, flashcardId); // validates ownership
 
     const schedule = await this.prisma.flashcardReviewSchedule.findUnique({
       where: { userId_flashcardId: { userId, flashcardId } },
@@ -167,50 +204,81 @@ export class FlashcardsService {
     const prevInterval = schedule?.interval ?? 0;
     const prevReps = schedule?.repetitions ?? 0;
     const prevEF = Number(schedule?.easeFactor ?? 2.5);
+    const prevLapses = 0; // schema does not yet have lapses column; defaulting to 0
 
-    const { interval, repetitions, easeFactor } = this.calculateSM2(
-      quality,
+    const sm2 = calculateSM2({
+      quality: dto.quality,
       prevInterval,
-      prevReps,
-      prevEF,
-    );
+      prevRepetitions: prevReps,
+      prevEaseFactor: prevEF,
+      prevLapses,
+    });
 
     const nextReviewDate = new Date();
-    nextReviewDate.setDate(nextReviewDate.getDate() + interval);
+    nextReviewDate.setDate(nextReviewDate.getDate() + sm2.intervalDays);
 
-    // Determine mastery level
-    let mastery: 'NEW' | 'LEARNING' | 'REVIEW' | 'MASTERED' = 'NEW';
-    if (repetitions === 0) mastery = 'NEW';
-    else if (repetitions < 3) mastery = 'LEARNING';
-    else if (repetitions < 6) mastery = 'REVIEW';
-    else mastery = 'MASTERED';
-
-    return this.prisma.flashcardReviewSchedule.upsert({
+    const updated = await this.prisma.flashcardReviewSchedule.upsert({
       where: { userId_flashcardId: { userId, flashcardId } },
       update: {
-        interval,
-        repetitions,
-        easeFactor,
+        interval: sm2.intervalDays,
+        repetitions: sm2.repetitions,
+        easeFactor: sm2.easeFactor,
         nextReviewDate,
-        mastery,
+        mastery: sm2.mastery,
       },
       create: {
         userId,
         flashcardId,
-        interval,
-        repetitions,
-        easeFactor,
+        interval: sm2.intervalDays,
+        repetitions: sm2.repetitions,
+        easeFactor: sm2.easeFactor,
         nextReviewDate,
-        mastery,
+        mastery: sm2.mastery,
       },
     });
+
+    // Store idempotency entry after successful write
+    if (dto.idempotencyKey) {
+      checkAndSetIdempotency(
+        userId,
+        flashcardId,
+        dto.idempotencyKey,
+        updated.id,
+      );
+    }
+
+    // Audit log — fire-and-forget; failures should not surface to the caller
+    this.audit
+      .log({
+        userId,
+        action: 'FLASHCARD_REVIEW_SUBMITTED',
+        targetType: 'FlashcardReviewSchedule',
+        targetId: updated.id,
+        metadata: {
+          flashcardId,
+          quality: dto.quality,
+          intervalDays: sm2.intervalDays,
+          repetitions: sm2.repetitions,
+          mastery: sm2.mastery,
+        },
+      })
+      .catch(() => {
+        // intentionally swallowed — audit failure must not break review flow
+      });
+
+    return updated;
   }
 
-  async getDueReviews(userId: string, deckId?: string) {
+  async getDueReviews(
+    userId: string,
+    deckId?: string,
+    limit = 20,
+    cursor?: string,
+  ) {
     const today = new Date();
 
-    // 1. Get scheduled due cards
-    const scheduledWhere: any = {
+    // 1. Get scheduled due cards (cursor-based pagination)
+    const scheduledWhere: Record<string, unknown> = {
       userId,
       nextReviewDate: { lte: today },
     };
@@ -227,13 +295,14 @@ export class FlashcardsService {
             include: { deck: true },
           },
         },
+        take: limit,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
         orderBy: { nextReviewDate: 'asc' },
-        take: 20, // max 20 due cards per session to avoid overwhelming
       },
     );
 
     // 2. Get NEW cards (cards that have NO schedule at all)
-    const newCardsWhere: any = {
+    const newCardsWhere: Record<string, unknown> = {
       deck: { userId },
       schedule: null,
     };
@@ -245,7 +314,7 @@ export class FlashcardsService {
     const newCards = await this.prisma.flashcard.findMany({
       where: newCardsWhere,
       include: { deck: true },
-      take: Math.max(0, 20 - scheduledReviews.length), // fill the rest of the session with new cards
+      take: Math.max(0, limit - scheduledReviews.length),
     });
 
     // 3. Format new cards to match the expected return type

--- a/backend/src/flashcards/sm2.ts
+++ b/backend/src/flashcards/sm2.ts
@@ -1,0 +1,70 @@
+export type MasteryLevel = 'NEW' | 'LEARNING' | 'REVIEW' | 'MASTERED';
+
+export interface SM2Input {
+  quality: number; // 0-5
+  prevInterval: number;
+  prevRepetitions: number;
+  prevEaseFactor: number;
+  prevLapses: number;
+}
+
+export interface SM2Output {
+  intervalDays: number;
+  repetitions: number;
+  easeFactor: number;
+  lapses: number;
+  mastery: MasteryLevel;
+}
+
+/**
+ * Pure SM-2 algorithm implementation.
+ * quality: 0-5 (0=blackout, 3=correct with difficulty, 5=perfect)
+ */
+export function calculateSM2(input: SM2Input): SM2Output {
+  const { quality, prevInterval, prevRepetitions, prevEaseFactor, prevLapses } =
+    input;
+
+  let intervalDays: number;
+  let repetitions: number;
+  let easeFactor: number;
+  let lapses: number;
+
+  if (quality >= 3) {
+    // Correct response
+    if (prevRepetitions === 0) {
+      intervalDays = 1;
+    } else if (prevRepetitions === 1) {
+      intervalDays = 6;
+    } else {
+      intervalDays = Math.round(prevInterval * prevEaseFactor);
+    }
+    repetitions = prevRepetitions + 1;
+    easeFactor =
+      prevEaseFactor + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02));
+    lapses = prevLapses;
+  } else {
+    // Failed response — lapse
+    repetitions = 0;
+    intervalDays = 1;
+    easeFactor = prevEaseFactor;
+    lapses = prevLapses + 1;
+  }
+
+  if (easeFactor < 1.3) {
+    easeFactor = 1.3;
+  }
+
+  const mastery = computeMastery(repetitions, intervalDays);
+
+  return { intervalDays, repetitions, easeFactor, lapses, mastery };
+}
+
+export function computeMastery(
+  repetitions: number,
+  intervalDays: number,
+): MasteryLevel {
+  if (repetitions === 0) return 'NEW';
+  if (repetitions < 3) return 'LEARNING';
+  if (intervalDays < 21) return 'REVIEW';
+  return 'MASTERED';
+}


### PR DESCRIPTION
## Summary

- Add `backend/src/flashcards/dto/submit-review.dto.ts` — `SubmitReviewDto` with `@IsInt() @Min(0) @Max(5) quality` and optional `idempotencyKey`
- Update `FlashcardsController` — use `@Body() dto: SubmitReviewDto` with `ValidationPipe({ transform: true, whitelist: true })`
- Update `FlashcardsService`:
  - Wire `calculateSM2()` from `sm2.ts` into `submitReview()`
  - In-memory idempotency store (TTL 5 min, key: `flashcard:review:idempotency:<userId>:<fcId>:<key>`); TODO comment for Redis SETNX upgrade in Sprint 2
  - `getDueReviews()` supports `limit` + `cursor` pagination
- Add `backend/src/flashcards/flashcards.service.spec.ts` — 7 unit tests:
  - quality=4/5 happy path, quality=1 (lapse), idempotency dedup, 403 wrong owner, 404 not found, cursor pagination

**Depends on:** US-103 (SM-2 fields on `ReviewSchedule`) must be migrated first.

## Test plan

- [ ] `POST /flashcards/:id/review` with `quality: 6` → 400 Bad Request
- [ ] `POST /flashcards/:id/review` with `quality: 3` → 200, `ReviewSchedule` updated
- [ ] Duplicate request with same `idempotencyKey` → returns cached response (no DB write)
- [ ] Request for another user's flashcard → 403
- [ ] `GET /flashcards/due` with `?limit=10&cursor=<id>` → paginated response
- [ ] All 7 service unit tests pass

## DoD checklist

- [x] Input validation (0-5 guard) using class-validator
- [x] Idempotency prevents double-submission
- [x] SM-2 algorithm wired from pure function (US-103)
- [x] Pagination on getDueReviews (cursor-based)
- [x] 7 unit tests covering happy path, edge cases, and auth failures