### PR TITLE
docs: add team planning docs for Q2–Q4 2026 (roadmap, epics, sprint 1-3, RFCs)

### DIFF
--- a/docs/team-planning/00-master-roadmap.md
+++ b/docs/team-planning/00-master-roadmap.md
@@ -1,0 +1,228 @@
+# 00 — Master Roadmap: CertGym (Brain Gym) Q2–Q4 2026
+
+> **Tổng hợp** từ 4 góc nhìn của Scrum team: Product Owner, Scrum Master, Tech Lead, UX/QA Lead.
+> Mỗi vai trò có deliverable riêng (file 01–04). File này là **sự đồng thuận** + **traceability** giữa các quyết định.
+
+---
+
+## 📚 Bộ tài liệu
+
+| File                                       | Vai trò       | Nội dung chính                                                                                                                            |
+| ------------------------------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [01-product-owner.md](01-product-owner.md) | Product Owner | 4 personas, 8 epics, 22 user stories (US-001…US-022), release plan v1.1→v2.0, 5 OKRs Q3                                                   |
+| [02-scrum-master.md](02-scrum-master.md)   | Scrum Master  | Team 6 dev / 5.5 FTE, 40 SP/sprint, DoR/DoD, 10 risks, sprint 1–3 plan, 10 process improvements                                           |
+| [03-tech-lead.md](03-tech-lead.md)         | Tech Lead     | Bounded contexts, 12 RFCs (RFC-001…RFC-012), 6 schema models mới, infra roadmap, top 10 tech debt, 7 spikes                               |
+| [04-ux-qa-lead.md](04-ux-qa-lead.md)       | UX/QA Lead    | Editorial + Dark luxury direction, 10 components mới, test pyramid, 10 a11y gap WCAG 2.2 AA, perf budget, 250 visual regression baselines |
+
+---
+
+## 1. Executive Summary
+
+### Vấn đề
+
+CertGym đã có **MVP rộng** (40+ Prisma models, 23 page FE, multi-tenant org, AI generator, flashcard SRS) nhưng mới phủ **~50% vision** từ `docs/vision.md`. Khoảng cách lớn nhất: **không có moat khác biệt** so với Whizlabs/ExamTopics — chưa biến từ "question bank" thành "training system".
+
+### Hướng đi (3 quý)
+
+1. **Q2** — Vững nền: stabilize CI, kích hoạt **Question SRS** (schema có sẵn nhưng chưa wire), event sourcing.
+2. **Q3** — Build moat: **Pass Predictor** (Readiness Score) + Behavioral Insights + Scenario Simulation.
+3. **Q4** — Retention engine: **Training Squads** + Cross-Cert Knowledge Graph + AI Coach 1-1.
+
+### Tin chính
+
+- 🔴 **Blocker tech debt** phải giải quyết trong Sprint 1–2 trước khi Q3 feature khởi động (event store, job queue, multi-tenant RLS, TS strict pilot).
+- 🟢 Schema đã có **`ReviewSchedule`** cho Question SRS nhưng chưa wire — quick win 1 sprint (RFC-002 + US-003/US-004).
+- 🟡 **Pass Predictor** bắt đầu bằng **heuristic v0** (RFC-003), không phải ML — đủ giá trị cho launch Q3.
+- 🟡 **LLM cost** sẽ là biến số tài chính lớn nhất khi scale — cần `LlmUsageEvent` + per-feature dashboard từ Sprint 2.
+
+---
+
+## 2. Roadmap Tổng hợp (Quarter View)
+
+```
+Q2 2026                  Q3 2026                  Q4 2026
+────────────────────     ────────────────────     ────────────────────
+Sprint 1–4               Sprint 5–8               Sprint 9–12
+v1.1 → v1.2              v1.3 → v1.4              v2.0
+──────────────────       ──────────────────       ──────────────────
+Foundation +             Build the Moat           Retention Engine
+Question SRS             ──────────────────       ──────────────────
+──────────────────       Pass Predictor v1        Squads
+Stabilize CI             Behavioral Insights      Cross-Cert Graph
+Event store              Scenario Simulation      AI Coach 1-1
+SRS activation           AI Coach Beta            DDS
+Time Pressure mode       Reviewer Queue           Peer Review
+                         Reviewer Queue           Exam Day Protocol
+```
+
+### Mapping Epic → US → RFC → UX/QA artifact
+
+| Epic                       | User Stories                   | RFCs cần                  | UX artifact                                           | Test focus                                             |
+| -------------------------- | ------------------------------ | ------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| **E1 Pass Predictor**      | US-001, US-002, US-022         | RFC-001, RFC-003          | ReadinessGauge + DomainBentoCard, Editorial dashboard | Predictor accuracy (corr ≥ 0.75), 250 visual baselines |
+| **E2 Question SRS**        | US-003, US-004, US-007, US-016 | RFC-001, RFC-002          | SrsRatingBar, ForgettingCurve, Daily Review flow      | SM-2 unit test, 25 SRS card/user/day load              |
+| **E3 Adaptive Training**   | US-006, US-018                 | RFC-002, RFC-007          | Adaptive suggest carousel                             | Edge-of-competence A/B test                            |
+| **E4 Scenario Simulation** | US-012, US-013                 | (content team owned)      | Scenario reader (multi-paragraph + diagram)           | A11y reader mode, perf for diagrams                    |
+| **E5 Training Squads**     | US-009, US-010, US-011, US-020 | RFC-005, RFC-011          | SquadRankRow, ActivityFeedItem                        | Realtime SSE leaderboard load test                     |
+| **E6 AI Coach + Burnout**  | US-014, US-015, US-019, US-021 | RFC-008, RFC-010, RFC-012 | CoachChat, MicroBreakOverlay                          | Prompt injection threat model (SP-7)                   |
+| **E7 Cross-Cert Graph**    | US-017                         | RFC-007                   | Graph viz (D3 / Cytoscape)                            | Vector dedup quality                                   |
+| **E8 Time Pressure Mode**  | US-005, US-008                 | (no new RFC)              | Timer + warning state                                 | Reduced-motion + a11y aria-live                        |
+
+---
+
+## 3. Sprint 1–3 — Đồng thuận chi tiết
+
+### Sprint 1 — "Stabilize the Gym" (capacity 40 SP) · v1.1.0
+
+| Lane              | Stories / Tasks (SM)                                                     | Liên quan US (PO)         | RFC / Spike (Tech) | UX/QA                    |
+| ----------------- | ------------------------------------------------------------------------ | ------------------------- | ------------------ | ------------------------ |
+| **Tech Debt**     | US-101 fix E2E isolation, US-102 strict TS pilot (`services/` + `auth/`) | —                         | SP-6, RFC-009      | E2E quarantine flow      |
+| **Foundation**    | US-103 SRS schema + migration, US-104 Flashcard review API               | US-003, US-004 (chuẩn bị) | RFC-002 schema     | SM-2 unit test           |
+| **Security**      | US-105 CSP nonce + DOMPurify                                             | —                         | —                  | CSP gate ở Lighthouse CI |
+| **Spike**         | US-106 BullMQ feasibility                                                | —                         | RFC-004, SP-2      | —                        |
+| **Foundation FE** | US-108 Lighthouse CI baseline                                            | —                         | —                  | Perf budget gate         |
+| **Bug pool**      | US-107 (4 SP)                                                            | —                         | —                  | —                        |
+
+**Demo:** CI pipeline xanh 5 lần liên tiếp, flashcard review API qua Postman, Lighthouse baseline.
+**Goal Hit Criteria:** flaky e2e xuống 0, schema migration xanh staging, BullMQ POC chạy được 1 job email.
+
+### Sprint 2 — "First Learner Loop" (capacity 42 SP) · v1.1.1
+
+| Lane           | Stories / Tasks                                                             | Liên quan US   | RFC / Spike     | UX/QA                                        |
+| -------------- | --------------------------------------------------------------------------- | -------------- | --------------- | -------------------------------------------- |
+| **Feature FE** | US-201 Flashcard review UI, US-202 Due-today widget                         | US-003, US-004 | —               | SrsRatingBar component, Daily Review journey |
+| **Feature BE** | US-203 SM-2 polish + unit test                                              | US-003         | RFC-002 wrap up | SM-2 algorithm spec                          |
+| **Platform**   | US-206 BullMQ production (AI gen worker), US-204 index tuning + k6 10k user | —              | RFC-004         | Load test target p95 < 300ms                 |
+| **QA**         | US-205 Visual regression Playwright (5 page × 3 breakpoint)                 | —              | —               | 250 baseline mục tiêu                        |
+| **Tech debt**  | US-207 `api.ts` interceptor unit test                                       | —              | —               | —                                            |
+
+**Demo:** học viên thật làm 20 flashcard, due queue cập nhật, Playwright screenshots diff = 0, k6 report 10k user.
+**Goal Hit Criteria:** Question SRS GA cho cohort beta (≥50 user), DAU/MAU baseline đo được.
+
+### Sprint 3 — "Insight Kickoff" (capacity 44 SP) · v1.2.0-alpha
+
+| Lane                   | Stories / Tasks                                       | Liên quan US      | RFC / Spike    | UX/QA                                        |
+| ---------------------- | ----------------------------------------------------- | ----------------- | -------------- | -------------------------------------------- |
+| **Foundation**         | US-301 AttemptEvent schema, US-302 ingestion endpoint | US-001 (chuẩn bị) | **RFC-001** GA | Privacy review, telemetry contract           |
+| **Feature FE**         | US-303 Mastery dashboard v1, US-304 streak edge-case  | US-002 (chuẩn bị) | —              | DomainBentoCard, editorial direction kickoff |
+| **Knowledge transfer** | US-305 exam engine doc + pair tour                    | —                 | —              | Bus factor mitigation (R5)                   |
+| **A11y**               | US-306 fix top-10 a11y issue                          | —                 | —              | UX/QA roadmap §7                             |
+| **Spike**              | US-307 Pass Predictor feature definition              | US-001 spec       | **SP-4**       | Heuristic notebook                           |
+| **Bug + retro**        | US-308, US-309                                        | —                 | —              | —                                            |
+
+**Demo:** event flow end-to-end (FE action → BE event → dashboard query), mastery dashboard với data thật, Pass Predictor v0 spec presentation.
+**Goal Hit Criteria:** ≥10k events/ngày ingest stable, RFC-003 approved, DAU/MAU ≥ 28% (target Q3 35%).
+
+---
+
+## 4. Key Decisions cần PO chốt (deadline 2026-05-05)
+
+| #   | Decision                                                                               | Recommendation                                                          | Tradeoff                                                                                   |
+| --- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| D1  | **Tier hóa Pass Predictor**: Free hay Premium-only?                                    | **Premium-only** từ v1.2; free user thấy "blurred score + unlock CTA"   | Premium tăng conversion nhưng giảm viral. Recommend premium vì là moat.                    |
+| D2  | **Realtime infra** cho Squad: Pusher (managed $) hay self-host SSE?                    | **SSE-first** (RFC-005), migrate khi >1k concurrent                     | SSE rẻ + work với Nginx; Pusher nhanh hơn để launch nhưng lock-in                          |
+| D3  | **AI Coach LLM provider**: Anthropic Haiku 4.5 hay OpenAI mini?                        | **Haiku 4.5** — theo `common/performance.md`, rẻ + đủ tốt cho coach 1-1 | Haiku rẻ hơn 60% nhưng cần benchmark CSAT                                                  |
+| D4  | **Sprint 1 có hoãn feature không?**                                                    | **CÓ** — full sprint cho stabilization                                  | 2 tuần delay roadmap nhưng tránh ăn nợ trong Q3                                            |
+| D5  | **Squad là sub-type của Org hay model riêng?**                                         | **Sub-type Organization** (RFC-011)                                     | Tận dụng infra có sẵn, tránh duplicate code; constraint: Squad không có Catalog/Assessment |
+| D6  | **Open beta cohort cho Pass Predictor**: 200 user ở Sprint 4 hay đợi 1k user Sprint 6? | **200 user Sprint 4** + opt-in feedback survey                          | Validate sớm, accept noise                                                                 |
+
+---
+
+## 5. Risk Heatmap (tổng hợp)
+
+| Risk                                                  | Source               | P×I | Owner             | Mitigation Sprint                     |
+| ----------------------------------------------------- | -------------------- | --- | ----------------- | ------------------------------------- |
+| Event store thiếu → block Predictor + Coach + Burnout | Tech Lead R1         | H×H | Tech Lead         | RFC-001 trong Sprint 1, GA Sprint 3   |
+| E2E flaky chặn CI                                     | SM R2                | H×H | QA                | Sprint 1 — isolation + quarantine     |
+| Multi-tenant data leak                                | SM R4 + Tech R3      | L×H | Senior BE         | RFC-006 RLS Sprint 4–5                |
+| LLM cost runaway                                      | Tech R6 cost         | M×H | Platform          | RFC-012 Sprint 2                      |
+| Pass Predictor data quá ít → overfit                  | SM R7                | M×H | PO + BE           | Lùi launch nếu < 1k attempt           |
+| TS loose introduce runtime bug khó trace              | SM R1 + Tech debt #5 | H×H | Senior FE         | RFC-009 + ESLint no-new-any rule      |
+| Bus factor exam engine = 1                            | SM R5                | M×H | SM                | US-305 doc + pair tour Sprint 3       |
+| Burnout content team (Scenarios)                      | Implicit từ E4       | M×H | PO                | Outsource scenario authoring Sprint 5 |
+| LLM prompt injection (Coach + DDS)                    | Tech §8 + SP-7       | M×H | Security Champion | Threat model trước launch v1.4        |
+| Visual regression chưa có → release vỡ UI             | SM R9 + UX/QA §9     | M×M | QA                | Sprint 2 — 5 page × 3 breakpoint      |
+
+---
+
+## 6. North-Star Metrics & Guardrails
+
+### OKR Q3 2026 (PO §5)
+
+| O                                 | KR                                   | Baseline | Target        |
+| --------------------------------- | ------------------------------------ | -------- | ------------- |
+| O1 — "Training system" perception | 70% premium check Readiness ≥3×/tuần | 0%       | 70%           |
+| O2 — Long-term retention via SRS  | DAU/MAU                              | ~22%     | ≥35%          |
+| O3 — Squad as retention engine    | Squad 30d retention vs solo          | 1.0x     | ≥1.5x         |
+| O4 — Predictor validity           | Corr(Score≥80, actual pass)          | n/a      | r≥0.75, n≥200 |
+| O5 — Conversion uplift            | Free→Premium 30d                     | 4%       | ≥7%           |
+
+### Guardrails (không được vi phạm)
+
+| Guardrail                          | Threshold                | Owner              |
+| ---------------------------------- | ------------------------ | ------------------ |
+| API p95 latency                    | <400ms (excl. LLM)       | Tech Lead          |
+| Question bank accuracy post-review | ≥98%                     | PO + Reviewer Lead |
+| LLM cost / premium user / tháng    | <$1.20                   | Platform           |
+| Crash-free session                 | >99.5%                   | QA                 |
+| Test coverage                      | ≥80%, không giảm >1%     | QA                 |
+| Sprint goal hit rate               | ≥80%                     | SM                 |
+| Lead time story start→done         | ≤6 ngày                  | SM                 |
+| Escaped defects                    | ≤2/sprint                | QA                 |
+| Lighthouse perf                    | ≥85 (app), ≥95 (landing) | UX/QA              |
+| Lighthouse a11y                    | ≥95 mọi page             | UX/QA              |
+
+---
+
+## 7. Action Items — 14 Ngày Tới
+
+### PO (deadline 2026-05-05)
+
+- [ ] Chốt D1–D6 ở §4
+- [ ] Xác nhận velocity assumption 40 SP/sprint
+- [ ] Approve release plan v1.1→v2.0
+- [ ] Identify 200-user beta cohort cho Pass Predictor
+
+### Scrum Master (deadline 2026-05-02)
+
+- [ ] Setup Linear project + sprint board
+- [ ] Publish DoR/DoD vào `/docs/team-planning/`
+- [ ] Schedule ceremonies (planning Wed, review/retro Tue cuối sprint)
+- [ ] Setup `#certgym-daily` + 4 channel khác
+
+### Tech Lead (deadline 2026-05-15)
+
+- [ ] Viết RFC-001 (AttemptEvent) full draft
+- [ ] Viết RFC-004 (BullMQ) draft
+- [ ] Viết RFC-009 (TS strict migration) draft
+- [ ] Run SP-1, SP-2, SP-6 spike (5 ngày timebox)
+
+### UX/QA Lead (deadline 2026-05-10)
+
+- [ ] Confirm Editorial + Dark luxury direction với PO + designer
+- [ ] Tokens spec (oklch palette, typography, spacing) commit vào `src/styles/tokens.css`
+- [ ] Setup Playwright visual regression baseline cho 5 page critical
+- [ ] A11y audit baseline (axe-core CI gate)
+
+### Cả team (Sprint 1)
+
+- [ ] Working agreement ký commit (PR ≤400 LOC, no `--no-verify`, blocker >4h gọi SM)
+- [ ] On-call rotation tuần đầu (1 BE + 1 FE)
+
+---
+
+## 8. Liên kết tài liệu nguồn
+
+- **Vision**: [docs/vision.md](../vision.md)
+- **Architecture hiện tại**: [docs/01-architecture.md](../01-architecture.md)
+- **Data model**: [docs/02-data_model.md](../02-data_model.md)
+- **API design**: [docs/03-api_design.md](../03-api_design.md)
+- **Frontend**: [docs/04-frontend.md](../04-frontend.md)
+- **Security**: [docs/06-security.md](../06-security.md)
+- **Schema**: [backend/prisma/schema.prisma](../../backend/prisma/schema.prisma)
+- **CLAUDE.md** (project rules): [CLAUDE.md](../../CLAUDE.md)
+
+---
+
+> **Tài liệu sống** — review cuối mỗi quý, cập nhật theo sprint review + retro action items.
+> **Ownership**: SM duy trì cấu trúc, PO duy trì backlog, Tech Lead duy trì RFC list, UX/QA duy trì design system + test gate.

--- a/docs/team-planning/01-product-owner.md
+++ b/docs/team-planning/01-product-owner.md
@@ -1,0 +1,194 @@
+# 01 — Product Owner Deliverable: CertGym (Brain Gym)
+
+> Vai trò: Product Owner — Scrum Team CertGym
+> Phạm vi: 3 quý tới (Q2 — Q4 2026), từ v1.1 đến v2.0
+> Tham chiếu: `docs/vision.md`, `CLAUDE.md`, `backend/prisma/schema.prisma`
+
+---
+
+## 1. Personas
+
+### P1 — Linh, "The First-Try Learner" (28, DevOps Engineer)
+
+- Mục tiêu: pass AWS SAA-C03 trong 6 tuần, không trượt lần nào (đã trượt 1 lần).
+- Pain: học lan man, không biết "đủ chưa", lo lắng dồn dập 1 tuần trước thi.
+- Hành vi: học 30–60 phút/ngày trên mobile, cuối tuần luyện mock 2 tiếng trên laptop.
+- Giá trị mong đợi: biết chính xác "khi nào sẵn sàng" và "phải học gì kế tiếp".
+
+### P2 — Khoa, "The Repeat Certifier" (35, Cloud Architect)
+
+- Mục tiêu: đã có AWS SAP, đang chinh phục Azure + GCP để T-shaped.
+- Pain: kiến thức chồng chéo nhưng không biết tận dụng, học lại từ đầu mỗi vendor.
+- Hành vi: ưu tiên scenario phức tạp, ghét MCQ ngơ ngẩn, thích "trap question".
+- Giá trị mong đợi: knowledge graph cross-cert, scenario simulation, leaderboard chuyên gia.
+
+### P3 — Mai, "The Squad Lead" (32, Tech Lead Mentor)
+
+- Mục tiêu: dẫn dắt 6 junior trong team cùng pass CKAD trong Q3.
+- Pain: thiếu công cụ track tiến độ nhóm, mất thời gian tổng hợp tay từng người.
+- Hành vi: setup squad 1 lần/tuần, review báo cáo, tag câu khó cho cả nhóm.
+- Giá trị mong đợi: squad dashboard, peer-review queue, tag/assign câu hỏi cho member.
+
+### P4 — Hùng, "The Contributor Expert" (40, Principal Engineer)
+
+- Mục tiêu: build reputation, tăng badge "Expert Reviewer", đóng góp 200+ câu chất lượng.
+- Pain: tool review nghèo nàn, không thấy impact đóng góp của mình.
+- Hành vi: review 10–20 câu/tuần, viết explanation dài, debate trong comment.
+- Giá trị mong đợi: reviewer dashboard, audit trail, contribution score, Hall of Fame.
+
+---
+
+## 2. Epic List
+
+| Epic ID | Tên Epic                                       | Business Value                                                                                                           | Success Metric (Q3 target)                                                    |
+| ------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| **E1**  | Exam Readiness Score (Pass Predictor)          | Moat lớn nhất — mỗi user trả tiền để biết "tôi đã sẵn sàng chưa". Chuyển CertGym từ "question bank" → "training system". | ≥70% premium user check Readiness ≥3 lần/tuần; correlation actual-pass ≥ 0.75 |
+| **E2**  | Question-Level SRS (Spaced Repetition cho MCQ) | Tăng retention dài hạn, kéo daily active. Khác biệt với Anki vì tích hợp domain + difficulty.                            | DAU/MAU ≥ 35%; trung bình 25 câu SRS/user/ngày                                |
+| **E3**  | Adaptive Weakness Training v2                  | Giảm "waste study", giữ user ở edge-of-competence. Tăng study efficiency.                                                | Time-to-readiness giảm 25% so với baseline; NPS ≥ 50                          |
+| **E4**  | Scenario Simulation Engine                     | Differentiator vs Whizlabs/ExamTopics. Kéo giá premium tier.                                                             | ≥40% premium user complete ≥1 scenario/tuần; conversion free→premium +15%     |
+| **E5**  | Training Squads (Social Layer)                 | Cohort retention — giảm churn 30 ngày, tăng word-of-mouth B2B (team licenses).                                           | ≥20% active user join squad; squad-mode retention 30d > solo 1.5x             |
+| **E6**  | AI Coach 1-1 & Burnout Detection               | Premium upgrade hook. Behavioral insights là moat về data.                                                               | ≥60% premium user nhận ≥1 coach insight/tuần; CSAT ≥ 4.4/5                    |
+| **E7**  | Cross-Cert Knowledge Graph                     | Long-term retention — user ở lại sau khi pass cert đầu tiên.                                                             | ≥30% user pass cert 1 → start cert 2 trong 60 ngày                            |
+| **E8**  | Time Pressure Training Mode                    | Hoàn thiện "Stamina pillar". Quick win — tận dụng exam engine sẵn có.                                                    | ≥25% user thử mode trong 14 ngày đầu; speed-mode pass rate cải thiện 10%      |
+
+---
+
+## 3. User Stories — Prioritized Backlog
+
+### NOW — Q2 2026 (v1.1 → v1.2, Sprint 1–4)
+
+| ID     | Story                                                                                                     | Priority | SP  | Epic |
+| ------ | --------------------------------------------------------------------------------------------------------- | -------- | --- | ---- |
+| US-001 | Là Linh, tôi muốn xem **Readiness Score %** trên dashboard, để biết khoảng cách tới ngày thi.             | Must     | 8   | E1   |
+| US-002 | Là Linh, tôi muốn click vào Score để xem **breakdown theo domain**, để biết domain nào kéo điểm xuống.    | Must     | 5   | E1   |
+| US-003 | Là Linh, tôi muốn câu MCQ đã sai được **lên lịch ôn lại theo SM-2** (1/3/7/21 ngày), để không quên.       | Must     | 13  | E2   |
+| US-004 | Là Linh, tôi muốn dashboard có widget **"Due for review today: 24 questions"**, để bắt đầu nhanh.         | Must     | 3   | E2   |
+| US-005 | Là Khoa, tôi muốn vào **Time Pressure Mode** (65 câu / 90 phút thay vì 130), để rèn tốc độ.               | Should   | 5   | E8   |
+| US-006 | Là Linh, tôi muốn hệ thống **gợi ý topic kế tiếp** dựa trên proficiency thấp nhất, để không phải tự chọn. | Must     | 8   | E3   |
+| US-007 | Là Hùng, tôi muốn **flag câu hỏi nghi vấn** với lý do, để reviewer xử lý.                                 | Should   | 3   | E2   |
+| US-008 | Là Linh, tôi muốn nhận **email nhắc** "bạn có 24 câu cần ôn", để duy trì streak.                          | Could    | 2   | E2   |
+
+**AC mẫu — US-001 (Readiness Score):**
+
+- _Given_ user đã làm ≥50 câu trong 1 cert, _When_ mở dashboard, _Then_ hiển thị score 0–100 + label (Not Ready / Borderline / Ready / Strong).
+- _Given_ score được tính, _When_ user hover info icon, _Then_ show formula breakdown (accuracy × domain coverage × recency × difficulty).
+- _Given_ user làm thêm câu mới, _When_ hoàn thành session, _Then_ score recompute trong < 2s.
+- _Given_ user có < 50 câu, _When_ mở dashboard, _Then_ show "Need 50+ questions to unlock" + progress bar.
+
+**AC mẫu — US-003 (Question SRS):**
+
+- _Given_ user trả lời sai 1 MCQ, _When_ submit, _Then_ tạo SrsCard với interval = 1 day.
+- _Given_ user trả lời lại đúng câu đó, _When_ submit ở review session, _Then_ interval × 2.5 (SM-2 ease factor).
+- _Given_ card đến hạn, _When_ user mở "Review Today", _Then_ xuất hiện trong queue, ưu tiên overdue lâu nhất.
+- _Given_ user trả lời đúng 5 lần liên tiếp, _When_ ease factor > 2.8, _Then_ card chuyển trạng thái MASTERED.
+
+**AC mẫu — US-006 (Adaptive Topic Suggestion):**
+
+- _Given_ user có proficiency map theo domain, _When_ mở "Practice", _Then_ top 3 gợi ý là domain có proficiency thấp nhất nhưng > 30% (edge-of-competence).
+- _Given_ user dismiss gợi ý, _When_ refresh, _Then_ hệ thống đề xuất lựa chọn khác (không lặp).
+- _Given_ user accept gợi ý, _When_ hoàn thành 10 câu, _Then_ proficiency được recompute và phản ánh trong dashboard.
+
+---
+
+### NEXT — Q3 2026 (v1.3 → v1.4, Sprint 5–8)
+
+| ID     | Story                                                                                                     | Priority | SP  | Epic |
+| ------ | --------------------------------------------------------------------------------------------------------- | -------- | --- | ---- |
+| US-009 | Là Mai, tôi muốn **tạo Squad** (5–10 người) với cert mục tiêu + ngày thi, để dẫn dắt nhóm.                | Must     | 8   | E5   |
+| US-010 | Là Mai, tôi muốn xem **Squad Dashboard** với progress, weak domain, leaderboard nội bộ, để coach.         | Must     | 13  | E5   |
+| US-011 | Là Linh (squad member), tôi muốn nhận **daily challenge từ squad lead**, để học cùng nhóm.                | Should   | 5   | E5   |
+| US-012 | Là Khoa, tôi muốn làm **Scenario Simulation** (multi-paragraph + diagram), để rèn architecture reasoning. | Must     | 13  | E4   |
+| US-013 | Là Khoa, tôi muốn xem **explanation logic** của scenario (vì sao A đúng, B sai), để học elimination.      | Must     | 5   | E4   |
+| US-014 | Là Linh, tôi muốn **AI Coach gửi insight tuần** ("bạn yếu IAM khi đọc > 60 phút"), để cải thiện.          | Should   | 8   | E6   |
+| US-015 | Là Linh, tôi muốn hệ thống **phát hiện burnout** (response time variance) và đề xuất 5-min reset.         | Could    | 5   | E6   |
+| US-016 | Là Hùng, tôi muốn **Reviewer Queue** với filter (flagged, new, ambiguous), để review hiệu quả.            | Should   | 5   | E2   |
+
+**AC mẫu — US-010 (Squad Dashboard):**
+
+- _Given_ Mai là squad lead, _When_ mở `/org/:slug/squads/:id`, _Then_ hiển thị bảng: member, readiness%, weak domain top-1, last active.
+- _Given_ squad có ≥3 member, _When_ mở dashboard, _Then_ show squad-level heatmap domain proficiency.
+- _Given_ member chưa active 7+ ngày, _When_ dashboard load, _Then_ highlight đỏ + nút "send nudge".
+- _Given_ Mai click member, _When_ drill-down, _Then_ show timeline 30 ngày + suggested coaching action.
+
+**AC mẫu — US-012 (Scenario Simulation):**
+
+- _Given_ scenario có markdown + diagram URL, _When_ user mở, _Then_ render diagram + 4–6 đoạn context.
+- _Given_ user chọn answer, _When_ submit, _Then_ show explanation theo từng option (correct/distractor/marketing).
+- _Given_ scenario có time limit, _When_ hết giờ, _Then_ auto-submit + hiển thị "thinking time" analytics.
+- _Given_ user quay lại, _When_ xem history, _Then_ lưu reasoning trace của user (option đã chọn rồi đổi).
+
+---
+
+### LATER — Q4 2026 (v2.0, Sprint 9–12)
+
+| ID     | Story                                                                                                           | Priority | SP  | Epic |
+| ------ | --------------------------------------------------------------------------------------------------------------- | -------- | --- | ---- |
+| US-017 | Là Khoa, tôi muốn xem **Cross-Cert Knowledge Graph** ("AWS VPC ↔ Azure VNet 70%"), để chọn cert kế tiếp.        | Should   | 13  | E7   |
+| US-018 | Là Linh, tôi muốn **Dynamic Difficulty Scaling** — câu cũ tự động tinh chỉnh distractor, để chống học vẹt.      | Could    | 8   | E3   |
+| US-019 | Là Linh, tôi muốn **AI Coach 1-1 chat** trả lời "tại sao đáp án này đúng", để hiểu sâu.                         | Should   | 13  | E6   |
+| US-020 | Là Mai, tôi muốn **Peer Review Challenge** — squad member vote explanation tốt nhất, để xây kỹ năng giải thích. | Could    | 8   | E5   |
+| US-021 | Là Khoa, tôi muốn **Exam Day Protocol checklist** (24h trước thi), để giảm anxiety.                             | Should   | 3   | E6   |
+| US-022 | Là Linh, tôi muốn xem **benchmark vs top 10% candidate đã pass**, để biết mình đứng đâu.                        | Could    | 5   | E1   |
+
+**AC mẫu — US-017 (Cross-Cert Graph):**
+
+- _Given_ user pass AWS SAA, _When_ mở Knowledge Graph, _Then_ hiển thị graph vendor × domain với % overlap.
+- _Given_ user click 1 node Azure, _When_ drill-down, _Then_ show "skip-able" topic và "must-learn" topic.
+- _Given_ graph có data, _When_ user chọn cert mục tiêu mới, _Then_ generate study plan tối ưu (giảm 30–50% effort).
+
+---
+
+## 4. Release Plan
+
+| Release  | Sprint | Tên (Theme)                      | Scope chính                                                                                                      | Stories                                        | Risk chính                                                 |
+| -------- | ------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------- |
+| **v1.1** | 1–2    | "Quick Wins & Foundations"       | Time Pressure Mode, dashboard Due-for-Review skeleton, flag question, email nhắc. Hoàn thiện exam engine sẵn có. | US-005, US-007, US-008, US-004                 | Tech debt cleanup                                          |
+| **v1.2** | 3–4    | "The Pass Predictor" (Core Moat) | Readiness Score v1, Question-level SRS engine, Adaptive Weakness suggest.                                        | US-001, US-002, US-003, US-006                 | Algorithm correctness, cần data validation với cohort thật |
+| **v1.3** | 5–6    | "Squads & Scenarios"             | Training Squads + Squad Dashboard. Scenario Simulation (10 scenario/cert pilot).                                 | US-009, US-010, US-011, US-012, US-013         | Content production bottleneck (cần author scenarios)       |
+| **v1.4** | 7–8    | "AI Coach Beta"                  | AI weekly insights, burnout detection, reviewer queue.                                                           | US-014, US-015, US-016                         | LLM cost, prompt safety                                    |
+| **v2.0** | 9–12   | "Knowledge Graph & Mastery"      | Cross-Cert Graph, Dynamic Difficulty, AI Coach 1-1 chat, Peer Review Challenges, Exam Day Protocol.              | US-017, US-018, US-019, US-020, US-021, US-022 | Scope lớn — cần ưu tiên lại sau v1.4 retrospective         |
+
+**Velocity giả định:** team 5 người (2 FE + 2 BE + 1 FS), velocity ổn định ~30 SP/sprint sau sprint 2.
+
+---
+
+## 5. Top 5 OKRs cho Q3 2026
+
+> Quý trọng tâm: build the moat — Readiness Score + SRS + Squads phải đi vào tay user thật.
+
+| #      | Objective                                                                | Key Result                                                 | Baseline | Target Q3               |
+| ------ | ------------------------------------------------------------------------ | ---------------------------------------------------------- | -------- | ----------------------- |
+| **O1** | Trở thành "training system" thay vì "question bank" trong nhận thức user | 70% premium user kiểm tra Readiness Score ≥ 3 lần/tuần     | 0%       | 70%                     |
+| **O2** | Tăng retention dài hạn nhờ SRS                                           | DAU/MAU ratio                                              | ~22%     | ≥ 35%                   |
+| **O3** | Validate Squads là retention engine                                      | 30-day retention của user trong Squad cao hơn user solo    | 1.0x     | ≥ 1.5x                  |
+| **O4** | Pass Predictor có giá trị thật, không phải vanity metric                 | Correlation giữa Readiness Score (≥80) và actual pass exam | n/a      | r ≥ 0.75 (n ≥ 200 user) |
+| **O5** | Conversion free → premium tăng nhờ Scenario + AI Coach                   | Free → Premium conversion rate (30 ngày)                   | 4%       | ≥ 7%                    |
+
+**Guardrail metrics (không được giảm):**
+
+- p95 API latency < 400ms
+- Question bank accuracy (post-review) ≥ 98%
+- LLM cost / premium user / tháng < $1.20
+- Crash-free session > 99.5%
+
+---
+
+## Phụ lục — Definition of Ready (DoR) & Definition of Done (DoD)
+
+**DoR (story sẵn sàng vào sprint):**
+
+- [ ] Có persona + business value rõ
+- [ ] AC viết theo Given/When/Then, ≥ 3 điểm
+- [ ] Mock UI (nếu có UI thay đổi) đã reviewed
+- [ ] Story points đã estimate (planning poker)
+- [ ] Phụ thuộc kỹ thuật đã được flag
+
+**DoD (story xong):**
+
+- [ ] Code merged vào main, CI xanh
+- [ ] Unit + integration test, coverage ≥ 80%
+- [ ] E2E test cho critical flow (Playwright)
+- [ ] Reviewed bởi ≥ 1 dev khác
+- [ ] Telemetry/event tracking đã add (cho metric OKR)
+- [ ] Update docs (`docs/` hoặc inline)
+- [ ] Demo cho PO trong sprint review

--- a/docs/team-planning/02-scrum-master.md
+++ b/docs/team-planning/02-scrum-master.md
@@ -1,0 +1,229 @@
+# 02 — Scrum Master Playbook (CertGym)
+
+> Tài liệu vận hành Scrum cho CertGym (Brain Gym). Bám theo roadmap PO: Q2 Foundation + Question SRS, Q3 Pass Predictor + Behavioral Insights, Q4 Training Squads + Cross-Cert Graph.
+> Mục tiêu: tạo nhịp giao hàng đều đặn, bảo vệ chất lượng, kiểm soát tech debt và risk thay vì chạy theo feature mù quáng.
+
+---
+
+## 1. Team composition & capacity
+
+### 1.1 Team
+
+| Role                   | Số người | FTE     | Ghi chú                                                   |
+| ---------------------- | -------- | ------- | --------------------------------------------------------- |
+| Product Owner          | 1        | 1.0     | Sở hữu backlog, ưu tiên, gặp khách hàng/khoa thi          |
+| Scrum Master           | 1        | 0.7     | Kiêm 0.3 FTE engineering hỗ trợ tooling/CI                |
+| Frontend Engineer      | 2        | 2.0     | 1 senior (exam engine, design system), 1 mid (org, admin) |
+| Backend Engineer       | 2        | 2.0     | 1 senior (auth, multi-tenant, AI), 1 mid (SRS, analytics) |
+| QA Engineer            | 1        | 1.0     | Sở hữu Playwright suite, test plan, automation gate       |
+| UX/Product Designer    | 1        | 0.5     | Part-time, drive design system + research                 |
+| **Total dev capacity** | **6**    | **5.5** | Không tính PO                                             |
+
+### 1.2 Velocity giả định
+
+- Sprint 2 tuần, **6 dev** ~ 5.5 FTE.
+- Mỗi FTE tải ~8 SP/sprint (sau khi trừ ceremonies, support).
+- **Velocity nền: 40 SP/sprint** cho 3 sprint đầu, kỳ vọng tăng lên 48–55 SP từ sprint 4 khi team đã ổn định.
+
+### 1.3 Capacity split
+
+| Loại công việc                                      | % capacity | SP/sprint (≈40) |
+| --------------------------------------------------- | ---------- | --------------- |
+| Feature mới (roadmap PO)                            | 60%        | 24              |
+| Tech debt + platform (TS strict, Playwright, queue) | 20%        | 8               |
+| Bug + production support                            | 10%        | 4               |
+| Spike + R&D (AI, SRS algo)                          | 10%        | 4               |
+
+Giữ tỉ lệ này tối thiểu 2 quý đầu — không cho feature ăn quá 70% nếu không sẽ vỡ Q4.
+
+---
+
+## 2. Sprint cadence & ceremonies
+
+- **Sprint length:** 2 tuần (Thứ Tư → Thứ Ba kế tiếp). Tránh kết thúc thứ Sáu để retro/demo không bị nuốt vào weekend.
+- **Sprint Planning:** Thứ Tư, 90 phút. Phần 1: WHAT (PO trình goal + top stories). Phần 2: HOW (team commit, chia task).
+- **Daily Standup:** 9:30, 15 phút, async-first qua Slack `#certgym-daily` + sync 2 buổi/tuần (T2, T5) cho blocker.
+- **Backlog Refinement:** Thứ Năm tuần lẻ, 60 phút. Story phải đạt DoR trước planning kế tiếp.
+- **Sprint Review/Demo:** Thứ Ba cuối sprint, 45 phút. Demo build thật trên staging, mời 1–2 stakeholder/giáo viên.
+- **Retrospective:** Ngay sau Review, 45 phút. Format luân phiên: Start/Stop/Continue, 4Ls, Sailboat.
+- **Tech Sync:** Thứ Sáu hàng tuần, 30 phút (FE+BE+QA), bàn architecture, schema, test strategy.
+
+### Working agreement (5 quy ước)
+
+1. **PR ≤ 400 LOC**, mở review trong 4 giờ. Quá 400 LOC phải có lý do và thông báo SM.
+2. **Mọi PR phải xanh CI** (lint, type, unit, e2e smoke) trước khi merge. Không bypass `--no-verify`.
+3. **Story chỉ Done khi demo được trên staging** (không phải máy local).
+4. **Blocker > 4 giờ phải gọi SM**. Không ai được im lặng kẹt cả ngày.
+5. **Tech debt thấy là log ngay** vào `/tech-debt` board (không sửa lén trong PR feature lớn).
+
+---
+
+## 3. Definition of Ready (DoR) & Definition of Done (DoD)
+
+### DoR — Story sẵn sàng vào sprint
+
+- [ ] User story format `As a … I want … so that …` + business value rõ ràng.
+- [ ] Acceptance criteria viết theo Gherkin (Given/When/Then), tối thiểu 3 case (happy + edge + error).
+- [ ] UX có wireframe hoặc design Figma link (với story FE).
+- [ ] Phụ thuộc kỹ thuật (API, schema, env var) đã được note + xác nhận khả thi.
+- [ ] Estimate Story Points (Fibonacci, max 8 — story > 8 phải split).
+- [ ] QA đã review test approach (manual vs e2e vs unit).
+- [ ] Không có open question với PO; nếu có spike thì spike đã xong.
+
+### DoD — Story xong
+
+- [ ] Code merge vào `main`, qua review từ ≥1 dev khác (FE story → FE reviewer + BE nếu chạm API).
+- [ ] Unit test đạt coverage ≥80% file mới; không giảm coverage tổng quá 1%.
+- [ ] Integration/e2e test cho flow chính (Playwright cho FE, Jest e2e cho BE).
+- [ ] Lint + type check sạch (cả khi `noImplicitAny:false` vẫn không introduce `any` mới ở module mới).
+- [ ] A11y check: keyboard nav, contrast AA, focus visible (story FE).
+- [ ] Performance check: không regress LCP/INP > 10% trên Lighthouse staging.
+- [ ] Telemetry/log đủ để debug production (ít nhất 1 audit log + 1 metric).
+- [ ] Docs/CHANGELOG cập nhật; nếu chạm DB → migration + rollback plan.
+- [ ] Demo được trên staging và PO đã sign-off.
+- [ ] Security check: không hardcode secret, input validate ở boundary, role/guard cho route nhạy cảm.
+
+---
+
+## 4. Risk Register
+
+| #   | Risk                                                                      | P   | I   | Mitigation                                                                                                                       | Owner          |
+| --- | ------------------------------------------------------------------------- | --- | --- | -------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| R1  | TypeScript loose (`noImplicitAny:false`) gây runtime bug khó trace        | H   | H   | Spike Sprint 1: bật strict cho `src/services/` + `backend/src/auth/`; thêm gate "no new `any`" trong ESLint                      | Senior FE      |
+| R2  | E2E flaky (commit f732275, e63ade8) chặn pipeline                         | H   | H   | Sprint 1 lập "test isolation pattern", cô lập DB seed/teardown, stabilize 5 flow critical, set quarantine cho test flaky > 3 lần | QA Lead        |
+| R3  | Chưa có job queue → AI generation block request HTTP                      | M   | H   | Spike Sprint 2 (BullMQ trên Redis có sẵn), Sprint 4 đưa vào production cho AI question gen                                       | Senior BE      |
+| R4  | Multi-tenant leak data giữa org                                           | L   | H   | Guard tests bắt buộc cho mọi route `/org/:slug`, security review bắt buộc với mọi PR chạm `org.store` hoặc `OrgGuard`            | Senior BE + SM |
+| R5  | Người: 1 senior nghỉ → bus factor = 1 cho exam engine                     | M   | H   | Pair programming bắt buộc cho exam engine, doc hóa kiến trúc trong `/docs/exam-engine.md` trước Sprint 3                         | SM             |
+| R6  | LLM provider thay đổi giá/quota (OpenAI/Anthropic) ảnh hưởng AI Generator | M   | M   | Adapter pattern (đã có), benchmark 2 provider mỗi quý, cap cost trong env config                                                 | Senior BE      |
+| R7  | Q3 "Pass Predictor" thiếu data thật → model overfit                       | M   | H   | Sprint 3 bắt đầu collect feature event (anonymized), lùi launch nếu < 1k user attempt                                            | PO + BE        |
+| R8  | Postgres không tune index → SRS chậm khi user > 10k                       | M   | M   | Sprint 2 thêm index `due_at`, `user_id+card_id`, k6 load test 10k user mock                                                      | Senior BE      |
+| R9  | Visual regression chưa có → release làm vỡ UI                             | M   | M   | Sprint 2 thêm Playwright screenshot (320/768/1440) cho 5 page critical                                                           | QA + FE        |
+| R10 | Chưa CSP nonce-based → XSS risk khi mở rộng AI render markdown            | L   | H   | Sprint 1 thêm CSP nonce + sanitize markdown (DOMPurify), security review                                                         | Senior FE      |
+
+P/I: L=Low, M=Medium, H=High. Review register cuối mỗi sprint trong Retro.
+
+---
+
+## 5. Sprint Plan Sprint 1–3
+
+### Sprint 1 — "Stabilize the gym" (capacity 40 SP)
+
+- **Goal:** Pipeline xanh ổn định, foundation cho SRS, không introduce regression.
+- **Key stories:**
+  - US-101 Fix E2E isolation + quarantine flaky (8 SP) — QA + BE
+  - US-102 Bật strict TS cho `src/services/*` + `backend/src/auth/*` (5 SP) — FE + BE
+  - US-103 SRS schema + migration (review/repetition/easeFactor/dueAt) (8 SP) — BE
+  - US-104 Flashcard review API (POST /flashcards/:id/review) (5 SP) — BE
+  - US-105 CSP nonce + DOMPurify cho AI render (5 SP) — FE
+  - US-106 Spike: BullMQ feasibility (3 SP) — BE
+  - US-107 Bug pool + support (4 SP) — Team
+  - US-108 Onboard Lighthouse CI baseline (2 SP) — FE + SM
+- **Dependencies:** Redis sẵn, không cần infra mới.
+- **Demo plan:** Show CI pipeline xanh 5 lần liên tiếp, demo flashcard review API qua Postman, show Lighthouse baseline.
+
+### Sprint 2 — "First learner loop" (capacity 42 SP)
+
+- **Goal:** Học viên review được flashcard với SRS thực sự, có thấy due card hôm nay.
+- **Key stories:**
+  - US-201 Flashcard review UI (queue, rating 1–4, animation) (8 SP) — FE
+  - US-202 Due-today widget on dashboard (5 SP) — FE
+  - US-203 SRS algorithm SM-2 polish + unit test (5 SP) — BE
+  - US-204 Index tuning + k6 load test 10k user (5 SP) — BE
+  - US-205 Visual regression suite (Playwright screenshot 5 pages × 3 breakpoints) (8 SP) — QA + FE
+  - US-206 BullMQ setup + AI gen worker (8 SP) — BE
+  - US-207 Tech debt: extract `api.ts` interceptor unit test (3 SP) — FE
+- **Dependencies:** Sprint 1 schema + API.
+- **Demo plan:** Học viên thật làm 20 flashcard, show due queue cập nhật, show Playwright screenshots diff = 0.
+
+### Sprint 3 — "Insight kickoff" (capacity 44 SP)
+
+- **Goal:** Bắt đầu collect signal cho Pass Predictor; SRS đã production-grade.
+- **Key stories:**
+  - US-301 Event tracking schema (attempt, review, hint_used, time_spent) (5 SP) — BE
+  - US-302 Privacy-aware analytics ingestion endpoint (5 SP) — BE
+  - US-303 Mastery dashboard v1 (per-domain progress bars) (8 SP) — FE
+  - US-304 Streak tracking polish + edge case (timezone) (5 SP) — FE + BE
+  - US-305 Exam engine doc + pair tour (3 SP) — Senior FE + Mid FE
+  - US-306 A11y audit + fix top-10 issues (5 SP) — FE + UX
+  - US-307 Spike: Pass Predictor feature definition (5 SP) — BE + PO
+  - US-308 Bug pool + support (4 SP) — Team
+  - US-309 Retro action items thực thi (4 SP) — SM
+- **Dependencies:** Sprint 2 SRS production, BullMQ chạy thật.
+- **Demo plan:** Show event flow end-to-end (action FE → event BE → dashboard query), show mastery dashboard với data thật, present Pass Predictor feature spec.
+
+---
+
+## 6. Process metrics & cadence
+
+### 6.1 Metrics (review hàng sprint)
+
+| Metric                         | Target            | Cách đo                                  |
+| ------------------------------ | ----------------- | ---------------------------------------- |
+| Sprint goal hit rate           | ≥ 80%             | Goal đạt vs cam kết                      |
+| Velocity stability             | σ ≤ 15%           | StdDev / mean 5 sprint gần nhất          |
+| Lead time (story start → done) | ≤ 6 ngày          | Linear/Jira cycle time                   |
+| Escaped defects                | ≤ 2/sprint        | Bug production trong 14 ngày sau release |
+| PR review turnaround           | ≤ 4h working      | GitHub review latency                    |
+| Test coverage trend            | ≥ 80%, không giảm | Vitest + Jest coverage                   |
+| Flaky test count               | ≤ 3 quarantined   | Playwright quarantine list               |
+| Tech debt ratio                | 20% capacity      | Story point thực tế                      |
+
+### 6.2 Cadence chi tiết tuần
+
+| Day     | Activity                                                                  |
+| ------- | ------------------------------------------------------------------------- |
+| **Mon** | Async standup + 30' sync blocker; PO/SM 1:1 (15')                         |
+| **Tue** | (Tuần cuối sprint) Sprint Review + Retro; (tuần giữa) deep work           |
+| **Wed** | (Sprint mới) Planning 90'; pair programming buổi chiều                    |
+| **Thu** | Refinement (tuần lẻ) hoặc Design review (tuần chẵn); async standup        |
+| **Fri** | Tech Sync 30'; demo nội bộ Friday show-and-tell 30'; metrics review by SM |
+
+---
+
+## 7. Communication plan
+
+### Slack channels
+
+- `#certgym-daily` — async standup, bot reminder 9:00.
+- `#certgym-eng` — câu hỏi kỹ thuật FE/BE.
+- `#certgym-incidents` — alert + on-call response.
+- `#certgym-release` — auto post từ CI khi deploy staging/prod.
+- `#certgym-pm` — PO + SM + designer thảo luận roadmap.
+
+### Docs & sources of truth
+
+- **Backlog:** Linear (project `CertGym Q2`).
+- **Specs:** `/docs/*.md` (đã có), thêm `/docs/team-planning/` cho process artifact.
+- **Decisions:** ADR mới trong `/docs/adr/NNN-title.md` cho mỗi quyết định ảnh hưởng > 1 sprint.
+- **Runbook on-call:** `/docs/runbook.md` (cần tạo Sprint 2).
+
+### Async vs sync
+
+- **Async-first:** standup, code review, status update, RFC.
+- **Sync chỉ khi:** planning, retro, incident, kiến trúc lớn, conflict cá nhân.
+- Quy ước: nếu thread Slack > 10 reply → tạo doc + meeting.
+
+### Stakeholder reporting
+
+- **Hàng tuần (Fri):** SM gửi 1-pager trong `#certgym-pm`: progress, blocker, risk top-3.
+- **Cuối sprint:** PO gửi release note + demo recording cho stakeholder ngoài team.
+- **Hàng tháng:** Steering review (PO + SM + Tech Lead), 60', report metrics + roadmap drift.
+
+---
+
+## 8. Top 10 process improvements cần ngay (priority)
+
+1. **E2E test isolation pattern** (Sprint 1) — fix root cause flaky thay vì retry.
+2. **CI gate đầy đủ** (lint + type + unit + e2e smoke) bắt buộc trước merge.
+3. **No-new-`any` ESLint rule** cho module mới — chặn TS debt tăng thêm.
+4. **PR template + checklist DoD** trên GitHub — tự đánh dấu trước khi xin review.
+5. **Story split rule ≤ 8 SP** — bất kỳ story > 8 phải split trong refinement.
+6. **Quarantine flaky test sau 3 lần fail** — không block trunk, log issue tracking.
+7. **Visual regression baseline Sprint 2** — Playwright screenshot 5 page critical × 3 breakpoint.
+8. **ADR cho mọi quyết định kiến trúc** — tránh tribal knowledge.
+9. **On-call rotation tuần** + runbook tối thiểu (deploy, rollback, log access).
+10. **Metric dashboard công khai** (Linear + GitHub Actions API) — velocity, lead time, escaped defects view ai cũng đọc được.
+
+---
+
+> Tài liệu sống — review cuối mỗi quý, cập nhật theo retro action item lớn.

--- a/docs/team-planning/03-tech-lead.md
+++ b/docs/team-planning/03-tech-lead.md
@@ -1,0 +1,339 @@
+# Tech Lead Architecture Roadmap — CertGym (Brain Gym)
+
+> Deliverable từ **Tech Lead / Software Architect** trong sprint planning team.
+
+---
+
+## 1. Current State Assessment
+
+Đọc thực tế từ `backend/prisma/schema.prisma` (≈975 dòng, 40+ models) và `backend/src/app.module.ts` (24 modules):
+
+- **Strength — Domain coverage rộng**: schema đã cover B2C (Question, Exam, Attempt, Flashcard, ReviewSchedule SM-2), AI bank (SourceMaterial, SourceChunk, QuestionGenerationJob, UserLlmConfig với encryptedKey), B2B (Organization, OrgMember, OrgGroup, ExamCatalogItem, LearningTrack, Assessment, CandidateInvite). Đây là tài sản lớn — không cần làm lại nền.
+- **Strength — Module boundary backend đã rõ**: 24 NestJS modules tách theo domain (auth, exams, attempts, flashcards, ai-question-bank, organizations, org-questions, exam-catalog, assessments, org-analytics). Có chỗ để gắn DDD context map mà không phải rewrite.
+- **Strength — FE pattern thống nhất**: Axios interceptor + token refresh tập trung ở `src/services/api.ts`, TanStack Query cho server state, Zustand cho client state. Pattern này scale tốt khi thêm feature mới.
+- **Weakness — Loose TypeScript**: `noImplicitAny: false` + `strictNullChecks: false`. Khi đụng vào ML/predictor (số liệu), coach AI (chat schema), event sourcing (typed events) thì sẽ ăn lỗi runtime. Phải có kế hoạch siết dần.
+- **Weakness — Không có event store**: `Answer`, `ExamAttempt` lưu kết quả tổng hợp (totalCorrect, score, domainScores JSON). Không có bảng event chi tiết per-keystroke / per-question để feed Pass Predictor và Burnout Detection. Đây là blocker số 1 cho roadmap.
+- **Weakness — Không có job queue**: `QuestionGenerationJob` có status PENDING/PROCESSING/COMPLETED/FAILED nhưng không thấy BullMQ/Redis queue trong `app.module.ts`. Nghi ngờ đang chạy in-process — không scale, không retry chuẩn, không backoff.
+- **Weakness — Chưa có realtime layer**: không có WS/SSE module. Training Squads leaderboard, AI Coach streaming, live exam monitoring (Assessment có `tabSwitchCount` nhưng chỉ ghi sau submit) đều cần.
+- **Debt — SRS chỉ áp cho Flashcard**: có cả `ReviewSchedule` (cho Question) và `FlashcardReviewSchedule` — schema đã tách 2 bảng, nhưng FE/BE service hiện chỉ wire flashcards. Phần Question SRS gần như là dead code.
+- **Debt — Multi-tenant isolation chưa enforce ở DB level**: dùng `orgId` filter ở service layer, không có Postgres RLS. Dễ rò rỉ khi quên `where: { orgId }` ở 1 query.
+- **Debt — `Exam.create` shuffle bằng `Math.random()`** (xem `exams.service.ts:29`): không deterministic, không seeded, không kiểm soát difficulty distribution dù schema có `difficultyDist Json`. Khi thêm Adaptive / DDS sẽ phải refactor.
+- **Debt — Throttler global 300/min duy nhất** (`app.module.ts:34`): không phân biệt LLM endpoint (cần stricter), public read (lỏng hơn), auth (chống brute force).
+
+---
+
+## 2. Target Architecture (12-Month Horizon)
+
+```mermaid
+flowchart TB
+    subgraph Client
+      FE[React 18 + Vite + TanStack Query]
+      RT[SSE/WS Client]
+    end
+
+    subgraph Edge
+      NGX[Nginx]
+      CDN[CloudFront/Vercel CDN]
+    end
+
+    subgraph API[API Layer - NestJS 11]
+      GW[Auth + Rate Limit + Tenant Guard]
+      CORE[Core Bounded Contexts]
+      RT_OUT[Realtime Gateway SSE/WS]
+    end
+
+    subgraph Domains[Bounded Contexts]
+      LRN[Learning: Question SRS, Flashcard, Exam]
+      ASMT[Assessment: Org Catalog, Candidate Invite]
+      AI[AI Authoring: Generation, DDS, Coach]
+      INSIGHT[Insights: Predictor, Behavior, Squad]
+      ORG[Org & Identity]
+    end
+
+    subgraph Async[Async Backbone]
+      Q[(BullMQ on Redis)]
+      W1[Worker: LLM Gen]
+      W2[Worker: Embeddings]
+      W3[Worker: Scoring/Predictor]
+      W4[Worker: Behavioral Analyzer]
+      W5[Worker: Notifications]
+    end
+
+    subgraph Data[Data Layer]
+      PG[(PostgreSQL 16 - OLTP)]
+      EVT[(attempt_events table - append-only)]
+      RD[(Redis - cache + leaderboard ZSET)]
+      VEC[(pgvector - semantic dedup, KG)]
+      OBJ[(S3/R2 - PDF, exports)]
+      DW[(ClickHouse/DuckDB - analytics, M9+)]
+    end
+
+    subgraph External
+      LLM[OpenAI/Anthropic/Gemini]
+      OBS[OpenTelemetry → Grafana/Tempo]
+    end
+
+    FE --> NGX --> GW
+    CDN --> FE
+    GW --> CORE
+    CORE --> Domains
+    Domains --> PG
+    Domains --> EVT
+    Domains --> RD
+    Domains --> Q
+    Q --> W1 --> LLM
+    Q --> W2 --> VEC
+    Q --> W3 --> EVT
+    Q --> W4 --> EVT
+    Q --> W5
+    W3 --> PG
+    INSIGHT --> EVT
+    INSIGHT --> VEC
+    RT_OUT --> RT
+    Q -.metrics.-> OBS
+    API -.traces.-> OBS
+```
+
+**Bounded contexts (DDD-ish):**
+
+| Context              | Owns                                   | Key Aggregates                                                           | Talks to                       |
+| -------------------- | -------------------------------------- | ------------------------------------------------------------------------ | ------------------------------ |
+| **Identity & Org**   | User, Auth, Org, Member, Group, Invite | `User`, `Organization`                                                   | Tất cả (via JWT claims)        |
+| **Learning**         | Cá nhân học                            | `Question`, `Exam`, `ExamAttempt`, `Deck`, `Flashcard`, `ReviewSchedule` | Insights (publish events)      |
+| **AI Authoring**     | Sinh & edit content                    | `SourceMaterial`, `GenerationJob`, `OrgQuestion`                         | Vector DB, LLM                 |
+| **Assessment (B2B)** | Tuyển dụng & track                     | `Assessment`, `CandidateInvite`, `ExamCatalogItem`, `LearningTrack`      | Learning (read), Notifications |
+| **Insights**         | Predictor, behavior, squad, KG         | `AttemptEvent` (read-only consumer), `ReadinessScore`, `BurnoutSignal`   | Event store, Vector DB         |
+| **Realtime**         | SSE/WS fanout                          | session-bound                                                            | Redis pub/sub                  |
+
+**Layer mới cần thêm:**
+
+1. **Event store** — bảng `attempt_events` append-only (xem §4).
+2. **Job queue** — BullMQ trên Redis hiện có; tách worker process khỏi API.
+3. **ML/Inference** — service riêng (Nest worker hoặc Python FastAPI) chạy heuristic/scikit-learn cho Pass Predictor; bắt đầu bằng heuristic, swap được.
+4. **Realtime** — SSE cho leaderboard/coach (đơn giản, scale tốt với Nginx); WS chỉ khi cần bidi (Assessment proctoring live).
+5. **Vector layer** — `pgvector` extension trong cùng Postgres để KISS, migrate sang Qdrant nếu >5M vectors.
+6. **Observability** — OpenTelemetry SDK trong Nest, export OTLP → Grafana stack.
+
+---
+
+## 3. RFC List Q2–Q3
+
+| ID      | Title                                  | Problem                                                                                                                                   | Owner             | Deadline   | Dependencies     | Status   |
+| ------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ---------- | ---------------- | -------- |
+| RFC-001 | AttemptEvent Schema & Ingestion        | Hiện chỉ có `Answer` aggregate. Cần event chi tiết (focus, blur, choice_changed, marked, time_per_question) để feed predictor & behavior. | Tech Lead         | 2026-05-15 | Không            | Draft    |
+| RFC-002 | Question SRS Activation                | `ReviewSchedule` đã có schema nhưng không được FE/BE wire. Cần hook vào ExamAttempt completion.                                           | BE Lead           | 2026-05-22 | RFC-001          | Proposed |
+| RFC-003 | Pass Predictor v0 (Heuristic)          | Score 0–100 readiness per (user, certification). Bắt đầu bằng weighted heuristic, không ML.                                               | ML Champion       | 2026-06-01 | RFC-001, RFC-002 | Proposed |
+| RFC-004 | BullMQ Job Queue Foundation            | Move LLM generation, email, embeddings sang queue. Define job schema, retry, DLQ.                                                         | Platform          | 2026-05-10 | Không            | Proposed |
+| RFC-005 | Realtime Gateway (SSE-first)           | Leaderboard, AI Coach streaming, live notifications. Chọn SSE vì stateless, work với Nginx/HTTP2.                                         | FE+BE             | 2026-06-10 | RFC-004          | Proposed |
+| RFC-006 | Postgres RLS for Multi-Tenant          | Enforce org isolation ở DB layer thay vì service. Giảm rủi ro rò rỉ.                                                                      | Security Champion | 2026-06-20 | Không            | Proposed |
+| RFC-007 | pgvector Setup + Semantic Dedup        | Embedding cho Question để chống duplicate khi LLM generate, làm nền cho Knowledge Graph.                                                  | AI Lead           | 2026-06-15 | RFC-004          | Proposed |
+| RFC-008 | Behavioral Insights Pipeline           | Worker đọc AttemptEvent → tính burnout score (low accuracy + high session length + late-night).                                           | ML Champion       | 2026-07-01 | RFC-001, RFC-004 | Proposed |
+| RFC-009 | TypeScript Strict Migration Plan       | Bật `strictNullChecks` từng module. Score-driven (track lỗi).                                                                             | Tech Lead         | 2026-05-30 | Không            | Proposed |
+| RFC-010 | Dynamic Difficulty Scaling Spec        | LLM rewrite distractors khi user mastery cao. Cần audit trail + rollback.                                                                 | AI Lead           | 2026-07-15 | RFC-007          | Proposed |
+| RFC-011 | Training Squad Subtype on Organization | Squad là `Organization` nhẹ, không kế thừa Catalog/Assessment. Schema diff & permission matrix.                                           | BE Lead           | 2026-07-10 | RFC-005          | Proposed |
+| RFC-012 | LLM Cost & Quota Layer                 | Per-user, per-org quota; track tokens/cost ở `QuestionGenerationJob` (đã có cột) + extend cho Coach.                                      | Platform          | 2026-06-25 | RFC-004          | Proposed |
+
+---
+
+## 4. Schema Changes Plan
+
+### Models mới
+
+```prisma
+// RFC-001: Event sourcing cho attempt
+model AttemptEvent {
+  id           BigInt   @id @default(autoincrement())
+  attemptId    String   @map("attempt_id")
+  userId       String   @map("user_id")
+  questionId   String?  @map("question_id")
+  eventType    String   @map("event_type") // QUESTION_VIEWED, CHOICE_SELECTED, MARKED, FOCUS_LOST, SUBMITTED
+  payload      Json
+  clientTs     DateTime @map("client_ts")
+  serverTs     DateTime @default(now()) @map("server_ts")
+
+  @@index([attemptId, serverTs])
+  @@index([userId, eventType, serverTs])
+  @@map("attempt_events")
+}
+
+// RFC-003: Pass Predictor output
+model ReadinessScore {
+  id              String   @id @default(uuid())
+  userId          String   @map("user_id")
+  certificationId String   @map("certification_id")
+  score           Int      // 0-100
+  confidence      Decimal  @db.Decimal(4, 3)
+  signals         Json     // { srsCoverage, recentAccuracy, timePressure, domainGaps }
+  computedAt      DateTime @default(now()) @map("computed_at")
+  @@unique([userId, certificationId])
+  @@index([certificationId, score])
+  @@map("readiness_scores")
+}
+
+// RFC-008: Behavioral signals
+model BurnoutSignal {
+  id         String   @id @default(uuid())
+  userId     String   @map("user_id")
+  level      String   // GREEN/YELLOW/RED
+  reasons    Json
+  windowDays Int      @map("window_days")
+  detectedAt DateTime @default(now()) @map("detected_at")
+  @@index([userId, detectedAt])
+  @@map("burnout_signals")
+}
+
+// RFC-007: Vector embeddings
+// Cần migration raw để bật extension + cột vector
+// CREATE EXTENSION IF NOT EXISTS vector;
+model QuestionEmbedding {
+  questionId String  @id @map("question_id")
+  modelId    String  @map("model_id") // 'text-embedding-3-small' (1536 dim)
+  // pgvector column added via raw SQL migration
+  // embedding  vector(1536)
+  updatedAt  DateTime @updatedAt @map("updated_at")
+  @@map("question_embeddings")
+}
+
+// RFC-010: DDS audit
+model QuestionVariant {
+  id           String   @id @default(uuid())
+  questionId   String   @map("question_id")
+  variantOf    String?  @map("variant_of")
+  rewriteJobId String?  @map("rewrite_job_id")
+  reason       String   // DDS_HARDEN, DDS_SOFTEN, MANUAL
+  diff         Json
+  createdAt    DateTime @default(now()) @map("created_at")
+  @@index([questionId])
+  @@map("question_variants")
+}
+
+// RFC-012: LLM usage ledger
+model LlmUsageEvent {
+  id            BigInt   @id @default(autoincrement())
+  userId        String   @map("user_id")
+  orgId         String?  @map("org_id")
+  feature       String   // GENERATION, COACH, DDS, EMBEDDING
+  provider      LlmProvider
+  modelId       String   @map("model_id")
+  promptTokens  Int      @map("prompt_tokens")
+  outputTokens  Int      @map("output_tokens")
+  costUsd       Decimal  @db.Decimal(10, 6) @map("cost_usd")
+  createdAt     DateTime @default(now()) @map("created_at")
+  @@index([userId, createdAt])
+  @@index([orgId, createdAt])
+  @@index([feature, createdAt])
+  @@map("llm_usage_events")
+}
+```
+
+### Migration strategy (zero-downtime)
+
+1. **Expand–migrate–contract** cho mọi schema change:
+   - Add column `NULLABLE` → backfill async qua worker → enforce `NOT NULL` ở migration sau.
+2. **Append-only tables** (`attempt_events`, `llm_usage_events`): dùng Postgres native partitioning theo `serverTs` monthly. Drop partition cũ thay vì DELETE.
+3. **`pgvector`**: dùng raw SQL migration (Prisma chưa hỗ trợ tốt). Tạo IVFFlat index sau khi đã có ≥10k rows.
+4. **RLS rollout (RFC-006)**: bật policy ở `LOG-ONLY` mode trước (Postgres `FORCE ROW LEVEL SECURITY` off, custom audit), measure leak, sau đó enforce.
+
+### Index & query optimization
+
+- `attempt_events(attempt_id, server_ts)` — replay 1 attempt.
+- `attempt_events(user_id, event_type, server_ts)` — behavioral worker query.
+- `readiness_scores(certification_id, score DESC)` — leaderboard predictor.
+- Drop redundant indexes nếu có sau khi migrate (Postgres `pg_stat_user_indexes`).
+- `questions(certification_id, status)` đã có — tốt; thêm partial index `WHERE deleted_at IS NULL` để query active nhẹ hơn.
+
+---
+
+## 5. Infrastructure Roadmap
+
+| Capability             | Choice                                                           | Build vs Buy                   | Lý do                                                                                          |
+| ---------------------- | ---------------------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| **Job queue**          | BullMQ trên Redis 7                                              | Build (open source)            | Đã có Redis, Nest có `@nestjs/bullmq`, không add infra mới.                                    |
+| **Realtime**           | SSE qua Nest controller, fallback poll                           | Build                          | Đơn giản, work với Nginx hiện tại, không cần sticky session. WS chỉ khi cần bidi (proctoring). |
+| **Vector DB**          | `pgvector` (cùng Postgres)                                       | Build, migrate khi >5M vectors | Tránh thêm service. Qdrant Cloud là buy option khi scale.                                      |
+| **Observability**      | OpenTelemetry SDK + Grafana Cloud (logs/metrics/traces)          | Buy                            | Self-host Grafana stack tốn người. Free tier Grafana Cloud đủ Q2–Q3.                           |
+| **LLM cost tracking**  | `LlmUsageEvent` + dashboard nội bộ                               | Build                          | Đặc thù multi-provider, cần tie với org quota.                                                 |
+| **Email/Notification** | Resend hoặc Postmark                                             | Buy                            | Không tự host SMTP.                                                                            |
+| **Background ML**      | Nest worker với heuristic; chuyển Python FastAPI khi cần sklearn | Build                          | Bắt đầu nhẹ.                                                                                   |
+| **CDN/Image**          | Cloudflare R2 + Image Resizing                                   | Buy                            | Rẻ hơn S3+CloudFront cho file giáo dục (PDF, hình question).                                   |
+| **Secret manager**     | Doppler hoặc 1Password Connect                                   | Buy                            | `UserLlmConfig.encryptedKey` cần KMS đứng sau.                                                 |
+| **Feature flags**      | PostHog hoặc GrowthBook                                          | Buy                            | Cần cho DDS rollout từng cohort.                                                               |
+
+---
+
+## 6. Tech Debt — Top 10 Prioritized
+
+| #   | Item                                                     | Severity    | Effort          | Payoff                                      | Action                                                           |
+| --- | -------------------------------------------------------- | ----------- | --------------- | ------------------------------------------- | ---------------------------------------------------------------- |
+| 1   | Không có event store cho attempt                         | **Blocker** | 3 weeks         | Mở khoá Predictor + Burnout + Coach         | RFC-001 ngay Sprint 1                                            |
+| 2   | LLM gen chạy in-process (no queue)                       | **Blocker** | 1 week          | Stability, retry, cost control              | RFC-004                                                          |
+| 3   | Multi-tenant chỉ filter ở service layer                  | **High**    | 2 weeks         | Giảm rủi ro data leak nghiêm trọng          | RFC-006 RLS                                                      |
+| 4   | `Math.random()` shuffle exam, không seed                 | **High**    | 3 days          | Reproducibility, fairness                   | Thay bằng seeded shuffle (`xorshift32`) lưu seed vào ExamAttempt |
+| 5   | Loose TS (`strictNullChecks: false`)                     | **High**    | 6 weeks rolling | Bug runtime giảm, refactor an toàn hơn      | RFC-009 module-by-module                                         |
+| 6   | Throttler global 300/min duy nhất                        | **High**    | 2 days          | Chống brute-force auth, bảo vệ LLM endpoint | Tách `@Throttle` per route group                                 |
+| 7   | Question SRS schema có nhưng không wire                  | **Medium**  | 1 week          | Tận dụng schema sẵn, value cao              | RFC-002                                                          |
+| 8   | `domainScores Json` không typed                          | **Medium**  | 3 days          | Bug khi render dashboard                    | Zod schema runtime + TS type generated                           |
+| 9   | E2E test isolation (theo recent commits "fix e2e flake") | **Medium**  | 1 week          | CI reliability                              | DB snapshot/restore per test, tách worker DB                     |
+| 10  | Không có audit log cho `OrgQuestion` edits               | **Low**     | 2 days          | Compliance enterprise                       | Reuse `AuditLog` model                                           |
+
+---
+
+## 7. Spike List — Sprint 1–2
+
+| Spike                                     | Question                                                                                   | Timebox                          | Expected Output                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------ |
+| SP-1: Event ingestion shape               | Event payload size khi user làm bài 90 phút? Có cần batching client-side?                  | 2 ngày                           | Doc với benchmark: events/attempt, byte size, recommended batch interval |
+| SP-2: BullMQ + Nest pattern               | Worker process chung repo hay tách? Deploy graph?                                          | 1 ngày                           | PoC với 1 job (email), Dockerfile cho worker                             |
+| SP-3: pgvector benchmark                  | Với 50k questions, IVFFlat vs HNSW latency cho top-10 cosine?                              | 2 ngày                           | Bảng số liệu p50/p95/p99 + RAM cost                                      |
+| SP-4: Pass Predictor heuristic            | Weight nào (SRS coverage, accuracy 14d, domain spread, time pressure) tương quan với pass? | 3 ngày (cần data label thủ công) | Notebook + công thức v0                                                  |
+| SP-5: SSE behind Nginx                    | SSE proxy có giữ connection không? Idle timeout?                                           | 1 ngày                           | Nginx config + load test 1k concurrent                                   |
+| SP-6: Strict TS pilot                     | Bật `strictNullChecks` trên `auth/` + `users/` — bao nhiêu lỗi?                            | 1 ngày                           | Lỗi count, time-to-fix estimate                                          |
+| SP-7: LLM prompt injection trong AI Coach | Có bao nhiêu attack vector khi user gửi message tự do?                                     | 2 ngày                           | Threat model + mitigation list                                           |
+
+---
+
+## 8. Cross-Cutting Concerns
+
+### Security
+
+- **Multi-tenant isolation**: RFC-006 RLS bắt buộc. Set `app.current_org_id` qua `SET LOCAL` trong Prisma middleware. Test bằng adversarial integration test (User của org A query org B → expect empty/403).
+- **AI prompt injection**: Coach và DDS nhận free-text. Áp `system prompt isolation` (không nhúng user input vào system role), `output schema validation` bằng Zod, deny-list cho meta-instructions ("ignore previous", "you are now…"). Log mọi prompt vào `LlmUsageEvent` để forensic.
+- **PII**: Email candidate, IP address (`CandidateInvite.ipAddress`) cần data retention policy — auto-purge sau 12 tháng. Encrypt `UserLlmConfig.encryptedKey` bằng AES-GCM với key từ KMS, KHÔNG phải env var.
+- **CSP & headers**: thêm `Strict-Transport-Security`, `X-Content-Type-Options: nosniff`, CSP nonce-based ở Nginx layer.
+- **Rate limit per route**: `/auth/login` 5/min, `/ai-question-bank/generate` 10/hour per user, public read 300/min.
+
+### Performance Budgets
+
+| Surface             | Target               |
+| ------------------- | -------------------- |
+| API p95             | <300ms (excl. LLM)   |
+| API p99             | <800ms               |
+| LLM gen job         | <30s p95             |
+| Predictor refresh   | <5s per user (async) |
+| FE LCP              | <2.5s                |
+| FE bundle (landing) | <150KB gz            |
+| FE bundle (app)     | <300KB gz            |
+| Exam page TTI       | <1.5s                |
+| SSE message lag     | <500ms               |
+
+### A11y baseline
+
+- Tất cả exam UI: keyboard navigation đầy đủ (J/K cho prev/next, M cho mark, 1-4 cho choices).
+- Color contrast WCAG AA (timer warning state đặc biệt — không chỉ dùng màu đỏ).
+- Reduced-motion respect cho `<PageTransition>` Framer Motion.
+- Aria-live cho timer (announce mỗi 5 phút cuối).
+- Focus management khi modal mistake review mở.
+
+### Cost
+
+| Item                    | Estimate (10k MAU)              | Lever                                                            |
+| ----------------------- | ------------------------------- | ---------------------------------------------------------------- |
+| LLM (gen + coach + DDS) | $800–1500/tháng                 | Cache prompt, dedup câu hỏi, route Haiku/mini-model cho task nhẹ |
+| Postgres (managed)      | $200–400                        | Partition `attempt_events`, archive >90 ngày sang R2             |
+| Redis                   | $50                             | OK                                                               |
+| pgvector                | dùng chung Postgres             | Tách instance khi >100GB                                         |
+| Observability           | $0–100 (Grafana free)           | Sample traces 10%, full log lỗi                                  |
+| Email                   | $30                             | OK                                                               |
+| **Total**               | **~$1100–2000/tháng** ở 10k MAU |                                                                  |
+
+LLM là biến số lớn nhất — `LlmUsageEvent` + dashboard cost-per-feature là priority.

--- a/docs/team-planning/04-ux-qa-lead.md
+++ b/docs/team-planning/04-ux-qa-lead.md
@@ -1,0 +1,433 @@
+# 04 — UX Lead & QA Lead Strategy (CertGym / Brain Gym)
+
+> Author: UX Lead kiêm QA Lead
+> Status: **Proposed v1**
+> Scope: 5 feature mới (Question SRS, Exam Readiness, Behavioral Insights, Training Squads, AI Coach)
+
+---
+
+## Phần A — UX Strategy
+
+### 1. Design direction (anti-template)
+
+Brain Gym KHÔNG phải dashboard SaaS chung chung. Vision rõ là **"Training System, not a question bank"** — tức là người dùng cần cảm giác bước vào một **phòng tập trí não**: tập trung, có nhịp, đo được tiến bộ, có chút áp lực thi đấu. Vì vậy chọn 2 direction kết hợp:
+
+| Direction                          | Lý do                                                                                                                                                                                                                                                                           | Áp dụng ở đâu                                       |
+| :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------- |
+| **Editorial / Bento** (chính)      | Cho phép phá grid đều đặn — Dashboard, Readiness Score, Behavioral Insights cần hierarchy mạnh, các chỉ số "Pass Probability 82%" phải đập vào mắt như tít báo. Bento giúp gom nhiều mảnh dữ liệu (streak, weak domain, next review, squad rank) mà không nhìn như admin panel. | Dashboard, Readiness, Squad, Behavioral Insights    |
+| **Dark luxury (focus mode)** (phụ) | Khi vào Exam / Flashcard / SRS Review: low chrome, contrast cao, không decoration thừa. Đây là "trên thảm tập" — không có gì xen vào.                                                                                                                                           | ExamPage, FlashcardStudy, SRS Review, AI Coach chat |
+
+Light mode = editorial sáng (cream / off-white surface, accent đậm). Dark mode = luxury (oklch surface đen ấm, không xanh-than thường gặp). Cả hai đều phải **deliberate**, không phải "đảo invert".
+
+#### Color palette (oklch tokens)
+
+```css
+:root {
+  /* Surfaces — editorial light */
+  --color-bg: oklch(98.5% 0.005 90); /* warm cream */
+  --color-surface: oklch(100% 0 0);
+  --color-surface-2: oklch(96% 0.008 85); /* paper card */
+  --color-ink: oklch(18% 0.01 60); /* near-black warm */
+  --color-ink-soft: oklch(38% 0.015 60);
+
+  /* Brand — "Brain Gym" muscle + neuron */
+  --color-accent: oklch(64% 0.19 28); /* terracotta (effort) */
+  --color-accent-strong: oklch(54% 0.22 28);
+  --color-signal: oklch(72% 0.17 165); /* neuron mint (mastered) */
+  --color-warn: oklch(78% 0.16 75); /* amber (review due) */
+  --color-danger: oklch(58% 0.22 25);
+
+  /* Data viz — dùng cho domain proficiency */
+  --viz-1: oklch(64% 0.19 28);
+  --viz-2: oklch(70% 0.14 195);
+  --viz-3: oklch(74% 0.16 145);
+  --viz-4: oklch(68% 0.18 305);
+  --viz-5: oklch(76% 0.15 75);
+}
+
+[data-theme="dark"] {
+  --color-bg: oklch(14% 0.01 60); /* warm off-black */
+  --color-surface: oklch(18% 0.012 60);
+  --color-surface-2: oklch(22% 0.014 60);
+  --color-ink: oklch(96% 0.005 90);
+  --color-accent: oklch(72% 0.18 30); /* lifted on dark */
+}
+```
+
+Tất cả pairing kiểm bằng APCA Lc ≥ 75 cho body, ≥ 90 cho UI label nhỏ.
+
+#### Typography pairing
+
+- **Display / editorial headings**: `Fraunces` (variable, optical size) — chữ có "muscle", tốt cho tít "Pass Probability 82%".
+- **UI / body**: `Inter` (variable) — neutral, dày dạn ở UI dày dữ liệu.
+- **Numeric / data**: `JetBrains Mono` cho timer, score, leaderboard rank — tabular figures bắt buộc (`font-feature-settings: "tnum"`).
+
+Tokens scale: `--text-hero: clamp(2.5rem, 1.2rem + 5vw, 5.5rem)`, `--text-display: clamp(1.75rem, 1rem + 2.5vw, 3rem)`, `--text-base: clamp(1rem, 0.94rem + 0.3vw, 1.0625rem)`.
+
+#### Motion language
+
+- **Editorial reveal** cho dashboard / readiness: chữ slide-up + mask, easing `cubic-bezier(0.16, 1, 0.3, 1)`, duration 350-500ms.
+- **Focus mode** (exam, SRS): không có decorative motion — chỉ feedback (correct/wrong flash 120ms), tránh distraction.
+- **Squad realtime**: leaderboard rank thay đổi → spring nhẹ, không bouncing quá đà.
+- **Reduced motion**: tất cả transition giảm còn opacity fade 150ms; timer ring không animate, chỉ update text. Bắt buộc check `prefers-reduced-motion`.
+
+---
+
+### 2. User Journey Maps — 5 feature mới
+
+#### 2.1 Question SRS Daily Review
+
+| Bước           | Hành động                                                                        |
+| :------------- | :------------------------------------------------------------------------------- |
+| Persona        | The Learner (đang luyện AWS SAA, ngày 14/45)                                     |
+| Entry          | Dashboard widget "12 câu đến hạn ôn hôm nay" + push notification 8h sáng         |
+| 1              | Click widget → vào `/srs/today` — màn dark luxury, đếm lùi số câu còn lại        |
+| 2              | Đọc câu hỏi → chọn đáp án (không có timer áp lực)                                |
+| 3              | Sau khi reveal: 4 nút self-rating "Forgot / Hard / Good / Easy" (SM-2)           |
+| 4              | Animation câu được "lưu vào trí nhớ dài hạn" (subtle, 1 giây) → câu tiếp         |
+| 5              | Hết queue: summary "Bạn vừa khoá lại 12 câu, kế tiếp ôn ngày X"                  |
+| 6              | CTA: "Tập thêm 10 câu vùng yếu" hoặc "Hết, gặp lại mai"                          |
+| Pain points    | (a) User skip ngày → backlog phình; (b) self-rating bias; (c) cảm giác lặp       |
+| Delight        | "Memory streak" tăng khi review đúng giờ; visualisation forgetting curve cá nhân |
+| Retention hook | Email/push: "Nếu bỏ hôm nay, 8 câu sẽ tụt về Learning. Mất 6 phút thôi."         |
+
+#### 2.2 Exam Readiness Dashboard (Pass Predictor)
+
+| Bước           | Hành động                                                                 |
+| :------------- | :------------------------------------------------------------------------ |
+| Persona        | The Learner — đã làm 600+ câu, chuẩn bị book lịch thi                     |
+| Entry          | Tab "Readiness" trên Dashboard hoặc deep-link sau khi finish exam attempt |
+| 1              | Hero: gauge số lớn "82% chance of passing AWS SAA" + delta tuần           |
+| 2              | Bento dưới: 6 domain bars (proficiency %, target %), badge weak/strong    |
+| 3              | Section "Vs top 10% candidates" — radar chart so sánh                     |
+| 4              | Recommendation card: "Focus 3 ngày tới vào VPC + IAM Edge Cases"          |
+| 5              | CTA: "Start targeted drill" → Adaptive Weakness session                   |
+| 6              | Optional: "Book exam with confidence" — link vendor + checklist 24h       |
+| Pain points    | (a) % nhảy mạnh sau 1 lần làm tệ → user hoảng; (b) mô hình black-box      |
+| Delight        | Trend line lên đều — feedback rõ ràng; "Why?" tooltip giải thích model    |
+| Retention hook | Notification khi readiness ≥ 80% kéo dài 7 ngày: "Bạn sẵn sàng rồi"       |
+
+#### 2.3 Behavioral Insights & Burnout Micro-break
+
+| Bước           | Hành động                                                                      |
+| :------------- | :----------------------------------------------------------------------------- |
+| Persona        | The Learner — làm exam 60 phút, response time variance tăng                    |
+| Entry          | Trong exam: AI detect drift (response time σ tăng > threshold, accuracy giảm)  |
+| 1              | Banner non-blocking trên đỉnh: "Bạn đang giảm tốc. 90 giây nghỉ?" + "Tiếp tục" |
+| 2              | User chọn micro-break → overlay full-screen, dim, breathing circle 4-7-8       |
+| 3              | Timer dừng (chế độ Lenient) HOẶC vẫn chạy (Strict) — clearly labeled           |
+| 4              | Resume → quay lại câu đang làm, 2 giây countdown trước khi tương tác lại       |
+| 5              | Sau exam: insights tab "You slowed down at Q42. Pattern: 60-min wall"          |
+| 6              | Suggestion: "Next session, tập 'time-pressure resistance' module"              |
+| Pain points    | (a) False positive làm phiền; (b) interrupt trong câu khó = bực                |
+| Delight        | Insights mang tính coach, không judging; data viz đẹp, không số khô            |
+| Retention hook | Weekly digest email "Brain pattern of the week"                                |
+
+#### 2.4 Training Squads (Social + Realtime Leaderboard)
+
+| Bước           | Hành động                                                                      |
+| :------------- | :----------------------------------------------------------------------------- |
+| Persona        | The Squad Lead + 5-10 Learners cùng target AZ-104                              |
+| Entry          | Invite link / discover → "Join squad" CTA trên Leaderboard                     |
+| 1              | Squad Hub: bento — squad name, member avatars, weekly target progress          |
+| 2              | Realtime leaderboard (WebSocket): rank thay đổi khi member submit              |
+| 3              | Activity feed: "Lan vừa pass mock exam 78%", "Hùng streak day 21"              |
+| 4              | Weekly Challenge card: "Tổng 500 câu trước CN" — progress bar tập thể          |
+| 5              | Peer Review queue: review explanation của member khác → earn badge             |
+| 6              | DM/comments inline (lightweight, không phải full chat app)                     |
+| Pain points    | (a) Squad chết → user nản; (b) toxicity / spam; (c) social anxiety bị xếp cuối |
+| Delight        | "Personal best" highlight ngay cả khi không top — celebrate effort             |
+| Retention hook | Squad lead nudge tự động khi member im lặng > 3 ngày                           |
+
+#### 2.5 AI Coach 1-1 Chat
+
+| Bước           | Hành động                                                                |
+| :------------- | :----------------------------------------------------------------------- |
+| Persona        | The Learner — vừa fail mock exam, không biết học gì tiếp                 |
+| Entry          | Floating "Ask Coach" button (nav rail) hoặc "Get advice" sau exam result |
+| 1              | Chat panel mở (slide-in từ phải, không full-page) — dark luxury          |
+| 2              | Coach mở đầu với context: "Tôi thấy bạn vừa làm SAA mock — 62%. Hỏi gì?" |
+| 3              | Quick prompts: "Giải thích Q12", "Lập kế hoạch 7 ngày", "Vùng yếu nhất?" |
+| 4              | User chat — coach trả lời streaming, có cite vào câu hỏi / domain cụ thể |
+| 5              | Action chips: "Tạo drill 20 câu" / "Lên lịch SRS" — coach actionable     |
+| 6              | Lưu conversation; resume sau; export plan ra Dashboard                   |
+| Pain points    | (a) Hallucination; (b) generic advice; (c) latency >3s = mất flow        |
+| Delight        | Coach nhớ context user, dùng số liệu thật, đề xuất ngắn gọn actionable   |
+| Retention hook | Daily check-in proactive (opt-in): "Hôm nay tập 20' VPC nhé?"            |
+
+---
+
+### 3. Information Architecture update
+
+**Hiện tại** (suy ra từ `src/pages/`): Dashboard, ExamLibrary, ExamPage, FlashcardDecks, FlashcardStudy, StudyMode, TrainingHub, TrapQuestionsPage, Leaderboard, QuestionsBrowser, AiQuestionGenerator, Auth + admin/org routes.
+
+**Vấn đề**: TrainingHub, StudyMode, FlashcardDecks, ExamLibrary có overlap mục đích — user mới sẽ lạc.
+
+**Restructure đề xuất** (3 trục chính):
+
+```
+/                   → Dashboard (Bento: streak, due reviews, readiness, squad)
+/train              → Training Hub (gộp StudyMode + Adaptive Drill + SRS daily)
+  /train/srs        → SRS Daily Review (NEW)
+  /train/drill/:id  → Adaptive weakness drill
+  /train/flashcards → Flashcards (giữ nguyên)
+/exam               → Exam (Library + Builder + Attempt + Result)
+/readiness          → Pass Predictor (NEW)
+/squad              → Training Squads (NEW)
+  /squad/:id
+/coach              → AI Coach (overlay, không phải route riêng)
+/library            → Questions, Trap Questions, Decks (read-only browse)
+/me                 → Profile, Streak, Behavioral Insights (NEW), Settings
+```
+
+#### Onboarding 7 ngày đầu
+
+| Day | Mục tiêu                               | Trigger             |
+| :-- | :------------------------------------- | :------------------ |
+| 0   | Pick 1 cert + lý do thi                | Modal sau signup    |
+| 0   | Diagnostic 15 câu → readiness baseline | Dashboard CTA chính |
+| 1   | First SRS review (chỉ 5 câu)           | Push 8h sáng        |
+| 2   | First adaptive drill (vùng yếu nhất)   | Email nudge         |
+| 3   | Tour Trap Question Library             | In-app coach mark   |
+| 4   | First mock 30 câu                      | Dashboard banner    |
+| 5   | Suggest join Squad                     | Sau khi finish mock |
+| 7   | Weekly review + AI Coach intro         | Email digest        |
+
+Skippable nhưng có progress bar 7 dots ở top — Zeigarnik effect kéo user quay lại.
+
+---
+
+### 4. Component design system tasks
+
+**Components mới cần thêm** (shadcn/ui base + custom):
+
+| Component              | Mục đích                          | Notes                                         |
+| :--------------------- | :-------------------------------- | :-------------------------------------------- |
+| `<ReadinessGauge>`     | Số lớn + arc + delta              | SVG, không dùng canvas; tabular figures       |
+| `<DomainBentoCard>`    | Một ô bento cho 1 domain          | Variants: weak/balanced/strong                |
+| `<SrsRatingBar>`       | 4 nút Forgot/Hard/Good/Easy       | Keyboard 1-4, large hit area 48px             |
+| `<SquadRankRow>`       | Row leaderboard có realtime delta | Animate rank change (reduced-motion safe)     |
+| `<CoachChat>`          | Slide-in panel chat               | Streaming markdown, code block, citation chip |
+| `<MicroBreakOverlay>`  | Full-screen breathing             | Reduced-motion: static text + countdown       |
+| `<ForgettingCurve>`    | Visualisation cá nhân             | Recharts hoặc custom SVG                      |
+| `<StreakRing>`         | Ring + flame                      | Đã có `streak.store`, chỉ thêm visual         |
+| `<ActivityFeedItem>`   | Squad feed                        | Polymorphic: rank/badge/comment               |
+| `<AnnouncementBanner>` | Burnout nudge non-blocking        | aria-live=polite                              |
+
+**Tokens cần thêm**:
+
+- Spacing rhythm: `--space-bento-gap`, `--space-section`, `--space-card-pad-tight/normal/loose` (3 rhythm chứ không 1).
+- Radius: `--radius-card: 16px`, `--radius-pill: 999px`, `--radius-sharp: 4px` (editorial cần sharp).
+- Elevation: `--shadow-paper`, `--shadow-floating`, `--shadow-focus-ring` (focus indicator riêng).
+- Z-layer: explicit token cho overlay / coach panel / toast / micro-break (tránh chiến tranh z-index).
+- Motion duration: `--dur-instant 90ms`, `--dur-fast 150ms`, `--dur-base 240ms`, `--dur-slow 420ms`.
+- Data viz: `--viz-1..5` đã định nghĩa ở trên — pin vào docs để dev không tự chế màu.
+
+---
+
+## Phần B — QA Strategy
+
+### 5. Test pyramid hiện tại + target
+
+**Hiện tại**: Vitest unit (FE), Jest (BE), Playwright e2e mới sơ khai (theo recent commit `Add e2e test`). **Chưa có** visual regression, a11y automation, perf gate.
+
+| Tầng                   | Tỉ lệ target | Tooling                           | Coverage gate                        |
+| :--------------------- | :----------- | :-------------------------------- | :----------------------------------- |
+| Unit                   | ~65%         | Vitest + Testing Library          | ≥ 80% lines, ≥ 75% branches          |
+| Integration (API + DB) | ~20%         | Jest (NestJS) + supertest         | ≥ 80% controllers/services           |
+| E2E (critical flow)    | ~8%          | Playwright (Chromium + WebKit)    | 100% golden path qua trước merge     |
+| Visual regression      | ~4%          | Playwright screenshots + reg-cli  | 0 unintended diff trên 4 breakpoints |
+| Accessibility          | ~2%          | axe-core + Playwright + manual SR | 0 critical/serious axe violation     |
+| Performance            | ~1%          | Lighthouse CI                     | LCP/INP/CLS theo bảng §8             |
+
+Tổng coverage threshold (line+branch+func) tối thiểu **80%** — match `~/.claude/rules/common/testing.md`.
+
+---
+
+### 6. Test plan cho 5 feature mới
+
+#### 6.1 Question SRS Daily Review
+
+| Loại     | Cases                                                                                                                                                        |
+| :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Golden   | Login → có 12 câu due → review xong → counter = 0 → schedule cập nhật                                                                                        |
+| Edge     | (a) 0 câu due (empty state); (b) 500 câu backlog (perf + UX); (c) skip 14 ngày; (d) đổi timezone giữa session; (e) DST shift; (f) submit khi offline → queue |
+| A11y     | Keyboard 1-4 cho rating, focus visible, SR announce "Question 3 of 12", reduced-motion                                                                       |
+| Perf     | TTFB queue API < 300ms; bundle riêng cho SRS route < 60kb gz                                                                                                 |
+| Security | Không leak câu trả lời trong response trước khi user reveal; rate-limit submit; userId scope chặt                                                            |
+
+#### 6.2 Exam Readiness Dashboard
+
+| Loại     | Cases                                                                                                                                       |
+| :------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
+| Golden   | User có ≥ 100 attempts → gauge render → drill-down domain → CTA hoạt động                                                                   |
+| Edge     | (a) < 30 attempts → "need more data" state; (b) model 0% / 100% (clamp); (c) 2 cert song song không lẫn                                     |
+| A11y     | Gauge có `role="img"` + `aria-label="82% pass probability"`; bảng domain có `<caption>`; data viz colorblind-safe (palette test với Coblis) |
+| Perf     | Initial paint readiness < 2.5s; recompute server-side, cache 5 min                                                                          |
+| Security | Model output không expose raw user data của user khác trong "vs top 10%"                                                                    |
+
+#### 6.3 Behavioral Insights & Micro-break
+
+| Loại     | Cases                                                                                                                          |
+| :------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| Golden   | Detect drift → banner xuất hiện → user accept break → resume đúng câu                                                          |
+| Edge     | (a) Strict mode: timer không pause, label rõ; (b) decline 3 lần liên tiếp → tăng threshold; (c) network blip giữa break        |
+| A11y     | Banner `aria-live=polite`, không trap focus; overlay có Esc thoát; reduced-motion thay breathing animation bằng text countdown |
+| Perf     | Telemetry không block UI (sendBeacon); detection chạy worker hoặc throttled                                                    |
+| Security | Telemetry không gửi nội dung câu hỏi; chỉ metadata (timing, idx)                                                               |
+
+#### 6.4 Training Squads (Realtime)
+
+| Loại     | Cases                                                                                                                                     |
+| :------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| Golden   | Join squad → submit attempt → leaderboard update < 2s tới các thành viên khác                                                             |
+| Edge     | (a) WebSocket disconnect → fallback polling + reconcile; (b) 50 member squad (perf); (c) member rời giữa challenge; (d) timezone hiển thị |
+| A11y     | Realtime change announce qua `aria-live=polite` (không spam); rank delta có text alternative ngoài màu                                    |
+| Perf     | WS payload < 2KB/event; rate limit 1 update/s/squad/client                                                                                |
+| Security | RBAC: chỉ member thấy DM; moderation hook cho activity feed; XSS sanitisation cho explanation peer review                                 |
+
+#### 6.5 AI Coach Chat
+
+| Loại     | Cases                                                                                                                                                                            |
+| :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Golden   | User hỏi "vùng yếu" → coach trả về có cite domain + CTA tạo drill → drill được tạo                                                                                               |
+| Edge     | (a) LLM timeout > 10s → graceful retry; (b) prompt injection ("ignore previous"); (c) user dán PII; (d) rate limit; (e) streaming bị cắt giữa chừng                              |
+| A11y     | Streaming text có `aria-live=polite`; scroll lock không cản SR; markdown render giữ heading hierarchy                                                                            |
+| Perf     | Time-to-first-token < 1.2s; full response < 6s p95                                                                                                                               |
+| Security | (1) Server-side prompt template, không trust client system prompt; (2) PII redaction trước khi log; (3) Output filter (no exam answer key dump); (4) cost guardrail per user/day |
+
+---
+
+### 7. A11y roadmap (WCAG 2.2 AA)
+
+#### Top 10 a11y gap suy đoán + cách verify
+
+| #   | Gap suy đoán                                                         | Verify                                                         |
+| :-- | :------------------------------------------------------------------- | :------------------------------------------------------------- |
+| 1   | ExamPage timer chỉ thay đổi màu khi gần hết → fail SC 1.4.1          | Test colorblind sim + thêm icon + text "5:00 left"             |
+| 2   | Mark-for-review có thể là icon-only — no aria-label                  | NVDA/VoiceOver smoke test, assert accessible name              |
+| 3   | Modal exam confirm submit có thể không trap focus đúng               | Keyboard tab cycle test (Playwright)                           |
+| 4   | Flashcard flip dùng transform-only → SR không biết "đã lật"          | Inject `aria-pressed` + announce mặt sau                       |
+| 5   | Dashboard charts thiếu text alternative                              | axe-core + manual: mỗi chart có `<figcaption>` hoặc data table |
+| 6   | Color-only indicator weak/strong domain                              | Thêm icon + label, contrast 3:1 cho UI graphic                 |
+| 7   | Page transition Framer Motion không respect `prefers-reduced-motion` | Test với OS reduced motion ON, expect no transform             |
+| 8   | Touch target < 24×24 (icon nav, rating buttons)                      | Audit script đo `getBoundingClientRect`; SC 2.5.8              |
+| 9   | Form lỗi chỉ đỏ, không message bên dưới                              | RHF + Zod render `<p role="alert">`; SC 3.3.1, 3.3.3           |
+| 10  | Exam timer auto-submit không cảnh báo trước (SC 2.2.1)               | "1 phút còn lại" announce + tuỳ chọn extend (Lenient mode)     |
+
+#### A11y test automation setup
+
+```ts
+// tests/a11y/exam.spec.ts
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test("ExamPage has no critical a11y violations", async ({ page }) => {
+  await page.goto("/exam/aws-saa");
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag22aa"])
+    .analyze();
+  const critical = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(critical).toEqual([]);
+});
+```
+
+- Gate CI: 0 critical/serious axe violation trên 8 page chính.
+- Manual SR smoke (NVDA + VoiceOver) checklist cho mỗi release.
+- Storybook + `@storybook/addon-a11y` cho component-level.
+
+---
+
+### 8. Performance budgets
+
+| Page type             | LCP    | INP   | CLS  | FCP  | TBT   | JS gz            | CSS gz |
+| :-------------------- | :----- | :---- | :--- | :--- | :---- | :--------------- | :----- |
+| Auth / landing        | 2.0s   | 150ms | 0.05 | 1.2s | 150ms | 120 KB           | 25 KB  |
+| Dashboard / Readiness | 2.5s   | 200ms | 0.10 | 1.5s | 200ms | 220 KB           | 40 KB  |
+| ExamPage (focus)      | 2.0s   | 150ms | 0.05 | 1.3s | 150ms | 180 KB           | 30 KB  |
+| Squad realtime        | 2.5s   | 200ms | 0.10 | 1.5s | 200ms | 200 KB           | 35 KB  |
+| AI Coach panel        | (lazy) | 200ms | 0.05 | —    | 200ms | +60 KB on-demand | +10 KB |
+
+#### Lighthouse CI gate
+
+- Performance ≥ 85 cho route quan trọng, ≥ 90 cho landing.
+- Accessibility ≥ 95 mọi route.
+- Best practices ≥ 95.
+- Block PR nếu fail 2 lần liên tiếp.
+- Bundle analyzer chạy mỗi PR, comment diff size.
+
+#### Tactic chính
+
+- Code-split AI Coach + Recharts + Framer Motion.
+- Preload font 1 weight; rest swap.
+- IntersectionObserver cho dashboard widgets — không mount hết một lúc.
+- WebSocket lazy connect (chỉ khi vào /squad).
+
+---
+
+### 9. Visual regression strategy
+
+**Tool**: Playwright screenshots + `toHaveScreenshot()` built-in (đủ dùng, không cần Percy giai đoạn này).
+
+**Pages cần screenshot**:
+
+| Page              | Breakpoints          | States                                            |
+| :---------------- | :------------------- | :------------------------------------------------ |
+| Dashboard         | 320, 768, 1024, 1440 | Empty / Active / Lots-of-data                     |
+| Readiness         | 768, 1440            | < 30 attempts / Normal / Ready ≥ 80%              |
+| ExamPage          | 768, 1440            | Intro / In-progress / Marked / Last 5min / Result |
+| FlashcardStudy    | 320, 1024            | Front / Back / Empty                              |
+| Squad Hub         | 768, 1440            | Empty / Active / Realtime delta                   |
+| AI Coach panel    | 320, 1024            | Empty / Streaming / Error                         |
+| TrapQuestionsPage | 768, 1440            | Default                                           |
+| Leaderboard       | 768, 1440            | Default                                           |
+
+Mỗi state × **2 themes** (light + dark) × Chromium + WebKit. Tổng ~ 250 baseline.
+
+**Quy ước**:
+
+- Mock thời gian (`page.clock.install()`), seed data deterministic.
+- Disable animation trong test (`prefers-reduced-motion: reduce` + `animation-duration: 0`).
+- Tolerance pixel 0.1%, max diff pixels 100.
+- Baseline lưu trong `tests/visual/__screenshots__/`, review qua PR review (yêu cầu reviewer xác nhận).
+
+---
+
+### 10. Bug triage & quality gates
+
+#### Severity & SLA
+
+| Severity      | Định nghĩa                                                | Ví dụ                                | SLA fix    | Release block            |
+| :------------ | :-------------------------------------------------------- | :----------------------------------- | :--------- | :----------------------- |
+| S0 — Critical | Mất dữ liệu, lộ data, exam không submit được, auth bypass | Submit attempt mất, JWT leak         | < 4h       | Có (hotfix)              |
+| S1 — High     | Feature chính fail cho > 10% user                         | Timer reset random, SRS schedule sai | < 24h      | Có                       |
+| S2 — Medium   | Feature phụ fail / a11y serious                           | Squad feed không update realtime     | < 1 tuần   | Soft (release with note) |
+| S3 — Low      | Cosmetic, edge rare                                       | Spacing lệch ở 320px Squad card      | < 1 sprint | Không                    |
+
+#### Definition of Done (QA view)
+
+- [ ] Unit + integration coverage ≥ 80% file mới.
+- [ ] E2E golden path xanh trên Chromium + WebKit.
+- [ ] 0 critical/serious axe violation trên route mới.
+- [ ] Visual regression baseline approved.
+- [ ] Lighthouse perf không regress > 5 điểm vs main.
+- [ ] Bundle size không vượt budget (§8).
+- [ ] Manual SR smoke 1 lần (NVDA hoặc VoiceOver).
+- [ ] Reduced-motion verified.
+- [ ] Security checklist: input validation, RBAC, rate-limit, secret scan clean.
+- [ ] No console.log / debug code.
+- [ ] Docs cập nhật (component story, API contract).
+- [ ] Feature flag mặc định OFF khi merge, bật theo cohort.
+
+#### Release criteria
+
+- All S0/S1 closed.
+- ≤ 3 S2 open (with mitigation note).
+- Canary 5% traffic 24h không tăng error rate > 0.5%.
+- Rollback plan ghi rõ trong PR description.
+
+---
+
+> **Nguyên tắc tổng**: Brain Gym phải cho user cảm giác "tôi đang khoẻ lên mỗi ngày" — nên UX không được template, QA không được lơi. Mỗi feature mới đi qua đủ pyramid + a11y gate + perf budget trước khi gọi là Done.


### PR DESCRIPTION
## Summary

Adds the full team-planning document suite for CertGym Q2–Q4 2026 under `docs/team-planning/`:

- **[00-master-roadmap.md](docs/team-planning/00-master-roadmap.md)** — Synthesised view across all 4 roles; sprint 1–3 task breakdown, risk heatmap (10 risks), OKR Q3 targets, key decisions (D1–D6) pending PO sign-off by 2026-05-05
- **[01-product-owner.md](docs/team-planning/01-product-owner.md)** — 4 personas (Linh, Khoa, Mai, Hùng), 8 epics (E1–E8), 22 user stories (US-001…US-022) with Gherkin ACs, release plan v1.1→v2.0, 5 OKRs Q3
- **[02-scrum-master.md](docs/team-planning/02-scrum-master.md)** — Team 6 dev / 5.5 FTE, velocity 40 SP/sprint, DoR/DoD checklists, 10-risk register, sprint 1–3 detailed plans, 10 process improvements
- **[03-tech-lead.md](docs/team-planning/03-tech-lead.md)** — Current-state assessment (strengths/weaknesses), 12-month target architecture, 12 RFCs (RFC-001…RFC-012), 6 new schema models, infra roadmap, top-10 tech debt, 7 spikes
- **[04-ux-qa-lead.md](docs/team-planning/04-ux-qa-lead.md)** — Editorial + Dark luxury design direction, 10 new UI components, test pyramid, 10 a11y gaps (WCAG 2.2 AA), perf budget, 250 visual regression baselines target

## Context

Sprint 1 ("Stabilize the Gym") is complete — CI is green, SRS schema is migrated, flashcard review API is live, CSP nonces are wired. These docs formalise the shared roadmap agreement before Sprint 2 ("First Learner Loop") kicks off.

## Reviewer notes

- `docs/team-planning/` is purely documentation — no code changes
- The 5 files are referenced as "living docs"; SM owns structure, PO owns backlog, Tech Lead owns RFC list
- Key decisions in `00-master-roadmap.md §4` (D1–D6) need PO confirmation by 2026-05-05

## Test plan

- [ ] All 5 markdown files render correctly on GitHub
- [ ] Internal links between files resolve (e.g. `[01-product-owner.md](01-product-owner.md)`)
- [ ] No sensitive data (secrets, PII) introduced