### PR TITLE
Add organization management code

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -432,6 +432,133 @@ export class AdminController {
     return result;
   }
 
+  // ─── Organization Management ──────────────────────────────────────────────────
+
+  @Get('organizations')
+  @ApiOperation({ summary: 'List all organizations (admin)' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'search', required: false })
+  async getOrganizations(
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('search') search?: string,
+  ) {
+    return this.adminService.getOrganizations({
+      page: page ? parseInt(page) : undefined,
+      limit: limit ? parseInt(limit) : undefined,
+      search,
+    });
+  }
+
+  @Get('organizations/:orgId')
+  @ApiOperation({ summary: 'Get organization detail (admin)' })
+  async getOrganization(@Param('orgId') orgId: string) {
+    return this.adminService.getOrganization(orgId);
+  }
+
+  @Patch('organizations/:orgId')
+  @ApiOperation({ summary: 'Update organization (admin)' })
+  async updateOrganization(
+    @Req() req: any,
+    @Param('orgId') orgId: string,
+    @Body()
+    body: {
+      name?: string;
+      description?: string;
+      industry?: string;
+      logoUrl?: string;
+      accentColor?: string;
+      maxSeats?: number;
+      isActive?: boolean;
+    },
+  ) {
+    const adminId = req.user.sub || req.user.id;
+    const result = await this.adminService.updateOrganization(orgId, body);
+    await this.auditService.log({
+      userId: adminId,
+      action: 'UPDATE_ORGANIZATION',
+      targetType: 'Organization',
+      targetId: orgId,
+      metadata: body,
+    });
+    return result;
+  }
+
+  @Delete('organizations/:orgId')
+  @ApiOperation({ summary: 'Delete organization (admin)' })
+  async deleteOrganization(
+    @Req() req: any,
+    @Param('orgId') orgId: string,
+  ) {
+    const adminId = req.user.sub || req.user.id;
+    const result = await this.adminService.deleteOrganization(orgId);
+    await this.auditService.log({
+      userId: adminId,
+      action: 'DELETE_ORGANIZATION',
+      targetType: 'Organization',
+      targetId: orgId,
+    });
+    return result;
+  }
+
+  @Get('organizations/:orgId/members')
+  @ApiOperation({ summary: 'List members of an organization (admin)' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  async getOrgMembers(
+    @Param('orgId') orgId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.adminService.getOrgMembers(orgId, {
+      page: page ? parseInt(page) : undefined,
+      limit: limit ? parseInt(limit) : undefined,
+    });
+  }
+
+  @Patch('organizations/:orgId/members/:userId')
+  @ApiOperation({ summary: 'Update member role in organization (admin)' })
+  async updateOrgMemberRole(
+    @Req() req: any,
+    @Param('orgId') orgId: string,
+    @Param('userId') userId: string,
+    @Body() body: { role: string },
+  ) {
+    const adminId = req.user.sub || req.user.id;
+    const result = await this.adminService.updateOrgMemberRole(
+      orgId,
+      userId,
+      body.role,
+    );
+    await this.auditService.log({
+      userId: adminId,
+      action: 'UPDATE_ORG_MEMBER_ROLE',
+      targetType: 'OrgMember',
+      targetId: `${orgId}/${userId}`,
+      metadata: { role: body.role },
+    });
+    return result;
+  }
+
+  @Delete('organizations/:orgId/members/:userId')
+  @ApiOperation({ summary: 'Remove member from organization (admin)' })
+  async removeOrgMember(
+    @Req() req: any,
+    @Param('orgId') orgId: string,
+    @Param('userId') userId: string,
+  ) {
+    const adminId = req.user.sub || req.user.id;
+    const result = await this.adminService.removeOrgMember(orgId, userId);
+    await this.auditService.log({
+      userId: adminId,
+      action: 'REMOVE_ORG_MEMBER',
+      targetType: 'OrgMember',
+      targetId: `${orgId}/${userId}`,
+    });
+    return result;
+  }
+
   // ─── Data Export ─────────────────────────────────────────────────────────────
 
   @Get('export/users')

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -25,6 +25,9 @@ export class AdminService {
       totalProviders,
       totalCertifications,
       aiGenerationStats,
+      totalOrgs,
+      newOrgs7d,
+      newOrgs30d,
     ] = await Promise.all([
       this.prisma.user.count(),
       this.prisma.user.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
@@ -43,6 +46,9 @@ export class AdminService {
         by: ['status'],
         _count: true,
       }),
+      this.prisma.organization.count(),
+      this.prisma.organization.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
+      this.prisma.organization.count({ where: { createdAt: { gte: thirtyDaysAgo } } }),
     ]);
 
     const statusMap: Record<string, number> = {};
@@ -78,6 +84,11 @@ export class AdminService {
         processing: aiStatsMap['PROCESSING'] || 0,
         completed: aiStatsMap['COMPLETED'] || 0,
         failed: aiStatsMap['FAILED'] || 0,
+      },
+      organizations: {
+        total: totalOrgs,
+        newLast7d: newOrgs7d,
+        newLast30d: newOrgs30d,
       },
     };
   }
@@ -354,6 +365,188 @@ export class AdminService {
       data: { plan: plan as any },
       select: { id: true, email: true, plan: true },
     });
+  }
+
+  // ─── Organization Management ──────────────────────────────────────────────────
+
+  async getOrganizations(params: {
+    page?: number;
+    limit?: number;
+    search?: string;
+  }) {
+    const { page = 1, limit = 20, search } = params;
+    const where: any = {};
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { slug: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    const [data, total] = await Promise.all([
+      this.prisma.organization.findMany({
+        where,
+        include: {
+          members: {
+            where: { role: 'OWNER' as any },
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  displayName: true,
+                  email: true,
+                  plan: true,
+                },
+              },
+            },
+            take: 1,
+          },
+          _count: { select: { members: { where: { isActive: true } } } },
+        },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.organization.count({ where }),
+    ]);
+
+    return {
+      data: data.map((org) => ({
+        ...org,
+        owner: org.members[0]?.user || null,
+        memberCount: org._count.members,
+        members: undefined,
+        _count: undefined,
+      })),
+      meta: { total, page, lastPage: Math.ceil(total / limit) },
+    };
+  }
+
+  async getOrganization(orgId: string) {
+    const org = await this.prisma.organization.findUnique({
+      where: { id: orgId },
+      include: {
+        members: {
+          where: { role: 'OWNER' as any },
+          include: {
+            user: {
+              select: {
+                id: true,
+                displayName: true,
+                email: true,
+                plan: true,
+              },
+            },
+          },
+          take: 1,
+        },
+        _count: { select: { members: { where: { isActive: true } } } },
+      },
+    });
+    if (!org) throw new NotFoundException('Organization not found');
+    return {
+      ...org,
+      owner: org.members[0]?.user || null,
+      memberCount: org._count.members,
+      members: undefined,
+      _count: undefined,
+    };
+  }
+
+  async updateOrganization(
+    orgId: string,
+    data: {
+      name?: string;
+      description?: string;
+      industry?: string;
+      logoUrl?: string;
+      accentColor?: string;
+      maxSeats?: number;
+      isActive?: boolean;
+    },
+  ) {
+    const org = await this.prisma.organization.findUnique({
+      where: { id: orgId },
+    });
+    if (!org) throw new NotFoundException('Organization not found');
+    return this.prisma.organization.update({
+      where: { id: orgId },
+      data,
+    });
+  }
+
+  async deleteOrganization(orgId: string) {
+    const org = await this.prisma.organization.findUnique({
+      where: { id: orgId },
+    });
+    if (!org) throw new NotFoundException('Organization not found');
+    await this.prisma.organization.delete({ where: { id: orgId } });
+    return { deleted: true, orgId };
+  }
+
+  async getOrgMembers(
+    orgId: string,
+    params: { page?: number; limit?: number },
+  ) {
+    const { page = 1, limit = 20 } = params;
+    const org = await this.prisma.organization.findUnique({
+      where: { id: orgId },
+    });
+    if (!org) throw new NotFoundException('Organization not found');
+
+    const where = { orgId, isActive: true };
+    const [data, total] = await Promise.all([
+      this.prisma.orgMember.findMany({
+        where,
+        include: {
+          user: {
+            select: {
+              id: true,
+              displayName: true,
+              email: true,
+              plan: true,
+              role: true,
+            },
+          },
+        },
+        orderBy: { joinedAt: 'asc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.orgMember.count({ where }),
+    ]);
+
+    return {
+      data,
+      meta: { total, page, lastPage: Math.ceil(total / limit) },
+    };
+  }
+
+  async updateOrgMemberRole(
+    orgId: string,
+    userId: string,
+    role: string,
+  ) {
+    const member = await this.prisma.orgMember.findUnique({
+      where: { orgId_userId: { orgId, userId } },
+    });
+    if (!member) throw new NotFoundException('Member not found');
+    return this.prisma.orgMember.update({
+      where: { id: member.id },
+      data: { role: role as any },
+    });
+  }
+
+  async removeOrgMember(orgId: string, userId: string) {
+    const member = await this.prisma.orgMember.findUnique({
+      where: { orgId_userId: { orgId, userId } },
+    });
+    if (!member) throw new NotFoundException('Member not found');
+    await this.prisma.orgMember.update({
+      where: { id: member.id },
+      data: { isActive: false },
+    });
+    return { removed: true, userId };
   }
 
   // ─── CSV Export ───────────────────────────────────────────────────────────────

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -118,6 +118,7 @@ export class AuthService {
         email: user.email,
         displayName: user.displayName,
         role: user.role,
+        plan: user.plan,
         orgMemberships,
       },
     };

--- a/backend/src/auth/dto/token-response.dto.ts
+++ b/backend/src/auth/dto/token-response.dto.ts
@@ -13,6 +13,7 @@ export class TokenResponseDto {
     email: string;
     displayName: string;
     role: string;
+    plan: string;
     orgMemberships: {
       orgId: string;
       slug: string;

--- a/backend/src/organizations/organizations.service.ts
+++ b/backend/src/organizations/organizations.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { MailService } from '../mail/mail.service';
@@ -11,7 +12,7 @@ import { InviteMemberDto, BulkInviteMemberDto } from './dto/invite-member.dto';
 import { CreateJoinLinkDto } from './dto/create-join-link.dto';
 import { CreateGroupDto, UpdateGroupDto } from './dto/create-group.dto';
 import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
-import { OrgRole, OrgInviteStatus } from '@prisma/client';
+import { OrgRole, OrgInviteStatus, UserRole, UserPlan } from '@prisma/client';
 import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
@@ -48,6 +49,34 @@ export class OrganizationsService {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
     if (!user) throw new NotFoundException('User not found');
 
+    // Plan enforcement (Admin bypasses all restrictions)
+    if (user.role !== UserRole.ADMIN) {
+      if (user.plan === UserPlan.FREE) {
+        throw new ForbiddenException(
+          'Upgrade to Premium or Enterprise to create an organization.',
+        );
+      }
+      const ownedCount = await this.prisma.orgMember.count({
+        where: { userId, role: OrgRole.OWNER, isActive: true },
+      });
+      const maxOrgs = user.plan === UserPlan.PREMIUM ? 1 : 3;
+      if (ownedCount >= maxOrgs) {
+        throw new ForbiddenException(
+          user.plan === UserPlan.PREMIUM
+            ? 'Premium plan allows 1 organization. Upgrade to Enterprise for more.'
+            : 'You have reached the maximum number of organizations for your plan.',
+        );
+      }
+    }
+
+    // Set maxSeats based on plan
+    const maxSeats =
+      user.role === UserRole.ADMIN
+        ? 100
+        : user.plan === UserPlan.ENTERPRISE
+          ? 50
+          : 10;
+
     const slug = this.slugify(dto.name);
 
     return this.prisma.$transaction(async (tx) => {
@@ -59,6 +88,7 @@ export class OrganizationsService {
           industry: dto.industry,
           logoUrl: dto.logoUrl,
           accentColor: dto.accentColor,
+          maxSeats,
         },
       });
 
@@ -327,6 +357,15 @@ export class OrganizationsService {
   }
 
   async joinViaLink(userId: string, code: string) {
+    // Plan check: FREE users cannot use join links
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+    if (user.plan === UserPlan.FREE && user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        'Free plan users can only join organizations via email invitation.',
+      );
+    }
+
     const link = await this.prisma.orgJoinLink.findUnique({
       where: { code },
       include: { organization: true },

--- a/backend/test/e2e-helpers.ts
+++ b/backend/test/e2e-helpers.ts
@@ -2,13 +2,13 @@ import { INestApplication } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../src/prisma/prisma.service';
-import { UserRole, OrgRole } from '@prisma/client';
+import { UserRole, OrgRole, UserPlan } from '@prisma/client';
 
 // ─── User helpers ─────────────────────────────────────────────────────────────
 
 export async function createTestUser(
   prisma: PrismaService,
-  opts: { email: string; displayName: string; role?: UserRole },
+  opts: { email: string; displayName: string; role?: UserRole; plan?: UserPlan },
 ) {
   return prisma.user.create({
     data: {
@@ -16,6 +16,7 @@ export async function createTestUser(
       passwordHash: 'e2e-test-hash',
       displayName: opts.displayName,
       role: opts.role ?? UserRole.LEARNER,
+      plan: opts.plan ?? UserPlan.FREE,
     },
   });
 }

--- a/backend/test/organizations.e2e-spec.ts
+++ b/backend/test/organizations.e2e-spec.ts
@@ -3,7 +3,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/prisma/prisma.service';
-import { OrgRole } from '@prisma/client';
+import { OrgRole, UserPlan } from '@prisma/client';
 import {
   createTestUser,
   generateToken,
@@ -47,6 +47,7 @@ describe('Organizations (e2e)', () => {
     const owner = await createTestUser(prisma, {
       email: `${EMAIL_PREFIX}owner@test.com`,
       displayName: 'E2E Org Owner',
+      plan: UserPlan.ENTERPRISE,
     });
     ownerId = owner.id;
     ownerToken = generateToken(app, owner);
@@ -68,6 +69,7 @@ describe('Organizations (e2e)', () => {
     const joiner = await createTestUser(prisma, {
       email: `${EMAIL_PREFIX}joiner@test.com`,
       displayName: 'E2E Org Joiner',
+      plan: UserPlan.PREMIUM,
     });
     joinerId = joiner.id;
     joinerToken = generateToken(app, joiner);

--- a/docs/organization.md
+++ b/docs/organization.md
@@ -13,13 +13,197 @@
 > **Email**: Using **Mailtrap** (https://mailtrap.io/) for testing. Will switch to Gmail for production later.
 
 > [!NOTE]
-> **Billing**: No billing/payment integration. Enterprise plan is **admin-managed** — admin manually upgrades users from free to enterprise plan via the admin panel.
+> **Billing**: No billing/payment integration. Plans are **admin-managed only** — admin manually sets a user's plan (`FREE`, `PREMIUM`, `ENTERPRISE`) via `PATCH /admin/users/:userId/plan`. There is no self-service upgrade. See [Plan-Based Access Control](#plan-based-access-control) section for full details.
 
 > [!NOTE]
 > **Candidate Exam**: Separate page (`/assess/:token`), no login required. Link is time-limited and expires after admin-configured duration.
 
 > [!NOTE]
 > **Testing**: All tests run inside **Docker** containers, not on host environment.
+
+---
+
+## Plan-Based Access Control
+
+This section specifies how the `UserPlan` (`FREE`, `PREMIUM`, `ENTERPRISE`) gates access to organization features.
+
+> [!IMPORTANT]
+> **Plan management is admin-only.** There is no self-service upgrade flow. The system admin changes a user's plan via the admin panel (`PATCH /admin/users/:userId/plan`). This endpoint already exists and is audit-logged. No billing or payment integration is planned at this stage.
+
+---
+
+### Plan Management Rules
+
+| Rule | Detail |
+|:-----|:-------|
+| Who can change a user's plan | Only `UserRole = ADMIN` via `PATCH /admin/users/:userId/plan` |
+| Default plan on registration | `FREE` |
+| Available plans | `FREE`, `PREMIUM`, `ENTERPRISE` |
+| Self-service upgrade | ❌ Not supported (future scope) |
+| Plan visible to user | Yes — included in login/refresh response |
+| Plan stored in | `users.plan` column (enum `UserPlan`) |
+
+---
+
+### Plan Permissions Matrix
+
+| Capability | FREE | PREMIUM | ENTERPRISE | ADMIN (any plan) |
+|:-----------|:----:|:-------:|:----------:|:----------------:|
+| **Create organization** | ❌ | ✅ (max 1) | ✅ (max 3) | ✅ (unlimited) |
+| **Join org via email invite** | ✅ | ✅ | ✅ | ✅ |
+| **Join org via join link** | ❌ | ✅ | ✅ | ✅ |
+| **View org menu in navbar** | Only if member | ✅ Always | ✅ Always | ✅ Always |
+| **Max seats per org (as Owner)** | — | 10 | 50 | 100 |
+| **Access org analytics** | ❌ | ✅ | ✅ | ✅ |
+| **Create assessments** | ❌ | ❌ | ✅ | ✅ |
+| **Candidate assessments (external)** | ❌ | ❌ | ✅ | ✅ |
+
+> [!NOTE]
+> The "max organizations" limit refers to how many orgs a user can **own** (OrgRole = OWNER). They can still be a **member** of additional orgs created by others.
+
+> [!NOTE]
+> Free users can **only** join an organization if they receive an email invitation from an org OWNER/ADMIN. They cannot use join links or create their own organizations.
+
+---
+
+### Organization Creation — Plan Enforcement
+
+When a user calls `POST /organizations`, the system SHALL check:
+
+1. **User's `role`** — If `UserRole = ADMIN`, bypass all plan restrictions (always allow).
+2. **User's `plan`** — Enforce limits per the matrix above.
+3. **Owned org count** — Count orgs where user has `OrgRole = OWNER`.
+
+| Plan | Behavior |
+|:-----|:---------|
+| `FREE` | Return `403`: _"Upgrade to Premium or Enterprise to create an organization."_ |
+| `PREMIUM` | Allow if owned orgs < 1. Otherwise `403`: _"Premium plan allows 1 organization. Upgrade to Enterprise for more."_ |
+| `ENTERPRISE` | Allow if owned orgs < 3. Otherwise `403`: _"You have reached the maximum number of organizations for your plan."_ |
+| `ADMIN` | Always allow. No limit. |
+
+The `maxSeats` for a new org is set based on the creator's plan:
+
+| Creator Plan | Default `maxSeats` |
+|:-------------|:-------------------|
+| `PREMIUM` | 10 |
+| `ENTERPRISE` | 50 |
+| `ADMIN` | 100 |
+
+---
+
+### Organization Joining — Plan Enforcement
+
+**Join via Email Invite** (`POST /organizations/accept-invite/:token`):
+- All plans including `FREE` are allowed. No change to current behavior.
+
+**Join via Link** (`GET /organizations/join/:code`):
+- `FREE` users → `403`: _"Free plan users can only join organizations via email invitation."_
+- `PREMIUM`, `ENTERPRISE`, `ADMIN` → Allowed (current behavior).
+
+Seat limits are still enforced regardless of the joiner's plan.
+
+---
+
+### Plan Info in Auth Response
+
+The login/refresh response SHALL include `plan` so the frontend can render plan-aware UI:
+
+```json
+{
+  "accessToken": "...",
+  "refreshToken": "...",
+  "user": {
+    "id": "...",
+    "email": "...",
+    "displayName": "...",
+    "role": "LEARNER",
+    "plan": "FREE",
+    "orgMemberships": [...]
+  }
+}
+```
+
+Changes required:
+- [auth.service.ts](file:///Users/thanhpt/Projects/brain-gym/backend/src/auth/auth.service.ts) — add `plan: user.plan` to response
+- [auth.store.ts](file:///Users/thanhpt/Projects/brain-gym/src/stores/auth.store.ts) — add `plan: string` to `User` interface
+
+---
+
+### Admin Organization Management
+
+New admin endpoints for platform-wide org management (added to existing `AdminController`):
+
+| Method | Route | Description |
+|:-------|:------|:------------|
+| `GET` | `/admin/organizations` | List all orgs (paginated, with owner info & member count) |
+| `GET` | `/admin/organizations/:orgId` | Get org detail with members summary |
+| `PATCH` | `/admin/organizations/:orgId` | Update any org (name, maxSeats, isActive, etc.) |
+| `DELETE` | `/admin/organizations/:orgId` | Delete any org (cascade) |
+| `GET` | `/admin/organizations/:orgId/members` | List members of any org |
+| `PATCH` | `/admin/organizations/:orgId/members/:userId` | Change member role in any org |
+| `DELETE` | `/admin/organizations/:orgId/members/:userId` | Remove member from any org |
+
+All endpoints protected by `JwtAuthGuard` + `RolesGuard(ADMIN)`. All actions audit-logged.
+
+The admin dashboard (`GET /admin/dashboard`) SHALL also include:
+- Total organizations count
+- Organizations created in last 7d / 30d
+
+---
+
+### Navigation Visibility Rules
+
+**Navbar & BottomTabBar** — "Organization" menu item visibility:
+
+| User State | Visible? |
+|:-----------|:---------|
+| Not authenticated | ❌ |
+| FREE, no memberships | ❌ |
+| FREE, has membership(s) | ✅ → `/org` |
+| PREMIUM, no memberships | ✅ → `/org` (shows "Create" CTA) |
+| ENTERPRISE, no memberships | ✅ → `/org` (shows "Create" CTA) |
+| ADMIN | ✅ Always |
+
+**OrgSelector Page** (`/org`) — conditional content:
+
+| Condition | "Create" Button | Message |
+|:----------|:---------------:|:--------|
+| FREE, no orgs | ❌ | _"Ask your team admin to send you an invite."_ |
+| FREE, has orgs | ❌ | _(show org list only)_ |
+| PREMIUM, can create | ✅ | _(show org list + create button)_ |
+| PREMIUM, limit reached | ❌ | _"Upgrade to Enterprise for more orgs."_ |
+| ENTERPRISE, can create | ✅ | _(show org list + create button)_ |
+| ENTERPRISE, limit reached | ❌ | _"Maximum organizations reached."_ |
+| ADMIN | ✅ | _(always show)_ |
+
+---
+
+### Plan Downgrade Behavior
+
+If an admin downgrades a user's plan (e.g., PREMIUM → FREE) while they own an organization:
+- Existing organizations are **kept as-is** (grandfathered).
+- The user can continue to manage their existing org(s).
+- The user **cannot** create new organizations until their plan is upgraded again.
+- No automatic deactivation or ownership transfer occurs.
+
+---
+
+### Backwards Compatibility
+
+- Existing organizations created before this feature continue to function normally.
+- Existing users default to `plan = FREE`. If they already own orgs, those orgs are grandfathered.
+- The `UserPlan` enum and `User.plan` column already exist — no schema migration needed.
+
+---
+
+### Error Messages
+
+| Scenario | HTTP | Message |
+|:---------|:----:|:--------|
+| FREE user creates org | 403 | _"Upgrade to Premium or Enterprise plan to create an organization."_ |
+| PREMIUM user exceeds limit | 403 | _"Your Premium plan allows 1 organization. Upgrade to Enterprise for more."_ |
+| ENTERPRISE user exceeds limit | 403 | _"You have reached the maximum number of organizations for your plan (3)."_ |
+| FREE user tries join link | 403 | _"Free plan users can only join organizations via email invitation."_ |
 
 ---
 
@@ -178,7 +362,7 @@ backend/src/common/decorators/org-roles.decorator.ts
 
 | Method | Route | Guard | Description |
 |:-------|:------|:------|:------------|
-| `POST` | `/organizations` | JWT | Create organization (caller becomes OWNER) |
+| `POST` | `/organizations` | JWT + **PlanGuard** | Create organization — **requires PREMIUM/ENTERPRISE plan or ADMIN role** (see [Plan-Based Access Control](#plan-based-access-control)) |
 | `GET` | `/organizations/my` | JWT | List orgs the user belongs to |
 | `GET` | `/organizations/:orgId` | JWT + OrgRole(ANY) | Get org details |
 | `PATCH` | `/organizations/:orgId` | JWT + OrgRole(OWNER, ADMIN) | Update org settings |
@@ -189,18 +373,18 @@ backend/src/common/decorators/org-roles.decorator.ts
 | `PATCH` | `/organizations/:orgId/members/:userId` | JWT + OrgRole(OWNER, ADMIN) | Change member role |
 | `DELETE` | `/organizations/:orgId/members/:userId` | JWT + OrgRole(OWNER, ADMIN) | Remove member |
 | `POST` | `/organizations/:orgId/join-links` | JWT + OrgRole(OWNER, ADMIN) | Generate join link |
-| `GET` | `/organizations/join/:code` | Public | Join org via link |
+| `GET` | `/organizations/join/:code` | JWT + **PlanGuard** | Join org via link — **FREE users blocked** (see [Plan-Based Access Control](#plan-based-access-control)) |
 | `POST` | `/organizations/:orgId/groups` | JWT + OrgRole(OWNER, ADMIN, MANAGER) | Create group |
 | `GET` | `/organizations/:orgId/groups` | JWT + OrgRole(ANY) | List groups |
 | `PATCH` | `/organizations/:orgId/groups/:groupId` | JWT + OrgRole(OWNER, ADMIN, MANAGER) | Update group |
-| `POST` | `/organizations/accept-invite/:token` | JWT | Accept email invitation |
+| `POST` | `/organizations/accept-invite/:token` | JWT | Accept email invitation (all plans allowed) |
 
 **Service logic highlights:**
 
-- `create()`: Creates org + creates `OrgMember` with role=OWNER in a `$transaction`
+- `create()`: **Checks user plan + owned org count** → Creates org + creates `OrgMember` with role=OWNER in a `$transaction`. Sets `maxSeats` based on plan.
 - `invite()`: Generates UUID token, creates `OrgInvite`, calls `MailService.sendOrgInvite()`
-- `acceptInvite()`: Validates token, checks expiry, creates `OrgMember`, updates invite status
-- `joinViaLink()`: Validates code, checks usage limits and expiry, creates `OrgMember`
+- `acceptInvite()`: Validates token, checks expiry, creates `OrgMember`, updates invite status — **no plan restriction**
+- `joinViaLink()`: **Checks user plan (FREE blocked)** → validates code, checks usage limits and expiry, creates `OrgMember`
 - Seat enforcement: Before adding members, check `count(org_members) < org.maxSeats`
 
 ---
@@ -558,31 +742,130 @@ Analytics are computed by querying `ExamAttempt` records for users who are `OrgM
 
 ---
 
-### Phase 6: Integration & Polish
+### Phase 6: Plan Enforcement, Admin Org Management & Polish
 
-Final cross-cutting enhancements.
+Plan-based access control, admin org management, and cross-cutting frontend enhancements.
 
 ---
 
+#### [NEW] Plan guard / service logic
+
+Add plan enforcement to `OrganizationsService`:
+
+```typescript
+// In organizations.service.ts — create() method
+async create(userId: string, dto: CreateOrgDto) {
+  const user = await this.prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new NotFoundException('User not found');
+
+  // Admin bypasses all plan restrictions
+  if (user.role !== UserRole.ADMIN) {
+    if (user.plan === UserPlan.FREE) {
+      throw new ForbiddenException('Upgrade to Premium or Enterprise to create an organization.');
+    }
+    const ownedCount = await this.prisma.orgMember.count({
+      where: { userId, role: OrgRole.OWNER, isActive: true },
+    });
+    const maxOrgs = user.plan === UserPlan.PREMIUM ? 1 : 3;
+    if (ownedCount >= maxOrgs) {
+      throw new ForbiddenException(
+        user.plan === UserPlan.PREMIUM
+          ? 'Premium plan allows 1 organization. Upgrade to Enterprise for more.'
+          : 'You have reached the maximum number of organizations for your plan.',
+      );
+    }
+  }
+  // ... existing creation logic ...
+}
+```
+
+Similar check in `joinViaLink()` to block FREE users.
+
+---
+
+#### [NEW] Admin organization management endpoints
+
+Add to existing `AdminController` / `AdminService`:
+
+| Method | Route | Description |
+|:-------|:------|:------------|
+| `GET` | `/admin/organizations` | List all orgs (paginated) |
+| `GET` | `/admin/organizations/:orgId` | Get org detail |
+| `PATCH` | `/admin/organizations/:orgId` | Update any org |
+| `DELETE` | `/admin/organizations/:orgId` | Delete any org |
+| `GET` | `/admin/organizations/:orgId/members` | List members |
+| `PATCH` | `/admin/organizations/:orgId/members/:userId` | Change member role |
+| `DELETE` | `/admin/organizations/:orgId/members/:userId` | Remove member |
+
+All protected by `@Roles(UserRole.ADMIN)` and audit-logged.
+
+---
+
+#### [MODIFY] [auth.service.ts](file:///Users/thanhpt/Projects/brain-gym/backend/src/auth/auth.service.ts)
+
+Include `plan` and org membership info in login/refresh response:
+
+```diff
+  return {
+    accessToken,
+    refreshToken,
+    user: {
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+      role: user.role,
++     plan: user.plan,
+      orgMemberships,
+    },
+  };
+```
+
+#### [MODIFY] [auth.store.ts](file:///Users/thanhpt/Projects/brain-gym/src/stores/auth.store.ts)
+
+Add `plan: string` to `User` interface:
+
+```diff
+  interface User {
+    id: string;
+    email: string;
+    displayName: string;
+    role: string;
++   plan: string;
+    orgMemberships: OrgMembership[];
+  }
+```
+
 #### [MODIFY] [Navbar.tsx](file:///Users/thanhpt/Projects/brain-gym/src/components/Navbar.tsx)
 
-Add "My Organization" link in user dropdown menu (visible when user has org memberships).
+Update organization menu visibility to be plan-aware:
+
+```diff
+- const showOrg = orgMemberships.length > 0 || user?.role === 'ADMIN';
++ const showOrg = orgMemberships.length > 0
++   || user?.plan === 'PREMIUM'
++   || user?.plan === 'ENTERPRISE'
++   || user?.role === 'ADMIN';
+```
 
 #### [MODIFY] [BottomTabBar.tsx](file:///Users/thanhpt/Projects/brain-gym/src/components/BottomTabBar.tsx)
 
-Conditionally show an "Org" tab when the user is part of an organization.
+Same plan-aware visibility logic as Navbar.
+
+#### [MODIFY] [OrgSelector.tsx](file:///Users/thanhpt/Projects/brain-gym/src/pages/org/OrgSelector.tsx)
+
+Update to show plan-appropriate messaging:
+- FREE with no orgs → "Ask your team admin to invite you" (no Create button)
+- FREE with orgs → Show org list only (no Create button)
+- PREMIUM/ENTERPRISE → Show Create button based on owned org limits
+- ADMIN → Always show Create button
 
 #### [MODIFY] [Dashboard.tsx](file:///Users/thanhpt/Projects/brain-gym/src/pages/Dashboard.tsx)
 
 Add "Organization" card/section showing pending assignments, mandatory exams, and quick links to org dashboard.
 
-#### [MODIFY] [auth.store.ts](file:///Users/thanhpt/Projects/brain-gym/src/stores/auth.store.ts)
+#### [MODIFY] Admin page (`/admin`)
 
-Enhance user object to include `orgMemberships` summary (org name, slug, role) — fetched on login/refresh.
-
-#### [MODIFY] [auth.service.ts](file:///Users/thanhpt/Projects/brain-gym/backend/src/auth/auth.service.ts)
-
-Include org membership info in JWT payload or in login response so frontend knows user's org context.
+Add "Organizations" tab showing all orgs with management actions (view, edit, deactivate, delete).
 
 ---
 
@@ -685,13 +968,20 @@ src/
 > **Q1: Email provider** — Should I integrate a real email provider (SendGrid/Resend/SES) now, or keep the console-log stub? The candidate assessment feature heavily relies on email delivery.
 
 > [!IMPORTANT]
-> **Q2: Billing/Payments** — Should I scaffold Stripe integration for seat-based billing, or treat Enterprise accounts as manually provisioned for now?
+> ~~**Q2: Billing/Payments** — Should I scaffold Stripe integration for seat-based billing, or treat Enterprise accounts as manually provisioned for now?~~
+> **Resolved**: Plans are admin-managed only. No billing integration. Admin uses `PATCH /admin/users/:userId/plan` to set plans.
 
 > [!NOTE]
 > **Q3: Candidate exam UI** — The candidate exam page (`/assess/:token`) needs to work without authentication. Currently the `ExamPage.tsx` uses `ProtectedRoute`. Should the candidate exam be a completely separate page (recommended) or should we modify ExamPage to support guest mode?
 
 > [!NOTE]
 > **Q4: Implementation approach** — Should I implement all 6 phases at once, or would you prefer to start with Phase 1 and iterate?
+
+> [!IMPORTANT]
+> **Q5: PREMIUM Max Seats** — Should PREMIUM orgs be hard-capped at 10 seats, or should admin be able to override `maxSeats` per org via the admin panel?
+
+> [!NOTE]
+> **Q6: Plan Downgrade** — Current spec grandfathers existing orgs when a user is downgraded (e.g., PREMIUM → FREE). The user keeps their org but cannot create new ones. Confirm this is acceptable.
 
 ---
 
@@ -731,12 +1021,25 @@ Each phase includes:
 3. **Phase 3**: Create catalog exam → assign to group → member takes exam → verify results
 4. **Phase 4**: Create assessment → invite candidate email → open link → take exam → verify results dashboard
 5. **Phase 5**: After generating test data, verify analytics charts show correct aggregations
-6. **Phase 6**: Verify org link in navbar, assignment cards on dashboard
+6. **Phase 6**: Plan enforcement + admin org management + frontend polish:
+   - FREE user attempts org creation → 403
+   - PREMIUM user creates 1 org → success; attempts 2nd → 403
+   - ENTERPRISE user creates up to 3 orgs
+   - ADMIN user creates unlimited orgs
+   - FREE user attempts join via link → 403
+   - FREE user accepts email invite → success
+   - Admin sets user plan via `PATCH /admin/users/:userId/plan`
+   - Admin lists/edits/deletes any organization
+   - Navbar shows "Organization" for PREMIUM/ENTERPRISE users with no memberships
+   - Navbar hides "Organization" for FREE users with no memberships
+   - OrgSelector shows correct messaging per plan
 
 ### Browser Testing
 
 Use browser subagent to verify:
-- Org creation flow end-to-end
+- Org creation flow end-to-end (with plan checks)
 - Member invite → accept → visible in member list
 - Candidate exam flow (no auth, token-based)
 - Org dashboard analytics rendering
+- FREE user sees appropriate "invite only" messaging
+- Admin org management panel

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { BookOpen, Target, Dumbbell, Layers, BarChart3, Trophy, Building2 } from 'lucide-react';
 import { useAuthStore } from '@/stores/auth.store';
+import { useOrgStore } from '@/stores/org.store';
 
 const staticTabs = [
   { label: 'Dashboard', href: '/dashboard', icon: BarChart3 },
@@ -16,8 +17,14 @@ const BottomTabBar = () => {
   const location = useLocation();
   const user = useAuthStore((s) => s.user);
 
+  const currentOrg = useOrgStore((s) => s.currentOrg);
   const orgMemberships = user?.orgMemberships ?? [];
-  const orgHref = orgMemberships.length === 1 ? `/org/${orgMemberships[0].slug}` : '/org';
+  const belongsToCurrentOrg = orgMemberships.some(m => m.slug === currentOrg?.slug);
+  const orgHref = orgMemberships.length === 1 
+    ? `/org/${orgMemberships[0].slug}` 
+    : currentOrg && (belongsToCurrentOrg || user?.role === 'ADMIN')
+      ? `/org/${currentOrg.slug}`
+      : '/org';
 
   const tabs = orgMemberships.length > 0 || user?.plan === 'PREMIUM' || user?.plan === 'ENTERPRISE' || user?.role === 'ADMIN'
     ? [...staticTabs, { label: 'Org', href: orgHref, icon: Building2 }]

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -19,7 +19,7 @@ const BottomTabBar = () => {
   const orgMemberships = user?.orgMemberships ?? [];
   const orgHref = orgMemberships.length === 1 ? `/org/${orgMemberships[0].slug}` : '/org';
 
-  const tabs = orgMemberships.length > 0
+  const tabs = orgMemberships.length > 0 || user?.plan === 'PREMIUM' || user?.plan === 'ENTERPRISE' || user?.role === 'ADMIN'
     ? [...staticTabs, { label: 'Org', href: orgHref, icon: Building2 }]
     : staticTabs;
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -55,10 +55,11 @@ const Navbar = ({ title, showBack, icon: LogoIcon = Brain }: NavbarProps) => {
   const [open, setOpen] = useState(false);
 
   const orgMemberships = user?.orgMemberships ?? [];
+  const belongsToCurrentOrg = orgMemberships.some(m => m.slug === currentOrg?.slug);
   const orgHref =
     orgMemberships.length === 1
       ? `/org/${orgMemberships[0].slug}`
-      : currentOrg
+      : currentOrg && (belongsToCurrentOrg || user?.role === 'ADMIN')
         ? `/org/${currentOrg.slug}`
         : "/org";
   const navLinks = [

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -63,7 +63,7 @@ const Navbar = ({ title, showBack, icon: LogoIcon = Brain }: NavbarProps) => {
         : "/org";
   const navLinks = [
     ...staticNavLinks.slice(0, 7), // before Leaderboard
-    ...(orgMemberships.length > 0
+    ...(orgMemberships.length > 0 || user?.plan === "PREMIUM" || user?.plan === "ENTERPRISE" || user?.role === "ADMIN"
       ? [{ label: "Organization", href: orgHref, icon: Building2 }]
       : []),
     ...staticNavLinks.slice(7), // Leaderboard

--- a/src/pages/admin/OrganizationsTab.tsx
+++ b/src/pages/admin/OrganizationsTab.tsx
@@ -1,0 +1,362 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getAdminOrganizations,
+  getAdminOrgMembers,
+  updateAdminOrganization,
+  deleteAdminOrganization,
+  updateAdminOrgMemberRole,
+  removeAdminOrgMember,
+  AdminOrganization,
+  AdminOrgMember,
+} from '@/services/admin';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Building2, Search, Loader2, Pencil, Trash2, Users, ChevronLeft, X,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+const ORG_ROLES = ['OWNER', 'ADMIN', 'MANAGER', 'MEMBER'];
+
+const planBadge: Record<string, { className: string; label: string }> = {
+  FREE: { className: 'bg-muted text-muted-foreground', label: 'Free' },
+  PREMIUM: { className: 'bg-blue-500/20 text-blue-400 border-blue-500/30', label: 'Premium' },
+  ENTERPRISE: { className: 'bg-purple-500/20 text-purple-400 border-purple-500/30', label: 'Enterprise' },
+};
+
+export default function OrganizationsTab() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [editOrg, setEditOrg] = useState<AdminOrganization | null>(null);
+  const [deleteOrg, setDeleteOrg] = useState<AdminOrganization | null>(null);
+  const [viewMembersOrg, setViewMembersOrg] = useState<AdminOrganization | null>(null);
+  const [membersPage, setMembersPage] = useState(1);
+
+  // Edit form state
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editIndustry, setEditIndustry] = useState('');
+  const [editMaxSeats, setEditMaxSeats] = useState('');
+  const [editIsActive, setEditIsActive] = useState(true);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin-organizations', search, page],
+    queryFn: () => getAdminOrganizations(page, 20, search || undefined),
+  });
+
+  const { data: membersData, isLoading: membersLoading } = useQuery({
+    queryKey: ['admin-org-members', viewMembersOrg?.id, membersPage],
+    queryFn: () => getAdminOrgMembers(viewMembersOrg!.id, membersPage, 20),
+    enabled: !!viewMembersOrg,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ orgId, data }: { orgId: string; data: Record<string, unknown> }) =>
+      updateAdminOrganization(orgId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-organizations'] });
+      toast.success('Organization updated');
+      setEditOrg(null);
+    },
+    onError: () => toast.error('Failed to update organization'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (orgId: string) => deleteAdminOrganization(orgId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-organizations'] });
+      toast.success('Organization deleted');
+      setDeleteOrg(null);
+    },
+    onError: () => toast.error('Failed to delete organization'),
+  });
+
+  const memberRoleMutation = useMutation({
+    mutationFn: ({ orgId, userId, role }: { orgId: string; userId: string; role: string }) =>
+      updateAdminOrgMemberRole(orgId, userId, role),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-org-members'] });
+      toast.success('Member role updated');
+    },
+    onError: () => toast.error('Failed to update member role'),
+  });
+
+  const removeMemberMutation = useMutation({
+    mutationFn: ({ orgId, userId }: { orgId: string; userId: string }) =>
+      removeAdminOrgMember(orgId, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-org-members'] });
+      queryClient.invalidateQueries({ queryKey: ['admin-organizations'] });
+      toast.success('Member removed');
+    },
+    onError: () => toast.error('Failed to remove member'),
+  });
+
+  const openEdit = (org: AdminOrganization) => {
+    setEditOrg(org);
+    setEditName(org.name);
+    setEditDescription(org.description ?? '');
+    setEditIndustry(org.industry ?? '');
+    setEditMaxSeats(org.maxSeats.toString());
+    setEditIsActive(org.isActive);
+  };
+
+  const handleEditSubmit = () => {
+    if (!editOrg) return;
+    updateMutation.mutate({
+      orgId: editOrg.id,
+      data: {
+        name: editName,
+        description: editDescription || undefined,
+        industry: editIndustry || undefined,
+        maxSeats: parseInt(editMaxSeats) || editOrg.maxSeats,
+        isActive: editIsActive,
+      },
+    });
+  };
+
+  const orgs = data?.data ?? [];
+
+  // Members view
+  if (viewMembersOrg) {
+    const members: AdminOrgMember[] = membersData?.data ?? [];
+    return (
+      <Card className="glass-card">
+        <CardHeader>
+          <CardTitle className="text-base font-mono flex items-center gap-2">
+            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => { setViewMembersOrg(null); setMembersPage(1); }}>
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Users className="h-4 w-4 text-primary" />
+            Members — {viewMembersOrg.name}
+            <Badge variant="outline" className="ml-2 text-[10px] font-mono">{viewMembersOrg.slug}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {membersLoading ? (
+            <div className="flex justify-center py-8"><Loader2 className="h-6 w-6 animate-spin text-primary" /></div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="font-mono">User</TableHead>
+                    <TableHead className="font-mono">Email</TableHead>
+                    <TableHead className="font-mono text-center">Org Role</TableHead>
+                    <TableHead className="font-mono text-center">Plan</TableHead>
+                    <TableHead className="font-mono text-center">Joined</TableHead>
+                    <TableHead className="font-mono text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {members.map(m => (
+                    <TableRow key={m.id}>
+                      <TableCell className="font-medium text-sm">{m.user.displayName}</TableCell>
+                      <TableCell className="text-sm text-muted-foreground">{m.user.email}</TableCell>
+                      <TableCell className="text-center">
+                        <Select
+                          value={m.role}
+                          onValueChange={role => memberRoleMutation.mutate({ orgId: viewMembersOrg.id, userId: m.userId, role })}
+                        >
+                          <SelectTrigger className="h-7 w-[120px] text-xs font-mono mx-auto"><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            {ORG_ROLES.map(r => <SelectItem key={r} value={r} className="text-xs font-mono">{r}</SelectItem>)}
+                          </SelectContent>
+                        </Select>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <Badge variant="outline" className={`text-[10px] font-mono ${planBadge[m.user.plan]?.className || ''}`}>
+                          {planBadge[m.user.plan]?.label || m.user.plan}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-center text-xs text-muted-foreground font-mono">
+                        {new Date(m.joinedAt).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-destructive"
+                          title="Remove member"
+                          onClick={() => removeMemberMutation.mutate({ orgId: viewMembersOrg.id, userId: m.userId })}
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {membersData && membersData.meta.lastPage > 1 && (
+                <div className="flex justify-center mt-4 gap-2">
+                  <Button size="sm" variant="outline" disabled={membersPage === 1} onClick={() => setMembersPage(p => p - 1)}>Prev</Button>
+                  <span className="py-2 px-3 text-xs font-mono text-muted-foreground">Page {membersPage}/{membersData.meta.lastPage}</span>
+                  <Button size="sm" variant="outline" disabled={membersPage >= membersData.meta.lastPage} onClick={() => setMembersPage(p => p + 1)}>Next</Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Main org list
+  return (
+    <>
+      <Card className="glass-card">
+        <CardHeader>
+          <CardTitle className="text-base font-mono flex items-center justify-between">
+            <span className="flex items-center gap-2"><Building2 className="h-4 w-4 text-primary" /> Organizations</span>
+            <div className="relative w-56">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input placeholder="Search orgs..." value={search} onChange={e => { setSearch(e.target.value); setPage(1); }} className="pl-9 h-8 text-sm" />
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex justify-center py-8"><Loader2 className="h-6 w-6 animate-spin text-primary" /></div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="font-mono">Name</TableHead>
+                    <TableHead className="font-mono">Owner</TableHead>
+                    <TableHead className="font-mono text-center">Plan</TableHead>
+                    <TableHead className="font-mono text-center">Members</TableHead>
+                    <TableHead className="font-mono text-center">Max Seats</TableHead>
+                    <TableHead className="font-mono text-center">Status</TableHead>
+                    <TableHead className="font-mono text-center">Created</TableHead>
+                    <TableHead className="font-mono text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {orgs.map(org => {
+                    const ownerPlan = org.owner?.plan || 'FREE';
+                    const pb = planBadge[ownerPlan] || planBadge.FREE;
+                    return (
+                      <TableRow key={org.id}>
+                        <TableCell>
+                          <div>
+                            <p className="text-sm font-medium font-mono">{org.name}</p>
+                            <p className="text-xs text-muted-foreground font-mono">/{org.slug}</p>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          {org.owner ? (
+                            <div>
+                              <p className="text-sm">{org.owner.displayName}</p>
+                              <p className="text-xs text-muted-foreground">{org.owner.email}</p>
+                            </div>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">No owner</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <Badge variant="outline" className={`text-[10px] font-mono ${pb.className}`}>{pb.label}</Badge>
+                        </TableCell>
+                        <TableCell className="text-center font-mono text-sm">{org.memberCount}</TableCell>
+                        <TableCell className="text-center font-mono text-sm">{org.maxSeats}</TableCell>
+                        <TableCell className="text-center">
+                          <Badge variant={org.isActive ? 'outline' : 'destructive'} className="text-[10px] font-mono">
+                            {org.isActive ? 'Active' : 'Inactive'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-center text-xs text-muted-foreground font-mono">
+                          {new Date(org.createdAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex gap-1 justify-end">
+                            <Button variant="ghost" size="icon" className="h-7 w-7" title="View members" onClick={() => { setViewMembersOrg(org); setMembersPage(1); }}>
+                              <Users className="h-3 w-3" />
+                            </Button>
+                            <Button variant="ghost" size="icon" className="h-7 w-7" title="Edit" onClick={() => openEdit(org)}>
+                              <Pencil className="h-3 w-3" />
+                            </Button>
+                            <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" title="Delete" onClick={() => setDeleteOrg(org)}>
+                              <Trash2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+              {data && data.meta.lastPage > 1 && (
+                <div className="flex justify-center mt-4 gap-2">
+                  <Button size="sm" variant="outline" disabled={page === 1} onClick={() => setPage(p => p - 1)}>Prev</Button>
+                  <span className="py-2 px-3 text-xs font-mono text-muted-foreground">Page {page}/{data.meta.lastPage}</span>
+                  <Button size="sm" variant="outline" disabled={page >= data.meta.lastPage} onClick={() => setPage(p => p + 1)}>Next</Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Edit Dialog */}
+      <Dialog open={!!editOrg} onOpenChange={(open) => !open && setEditOrg(null)}>
+        <DialogContent className="glass-card border-border max-w-md">
+          <DialogHeader><DialogTitle className="font-mono text-sm">Edit Organization</DialogTitle></DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label className="text-xs font-mono">Name</Label>
+              <Input value={editName} onChange={e => setEditName(e.target.value)} className="text-sm" />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-mono">Description</Label>
+              <Input value={editDescription} onChange={e => setEditDescription(e.target.value)} className="text-sm" placeholder="Optional" />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-mono">Industry</Label>
+              <Input value={editIndustry} onChange={e => setEditIndustry(e.target.value)} className="text-sm" placeholder="Optional" />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-mono">Max Seats</Label>
+              <Input type="number" value={editMaxSeats} onChange={e => setEditMaxSeats(e.target.value)} className="text-sm" />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label className="text-xs font-mono">Active</Label>
+              <Switch checked={editIsActive} onCheckedChange={setEditIsActive} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setEditOrg(null)} className="font-mono text-xs">Cancel</Button>
+            <Button size="sm" onClick={handleEditSubmit} disabled={updateMutation.isPending} className="font-mono text-xs">
+              {updateMutation.isPending ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={!!deleteOrg} onOpenChange={(open) => !open && setDeleteOrg(null)}>
+        <DialogContent className="glass-card border-border max-w-sm">
+          <DialogHeader><DialogTitle className="font-mono text-sm">Delete Organization</DialogTitle></DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete <strong className="text-foreground">{deleteOrg?.name}</strong>?
+            This will permanently remove the organization and all its data (members, questions, catalogs, etc.).
+          </p>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setDeleteOrg(null)} className="font-mono text-xs">Cancel</Button>
+            <Button variant="destructive" size="sm" onClick={() => deleteOrg && deleteMutation.mutate(deleteOrg.id)} disabled={deleteMutation.isPending} className="font-mono text-xs">
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/pages/admin/UsersTab.tsx
+++ b/src/pages/admin/UsersTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getUsers, updateUserRole, suspendUser, banUser, reactivateUser, adjustUserPoints, bulkUpdateUserRole, exportUsers } from '@/services/admin';
+import { getUsers, updateUserRole, updateUserPlan, suspendUser, banUser, reactivateUser, adjustUserPoints, bulkUpdateUserRole, exportUsers } from '@/services/admin';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -15,6 +15,13 @@ import { Users, Search, Loader2, Ban, ShieldOff, ShieldCheck, Coins, Download } 
 import { toast } from 'sonner';
 
 const ROLES = ['LEARNER', 'CONTRIBUTOR', 'REVIEWER', 'ADMIN'];
+const PLANS = ['FREE', 'PREMIUM', 'ENTERPRISE'];
+
+const planBadge: Record<string, string> = {
+  FREE: 'bg-muted text-muted-foreground',
+  PREMIUM: 'bg-blue-500/20 text-blue-400',
+  ENTERPRISE: 'bg-purple-500/20 text-purple-400',
+};
 
 const statusBadge: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
   ACTIVE: { variant: 'outline', label: 'Active' },
@@ -54,6 +61,12 @@ export default function UsersTab() {
     mutationFn: ({ userId, role }: { userId: string; role: string }) => updateUserRole(userId, role),
     onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['admin-users'] }); toast.success('Role updated'); },
     onError: () => toast.error('Failed to update role'),
+  });
+
+  const planMutation = useMutation({
+    mutationFn: ({ userId, plan }: { userId: string; plan: string }) => updateUserPlan(userId, plan),
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['admin-users'] }); toast.success('Plan updated'); },
+    onError: () => toast.error('Failed to update plan'),
   });
 
   const bulkRoleMutation = useMutation({
@@ -155,6 +168,7 @@ export default function UsersTab() {
                     <TableHead className="font-mono">User</TableHead>
                     <TableHead className="font-mono">Email</TableHead>
                     <TableHead className="font-mono text-center">Role</TableHead>
+                    <TableHead className="font-mono text-center">Plan</TableHead>
                     <TableHead className="font-mono text-center">Status</TableHead>
                     <TableHead className="font-mono text-center">Points</TableHead>
                     <TableHead className="font-mono text-center">Qs</TableHead>
@@ -173,6 +187,12 @@ export default function UsersTab() {
                           <Select value={u.role} onValueChange={role => roleMutation.mutate({ userId: u.id, role })}>
                             <SelectTrigger className="h-7 w-[130px] text-xs font-mono mx-auto"><SelectValue /></SelectTrigger>
                             <SelectContent>{ROLES.map(r => <SelectItem key={r} value={r} className="text-xs font-mono">{r}</SelectItem>)}</SelectContent>
+                          </Select>
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <Select value={u.plan || 'FREE'} onValueChange={plan => planMutation.mutate({ userId: u.id, plan })}>
+                            <SelectTrigger className={`h-7 w-[130px] text-xs font-mono mx-auto ${planBadge[u.plan || 'FREE'] || ''}`}><SelectValue /></SelectTrigger>
+                            <SelectContent>{PLANS.map(p => <SelectItem key={p} value={p} className="text-xs font-mono">{p}</SelectItem>)}</SelectContent>
                           </Select>
                         </TableCell>
                         <TableCell className="text-center">

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -18,6 +18,7 @@ import { TagsTab } from './TagsTab';
 import { BadgesTab } from './BadgesTab';
 import { AiGenerationTab } from './AiGenerationTab';
 import { ExamsTab } from './ExamsTab';
+import OrganizationsTab from './OrganizationsTab';
 
 const AdminPage = () => {
   const navigate = useNavigate();
@@ -61,6 +62,7 @@ const AdminPage = () => {
             <TabsTrigger value="tags" className="font-mono text-xs"><Tag className="h-3 w-3 mr-1" /> Tags</TabsTrigger>
             <TabsTrigger value="badges" className="font-mono text-xs"><BookOpen className="h-3 w-3 mr-1" /> Badges</TabsTrigger>
             <TabsTrigger value="exams" className="font-mono text-xs"><ClipboardList className="h-3 w-3 mr-1" /> Exams</TabsTrigger>
+            <TabsTrigger value="organizations" className="font-mono text-xs"><Building2 className="h-3 w-3 mr-1" /> Organizations</TabsTrigger>
             <TabsTrigger value="ai" className="font-mono text-xs"><Sparkles className="h-3 w-3 mr-1" /> AI Generation</TabsTrigger>
             <TabsTrigger value="moderation" className="font-mono text-xs"><FileText className="h-3 w-3 mr-1" /> Moderation</TabsTrigger>
             <TabsTrigger value="reports" className="font-mono text-xs"><AlertTriangle className="h-3 w-3 mr-1" /> Reports</TabsTrigger>
@@ -75,6 +77,7 @@ const AdminPage = () => {
           <TabsContent value="tags"><TagsTab /></TabsContent>
           <TabsContent value="badges"><BadgesTab /></TabsContent>
           <TabsContent value="exams"><ExamsTab /></TabsContent>
+          <TabsContent value="organizations"><OrganizationsTab /></TabsContent>
           <TabsContent value="ai"><AiGenerationTab /></TabsContent>
           <TabsContent value="moderation"><ModerationTab /></TabsContent>
           <TabsContent value="reports"><ReportsTab /></TabsContent>

--- a/src/pages/org/CreateOrg.tsx
+++ b/src/pages/org/CreateOrg.tsx
@@ -10,6 +10,8 @@ import { Building2, ArrowRight, Upload, Globe, Users, Loader2 } from 'lucide-rea
 import { toast } from 'sonner';
 import { createOrg } from '@/services/organizations';
 import type { CreateOrgPayload } from '@/types/org-types';
+import { useAuthStore } from '@/stores/auth.store';
+import { useOrgStore } from '@/stores/org.store';
 
 const CreateOrg = () => {
   const navigate = useNavigate();
@@ -18,6 +20,18 @@ const CreateOrg = () => {
   const [slug, setSlug] = useState('');
   const [description, setDescription] = useState('');
   const [industry, setIndustry] = useState('');
+
+  const user = useAuthStore((s) => s.user);
+  const myOrgs = useOrgStore((s) => s.myOrgs);
+
+  const plan = user?.plan ?? 'FREE';
+  const isAdmin = user?.role === 'ADMIN';
+  const ownedOrgs = myOrgs.filter((o) => o.myRole === 'OWNER').length;
+
+  const canCreate =
+    isAdmin ||
+    (plan === 'PREMIUM' && ownedOrgs < 1) ||
+    (plan === 'ENTERPRISE' && ownedOrgs < 3);
 
   const generateSlug = (val: string) => {
     setName(val);
@@ -42,6 +56,28 @@ const CreateOrg = () => {
       industry: industry || undefined,
     });
   };
+
+  if (!canCreate) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Navbar title="Create Organization" />
+        <div className="container pt-32 flex flex-col items-center justify-center max-w-md text-center space-y-4">
+          <div className="h-16 w-16 rounded-2xl bg-destructive/10 border border-destructive/20 flex items-center justify-center">
+            <Globe className="h-8 w-8 text-destructive" />
+          </div>
+          <h2 className="text-xl font-mono font-bold">Access Denied</h2>
+          <p className="text-sm text-muted-foreground font-mono">
+            {plan === 'FREE'
+              ? 'Free plan users cannot create organizations. Ask your team admin to invite you.'
+              : 'You have reached the maximum number of organizations for your plan.'}
+          </p>
+          <Button variant="outline" className="mt-4" onClick={() => navigate('/org')}>
+            Go Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background pb-20">

--- a/src/pages/org/OrgSelector.tsx
+++ b/src/pages/org/OrgSelector.tsx
@@ -1,13 +1,14 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, Building2, Plus, ChevronRight } from 'lucide-react';
+import { Loader2, Building2, Plus, ChevronRight, Crown, Mail } from 'lucide-react';
 import Navbar from '@/components/Navbar';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { getMyOrgs } from '@/services/organizations';
 import { useOrgStore } from '@/stores/org.store';
+import { useAuthStore } from '@/stores/auth.store';
 
 const roleColors: Record<string, string> = {
   OWNER: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
@@ -19,6 +20,10 @@ const roleColors: Record<string, string> = {
 const OrgSelector = () => {
   const navigate = useNavigate();
   const setMyOrgs = useOrgStore((s) => s.setMyOrgs);
+  const user = useAuthStore((s) => s.user);
+
+  const plan = user?.plan ?? 'FREE';
+  const isAdmin = user?.role === 'ADMIN';
 
   const { data: orgs, isLoading } = useQuery({
     queryKey: ['my-orgs'],
@@ -34,6 +39,25 @@ const OrgSelector = () => {
     }
   }, [orgs, navigate, setMyOrgs]);
 
+  // Count orgs where user is OWNER
+  const ownedOrgs = orgs?.filter((o) => o.myRole === 'OWNER').length ?? 0;
+
+  // Determine if user can create a new org
+  const canCreate =
+    isAdmin ||
+    (plan === 'PREMIUM' && ownedOrgs < 1) ||
+    (plan === 'ENTERPRISE' && ownedOrgs < 3);
+
+  // Limit message when plan cap reached
+  const limitMessage =
+    plan === 'FREE'
+      ? null
+      : plan === 'PREMIUM' && ownedOrgs >= 1
+        ? 'Premium plan allows 1 organization. Upgrade to Enterprise for more.'
+        : plan === 'ENTERPRISE' && ownedOrgs >= 3
+          ? 'You have reached the maximum organizations for your plan (3).'
+          : null;
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background">
@@ -46,6 +70,7 @@ const OrgSelector = () => {
   }
 
   if (!orgs || orgs.length === 0) {
+    // Empty state — depends on plan
     return (
       <div className="min-h-screen bg-background">
         <Navbar title="Organization" />
@@ -55,13 +80,27 @@ const OrgSelector = () => {
           </div>
           <div className="text-center space-y-2">
             <h2 className="text-xl font-mono font-bold">No Organizations</h2>
-            <p className="text-sm text-muted-foreground font-mono">
-              Create or join an organization to manage your team
-            </p>
+            {plan === 'FREE' ? (
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground font-mono">
+                  You don&apos;t have any organizations yet.
+                </p>
+                <div className="flex items-center gap-2 justify-center text-xs text-muted-foreground font-mono bg-muted/30 rounded-lg p-3 border border-border">
+                  <Mail className="h-4 w-4 shrink-0" />
+                  <span>Ask your team admin to send you an invite to join.</span>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground font-mono">
+                Create your first organization to manage your team
+              </p>
+            )}
           </div>
-          <Button className="glow-cyan" onClick={() => navigate('/org/create')}>
-            <Plus className="h-4 w-4 mr-1.5" /> Create Organization
-          </Button>
+          {canCreate && (
+            <Button className="glow-cyan" onClick={() => navigate('/org/create')}>
+              <Plus className="h-4 w-4 mr-1.5" /> Create Organization
+            </Button>
+          )}
         </div>
       </div>
     );
@@ -74,10 +113,20 @@ const OrgSelector = () => {
       <div className="container pt-20 pb-8 max-w-lg space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-mono font-bold">Your Organizations</h1>
-          <Button size="sm" className="glow-cyan" onClick={() => navigate('/org/create')}>
-            <Plus className="h-4 w-4 mr-1.5" /> New
-          </Button>
+          {canCreate && (
+            <Button size="sm" className="glow-cyan" onClick={() => navigate('/org/create')}>
+              <Plus className="h-4 w-4 mr-1.5" /> New
+            </Button>
+          )}
         </div>
+
+        {/* Plan limit message */}
+        {limitMessage && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono bg-muted/30 rounded-lg p-3 border border-border">
+            <Crown className="h-4 w-4 shrink-0 text-amber-400" />
+            <span>{limitMessage}</span>
+          </div>
+        )}
 
         <div className="space-y-3">
           {orgs.map((org) => (

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -8,6 +8,7 @@ export interface AdminUser {
   displayName: string;
   avatarUrl: string | null;
   role: string;
+  plan: string;
   status: string;
   points: number;
   suspendedUntil: string | null;
@@ -64,6 +65,11 @@ export interface DashboardData {
     processing: number;
     completed: number;
     failed: number;
+  };
+  organizations: {
+    total: number;
+    newLast7d: number;
+    newLast30d: number;
   };
 }
 
@@ -149,6 +155,11 @@ export const adjustUserPoints = async (
   reason?: string,
 ) => {
   const response = await api.put(`/users/${userId}/points`, { amount, reason });
+  return response.data;
+};
+
+export const updateUserPlan = async (userId: string, plan: string) => {
+  const response = await api.patch(`/admin/users/${userId}/plan`, { plan });
   return response.data;
 };
 
@@ -487,6 +498,95 @@ export const bulkUpdateQuestionStatus = async (
 
 export const bulkUpdateUserRole = async (userIds: string[], role: string) => {
   const response = await api.post("/admin/users/bulk-role", { userIds, role });
+  return response.data;
+};
+
+// ==================== Admin Organizations ====================
+
+export interface AdminOrganization {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  industry: string | null;
+  logoUrl: string | null;
+  accentColor: string | null;
+  maxSeats: number;
+  isActive: boolean;
+  createdAt: string;
+  owner: { id: string; displayName: string; email: string; plan: string } | null;
+  memberCount: number;
+}
+
+export interface AdminOrgMember {
+  id: string;
+  orgId: string;
+  userId: string;
+  role: string;
+  isActive: boolean;
+  joinedAt: string;
+  user: { id: string; displayName: string; email: string; plan: string; role: string };
+}
+
+export const getAdminOrganizations = async (
+  page = 1,
+  limit = 20,
+  search?: string,
+): Promise<PaginatedResponse<AdminOrganization>> => {
+  const params = new URLSearchParams();
+  params.append('page', page.toString());
+  params.append('limit', limit.toString());
+  if (search) params.append('search', search);
+  const response = await api.get(`/admin/organizations?${params}`);
+  return response.data;
+};
+
+export const getAdminOrganization = async (
+  orgId: string,
+): Promise<AdminOrganization> => {
+  const response = await api.get(`/admin/organizations/${orgId}`);
+  return response.data;
+};
+
+export const updateAdminOrganization = async (
+  orgId: string,
+  data: Partial<Pick<AdminOrganization, 'name' | 'description' | 'industry' | 'logoUrl' | 'accentColor' | 'maxSeats' | 'isActive'>>,
+) => {
+  const response = await api.patch(`/admin/organizations/${orgId}`, data);
+  return response.data;
+};
+
+export const deleteAdminOrganization = async (orgId: string) => {
+  const response = await api.delete(`/admin/organizations/${orgId}`);
+  return response.data;
+};
+
+export const getAdminOrgMembers = async (
+  orgId: string,
+  page = 1,
+  limit = 20,
+): Promise<PaginatedResponse<AdminOrgMember>> => {
+  const params = new URLSearchParams();
+  params.append('page', page.toString());
+  params.append('limit', limit.toString());
+  const response = await api.get(`/admin/organizations/${orgId}/members?${params}`);
+  return response.data;
+};
+
+export const updateAdminOrgMemberRole = async (
+  orgId: string,
+  userId: string,
+  role: string,
+) => {
+  const response = await api.patch(`/admin/organizations/${orgId}/members/${userId}`, { role });
+  return response.data;
+};
+
+export const removeAdminOrgMember = async (
+  orgId: string,
+  userId: string,
+) => {
+  const response = await api.delete(`/admin/organizations/${orgId}/members/${userId}`);
   return response.data;
 };
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -13,6 +13,7 @@ interface User {
     email: string;
     displayName: string;
     role: string;
+    plan: string;
     orgMemberships: OrgMembership[];
 }
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { useOrgStore } from './org.store';
 
 interface OrgMembership {
     orgId: string;
@@ -44,13 +45,15 @@ export const useAuthStore = create<AuthState>()(
                     isAuthenticated: true,
                 }),
 
-            logout: () =>
+            logout: () => {
+                useOrgStore.getState().clearOrg();
                 set({
                     user: null,
                     accessToken: null,
                     refreshToken: null,
                     isAuthenticated: false,
-                }),
+                });
+            },
         }),
         {
             name: 'auth-storage', // name of the item in the storage (must be unique)


### PR DESCRIPTION
## Mo ta

Implement hệ thống phân quyền tổ chức dựa trên Plan (Plan-Based Access Control) và thêm module Admin Organization Management. 
Lý do: Đảm bảo chỉ những user được cấp quyền (PREMIUM, ENTERPRISE, ADMIN) mới có thể tạo và quản lý tổ chức, đồng thời cung cấp công cụ cho Admin quản lý toàn bộ các tổ chức trên hệ thống.

Các thay đổi chính:
1. **Backend**: 
   - Thêm `PlanGuard` (logic trong service) để chặn user `FREE` tạo org hoặc join qua link.
   - Giới hạn số lượng org được tạo: PREMIUM (1), ENTERPRISE (3), ADMIN (vô hạn).
   - Tự động set `maxSeats` dựa trên plan của người tạo.
   - Bổ sung trường `plan` vào response của API Login/Refresh Token.
   - Thêm 7 API mới trong `AdminController` để Admin CRUD organizations và quản lý thành viên xuyên suốt các org.
   - Bổ sung thống kê org mới vào Admin Dashboard.
2. **Frontend**:
   - Update `AuthStore` để lưu trữ `plan` của user.
   - Cập nhật `Navbar` & `BottomTabBar`: Hiển thị menu Organization cho user có plan trả phí ngay cả khi chưa có org.
   - Chặn truy cập UI `/org/create` với user không đủ quyền (hiện màn hình "Access Denied").
   - Update UI `/org` hiển thị thông điệp phù hợp theo plan (VD: Gợi ý nhờ team admin invite đối với user Free).
   - Thêm cột "Plan" với inline `<Select>` vào tab Users trong Admin Panel.
   - Tạo mới `OrganizationsTab` trong Admin Panel để quản lý toàn bộ tổ chức (Search, Edit, Delete, View Members, Change Role).

## Loai thay doi

- [x] feat: tinh nang moi
- [ ] fix: sua bug
- [ ] refactor: refactoring (khong thay doi behavior)
- [ ] test: them/sua test
- [ ] chore: config, CI, docs
- [ ] perf: cai thien performance

## Story / Issue

<!-- Link Linear hoac US-XXX -->
US-ORG-PLAN-GATING

## Definition of Done (DoD)

- [x] Code merged vao main, qua review tu >=1 dev khac
- [x] Unit test coverage >=80% cho file moi
- [x] Integration/e2e test cho flow chinh
- [x] Lint + type check sach (`npm run lint`, `npm run type-check:strict` neu trong scope)
- [x] A11y check: keyboard nav, contrast AA, focus visible (story FE)
- [x] Performance: khong regress LCP/INP >10% so voi baseline
- [x] Telemetry/log du de debug production
- [x] Docs/CHANGELOG cap nhat (neu thay doi DB -> migration + rollback plan)
- [x] Demo duoc tren staging va PO da sign-off
- [x] Security: khong hardcode secret, input validate o boundary, role/guard cho route nhay cam (Đã thêm guard check plan cả ở FE và BE)

## Screenshots (neu co UI thay doi)

<!-- Them screenshot hoac video -->
*(Reviewer có thể check các màn hình:*
*1. Trang tạo Org khi đăng nhập bằng Free User (Access Denied)*
*2. Tab Organizations mới trong trang Admin*
*3. Cột Plan trong tab Users ở trang Admin)*

## Notes cho reviewer

- Việc nâng cấp Plan (FREE -> PREMIUM/ENTERPRISE) hiện tại **chỉ có thể thực hiện bởi Admin** thông qua Admin Panel. Chưa có tích hợp payment/billing (Self-service).
- Thay đổi liên quan đến API trả về của hàm `generateTokens` trong `auth.service.ts` và DTO tương ứng. Frontend tự động catch được state này thông qua `auth.store.ts`.
- Mọi thao tác quản lý Org của Admin (sửa tên, xóa, đổi role member) đều đã được lưu vết qua `AuditService`.