### PR TITLE
fix: restore AI question review flow after TanStack Query v5 upgrade

### DIFF
--- a/src/components/ai-questions/GeneratedQuestionsReview.tsx
+++ b/src/components/ai-questions/GeneratedQuestionsReview.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import {
   CheckCircle2,
@@ -48,6 +48,7 @@ export default function GeneratedQuestionsReview({
   onReset,
 }: Props) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const questions = result.questions ?? [];
   const [included, setIncluded] = useState<Set<number>>(
     new Set(
@@ -78,6 +79,7 @@ export default function GeneratedQuestionsReview({
       toast.success(
         `Saved ${data.saved} questions${data.discarded ? `, ${data.discarded} discarded (low quality)` : ""}`,
       );
+      queryClient.invalidateQueries({ queryKey: ["generation-history"] });
       navigate("/questions?status=APPROVED&mine=true");
     },
     onError: () => toast.error("Failed to save questions"),

--- a/src/components/ai-questions/GenerationForm.tsx
+++ b/src/components/ai-questions/GenerationForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Zap, Loader2, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -73,7 +73,7 @@ export default function GenerationForm({ onResult }: Props) {
   const domains: any[] = selectedCert?.domains || [];
 
   // Poll job status until completed/failed
-  useQuery({
+  const { data: jobStatusData } = useQuery({
     queryKey: ["ai-gen-job", pendingJobId],
     queryFn: () => getJobStatus(pendingJobId!),
     enabled: !!pendingJobId,
@@ -83,13 +83,14 @@ export default function GenerationForm({ onResult }: Props) {
         ? false
         : POLL_INTERVAL_MS;
     },
-    onSuccess: (data: JobStatusResult) => {
-      if (data.status === "COMPLETED" && data.questions) {
-        setPendingJobId(null);
-        onResult(data, pendingCertId, pendingDomainId);
-      }
-    },
-  } as any);
+  });
+
+  useEffect(() => {
+    if (jobStatusData?.status === "COMPLETED" && jobStatusData.questions) {
+      setPendingJobId(null);
+      onResult(jobStatusData, pendingCertId, pendingDomainId);
+    }
+  }, [jobStatusData]);
 
   const estimateMutation = useMutation({
     mutationFn: () =>

--- a/src/pages/AiQuestionGenerator.tsx
+++ b/src/pages/AiQuestionGenerator.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Bot, Settings, Zap, History } from "lucide-react";
+import { Bot, Settings, Zap, History, Eye } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Card,
@@ -10,9 +10,15 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import Navbar from "@/components/Navbar";
-import { getLlmConfigs, getGenerationHistory } from "@/services/ai-questions";
-import { JobStatusResult } from "@/types/api-types";
+import { toast } from "sonner";
+import {
+  getLlmConfigs,
+  getGenerationHistory,
+  getJobStatus,
+} from "@/services/ai-questions";
+import { JobStatusResult, GenerationJob } from "@/types/api-types";
 import LlmConfigPanel from "@/components/ai-questions/LlmConfigPanel";
 import GenerationForm from "@/components/ai-questions/GenerationForm";
 import GeneratedQuestionsReview from "@/components/ai-questions/GeneratedQuestionsReview";
@@ -30,6 +36,8 @@ export default function AiQuestionGenerator() {
     certificationId: string;
     domainId?: string;
   } | null>(null);
+  const [activeTab, setActiveTab] = useState<string | undefined>(undefined);
+  const [loadingJobId, setLoadingJobId] = useState<string | null>(null);
 
   const { data: configs = [] } = useQuery({
     queryKey: ["llm-configs"],
@@ -48,7 +56,31 @@ export default function AiQuestionGenerator() {
     domainId?: string,
   ) => {
     setGenerationResult({ result, certificationId, domainId });
+    setActiveTab("review");
   };
+
+  const handleReviewJob = async (job: GenerationJob) => {
+    setLoadingJobId(job.id);
+    try {
+      const result = await getJobStatus(job.id);
+      setGenerationResult({
+        result,
+        certificationId: job.certificationId,
+        domainId: job.domainId,
+      });
+      setActiveTab("review");
+    } catch {
+      toast.error("Failed to load review data");
+    } finally {
+      setLoadingJobId(null);
+    }
+  };
+
+  const computedDefaultTab = generationResult
+    ? "review"
+    : hasKeys
+      ? "generate"
+      : "settings";
 
   return (
     <div className="min-h-screen bg-background">
@@ -66,9 +98,8 @@ export default function AiQuestionGenerator() {
         </div>
 
         <Tabs
-          defaultValue={
-            generationResult ? "review" : hasKeys ? "generate" : "settings"
-          }
+          value={activeTab ?? computedDefaultTab}
+          onValueChange={setActiveTab}
         >
           <TabsList className="mb-6">
             <TabsTrigger value="settings">
@@ -155,7 +186,10 @@ export default function AiQuestionGenerator() {
                 result={generationResult.result}
                 certificationId={generationResult.certificationId}
                 domainId={generationResult.domainId}
-                onReset={() => setGenerationResult(null)}
+                onReset={() => {
+                  setGenerationResult(null);
+                  setActiveTab("generate");
+                }}
               />
             </TabsContent>
           )}
@@ -173,40 +207,59 @@ export default function AiQuestionGenerator() {
                   </p>
                 ) : (
                   <div className="space-y-2">
-                    {historyData.data.map((job) => (
-                      <div
-                        key={job.id}
-                        className="flex items-center justify-between py-2 border-b last:border-0"
-                      >
-                        <div>
-                          <p className="text-sm font-medium">
-                            {job.certification.name}{" "}
-                            {job.domain ? `— ${job.domain.name}` : ""}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {job.provider} · {job.difficulty} ·{" "}
-                            {job.questionCount} questions ·{" "}
-                            {(job.promptTokens || 0) +
-                              (job.completionTokens || 0)}{" "}
-                            tokens ·{" "}
-                            {new Date(job.createdAt).toLocaleDateString()}
-                          </p>
+                    {historyData.data.map((job) => {
+                      const isReviewable =
+                        job.status === "COMPLETED" &&
+                        job._count.questions === 0;
+                      return (
+                        <div
+                          key={job.id}
+                          className="flex items-center justify-between py-2 border-b last:border-0"
+                        >
+                          <div>
+                            <p className="text-sm font-medium">
+                              {job.certification.name}{" "}
+                              {job.domain ? `— ${job.domain.name}` : ""}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {job.provider} · {job.difficulty} ·{" "}
+                              {job.questionCount} questions ·{" "}
+                              {(job.promptTokens || 0) +
+                                (job.completionTokens || 0)}{" "}
+                              tokens ·{" "}
+                              {new Date(job.createdAt).toLocaleDateString()}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Badge
+                              variant={STATUS_COLORS[job.status] as any}
+                              className="text-xs"
+                            >
+                              {job.status}
+                            </Badge>
+                            {job._count.questions > 0 && (
+                              <span className="text-xs text-muted-foreground">
+                                {job._count.questions} saved
+                              </span>
+                            )}
+                            {isReviewable && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-7 text-xs"
+                                disabled={loadingJobId === job.id}
+                                onClick={() => handleReviewJob(job)}
+                              >
+                                <Eye className="h-3 w-3 mr-1" />
+                                {loadingJobId === job.id
+                                  ? "Loading…"
+                                  : "Review"}
+                              </Button>
+                            )}
+                          </div>
                         </div>
-                        <div className="flex items-center gap-2">
-                          <Badge
-                            variant={STATUS_COLORS[job.status] as any}
-                            className="text-xs"
-                          >
-                            {job.status}
-                          </Badge>
-                          {job._count.questions > 0 && (
-                            <span className="text-xs text-muted-foreground">
-                              {job._count.questions} saved
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </CardContent>

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -353,6 +353,8 @@ export interface TokenEstimate {
 
 export interface GenerationJob {
   id: string;
+  certificationId: string;
+  domainId?: string;
   provider: LlmProvider;
   modelId?: string;
   difficulty: Difficulty;


### PR DESCRIPTION
## Summary

- **Root cause**: TanStack Query v5 removed `onSuccess` from `useQuery`. The polling query in `GenerationForm` used `onSuccess` (with `as any` cast to bypass TS) to trigger the Review tab — this callback was silently ignored in v5, so the Review tab never appeared after generation completed.
- Replaced the broken `onSuccess` with `useEffect` watching the query data.
- Switched `AiQuestionGenerator` Tabs from uncontrolled (`defaultValue`) to controlled (`value`/`onValueChange`) so the tab can be switched programmatically.
- Added a **"Review" button** in the History tab for completed jobs with unreviewed `previewData`, so users can recover previews after a page refresh.
- Fixed **"Generate More"** button navigating to `"history"` instead of `"generate"`.
- Added `toast.error` when loading a past job's review data fails.
- Invalidate `generation-history` query after successful save so the Review button disappears immediately.
- Added `certificationId` and `domainId` to the `GenerationJob` type (already returned by backend but untyped).

## Files changed

| File | Change |
|------|--------|
| `src/types/api-types.ts` | Add `certificationId`, `domainId` to `GenerationJob` |
| `src/components/ai-questions/GenerationForm.tsx` | Replace `useQuery onSuccess` with `useEffect` |
| `src/pages/AiQuestionGenerator.tsx` | Controlled tabs, Review button in history, error handling |
| `src/components/ai-questions/GeneratedQuestionsReview.tsx` | Invalidate history query on save |

## Test plan

- [ ] Generate questions → Review tab appears automatically after completion
- [ ] Refresh page → go to History tab → COMPLETED job shows "Review" button → click loads review
- [ ] Click "Generate More" → lands on Generate tab (not History)
- [ ] Save questions → History tab no longer shows "Review" button for that job
- [ ] Simulate `getJobStatus` failure → toast error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)