### PR TITLE
fix(test): mock IntersectionObserver in vitest setup

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,3 +13,24 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: () => {},
   }),
 });
+
+class MockIntersectionObserver {
+  observe = () => {};
+  unobserve = () => {};
+  disconnect = () => {};
+  takeRecords = () => [];
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+}
+
+Object.defineProperty(window, "IntersectionObserver", {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+});
+Object.defineProperty(globalThis, "IntersectionObserver", {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+});


### PR DESCRIPTION
## Summary
- Frontend unit tests were failing in CI with `ReferenceError: IntersectionObserver is not defined`.
- jsdom does not implement `IntersectionObserver`; `<ScenarioDiagram>` relies on it, which crashed the `ScenarioExam` and `ScenarioReader` specs (43 failing tests).
- Added an `IntersectionObserver` mock to `src/test/setup.ts`, alongside the existing `matchMedia` mock.

## Test plan
- [x] `ScenarioExam.spec.tsx` + `ScenarioReader.spec.tsx` now pass (53/53)
- [ ] CI Frontend Unit job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)