### PR TITLE
hotfix: replace all Vietnamese UI text with English

### DIFF
--- a/src/components/dashboard/ExamHistoryList.tsx
+++ b/src/components/dashboard/ExamHistoryList.tsx
@@ -55,8 +55,8 @@ export function ExamHistoryList({ certificationId }: ExamHistoryListProps) {
       ) : history.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center glass-card rounded-xl border-dashed">
           <Clock className="h-10 w-10 text-muted-foreground/30 mb-4" />
-          <h3 className="font-mono font-medium text-muted-foreground">Chưa có lịch sử thi</h3>
-          <p className="text-xs text-muted-foreground/60 mt-1">Bắt đầu luyện tập để theo dõi tiến độ của bạn tại đây.</p>
+          <h3 className="font-mono font-medium text-muted-foreground">No exam history yet</h3>
+          <p className="text-xs text-muted-foreground/60 mt-1">Start practicing to track your progress here.</p>
         </div>
       ) : (
         <>

--- a/src/components/dashboard/MistakePatternChart.tsx
+++ b/src/components/dashboard/MistakePatternChart.tsx
@@ -96,7 +96,7 @@ export default function MistakePatternChart({ history, patterns }: Props) {
       <CardContent>
         {chartData.length === 0 ? (
           <p className="text-sm text-muted-foreground py-8 text-center">
-            Chưa có dữ liệu lỗi. Hãy hoàn thành ít nhất 1 bài thi.
+            No error data yet. Complete at least 1 exam.
           </p>
         ) : (
           <div className="flex flex-col md:flex-row items-center gap-6">

--- a/src/components/dashboard/ReadinessScore.tsx
+++ b/src/components/dashboard/ReadinessScore.tsx
@@ -53,7 +53,7 @@ export default function ReadinessScore({ summary, domains, weakTopics, readiness
           </CardTitle>
         </CardHeader>
         <CardContent className="h-32 flex items-center justify-center text-sm text-muted-foreground font-mono">
-          Chọn certification để xem độ sẵn sàng
+          Select a certification to view readiness
         </CardContent>
       </Card>
     );

--- a/src/components/dashboard/ScoreTrendChart.tsx
+++ b/src/components/dashboard/ScoreTrendChart.tsx
@@ -43,7 +43,7 @@ export function ScoreTrendChart({ history }: ScoreTrendChartProps) {
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <TrendingUp className="h-8 w-8 text-muted-foreground/30 mb-3" />
             <p className="text-sm text-muted-foreground">
-              Cần ít nhất 2 bài thi để hiển thị biểu đồ xu hướng.
+              Need at least 2 exams to display trend chart.
             </p>
           </div>
         ) : (

--- a/src/components/dashboard/WeakTopicsChart.tsx
+++ b/src/components/dashboard/WeakTopicsChart.tsx
@@ -26,7 +26,7 @@ export function WeakTopicsChart({ weakTopics, domains }: WeakTopicsChartProps) {
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <AlertTriangle className="h-8 w-8 text-muted-foreground/30 mb-3" />
             <p className="text-sm text-muted-foreground">
-              Chưa có dữ liệu phân tích. Hãy hoàn thành ít nhất 1 bài thi để xem điểm yếu của bạn.
+              No analysis data yet. Complete at least 1 exam to see your weak areas.
             </p>
           </div>
         ) : (

--- a/src/components/questions/LivePreview.tsx
+++ b/src/components/questions/LivePreview.tsx
@@ -77,7 +77,7 @@ export function LivePreview({
 
           {/* Question */}
           <h2 className="text-base font-medium mb-1">
-            {title || <span className="text-muted-foreground italic">Nội dung câu hỏi...</span>}
+            {title || <span className="text-muted-foreground italic">Question content...</span>}
           </h2>
           {isScenario && description ? (
             <div className="p-4 rounded-lg bg-accent/5 border border-accent/10 mb-4 relative">

--- a/src/components/training/DailyReviewMode.tsx
+++ b/src/components/training/DailyReviewMode.tsx
@@ -35,15 +35,15 @@ export function DailyReviewMode({ certFilter, onBack }: DailyReviewModeProps) {
             <Calendar className="h-8 w-8 text-primary" />
           </div>
           <h2 className="text-2xl font-mono font-bold mb-2">Daily Review</h2>
-          <p className="text-muted-foreground mb-2">Ôn tập mỗi ngày theo phương pháp Spaced Repetition</p>
+          <p className="text-muted-foreground mb-2">Review daily using Spaced Repetition method</p>
           <p className="text-sm text-muted-foreground mb-6">
-            Hệ thống tự động chọn các câu hỏi đã đến lịch ôn tập (SRS).
+            The system automatically selects questions scheduled for review (SRS).
           </p>
 
           <div className="flex items-center justify-center gap-6 mb-6 text-sm">
             <div className="flex items-center gap-1.5">
               <Clock className="h-4 w-4 text-muted-foreground" />
-              <span className="text-muted-foreground">~10-15 phút</span>
+              <span className="text-muted-foreground">~10-15 minutes</span>
             </div>
             <div className="flex items-center gap-1.5">
               <Flame className="h-4 w-4 text-orange-400" />

--- a/src/components/training/FlashcardReviewMode.tsx
+++ b/src/components/training/FlashcardReviewMode.tsx
@@ -36,7 +36,7 @@ export function FlashcardReviewMode({ certFilter, onBack }: FlashcardReviewModeP
             <Layers className="h-8 w-8 text-accent" />
           </div>
           <h2 className="text-2xl font-mono font-bold mb-2">Flashcard Mastery</h2>
-          <p className="text-muted-foreground mb-4">Ôn tập các thẻ ghi nhớ và khái niệm quan trọng</p>
+          <p className="text-muted-foreground mb-4">Review flashcards and important concepts</p>
           
           <div className="grid grid-cols-2 gap-4 mb-6">
             <div className="p-4 rounded-lg bg-secondary/50 border border-border">
@@ -70,9 +70,9 @@ export function FlashcardReviewMode({ certFilter, onBack }: FlashcardReviewModeP
       <div className="text-center py-20">
         <CheckCircle2 className="h-12 w-12 text-accent mx-auto mb-4" />
         <h3 className="text-lg font-mono font-bold mb-2">All Caught Up!</h3>
-        <p className="text-sm text-muted-foreground mb-6">Bạn đã hoàn thành tất cả các thẻ cần ôn tập hôm nay.</p>
+        <p className="text-sm text-muted-foreground mb-6">You've completed all flashcards for today.</p>
         <Button variant="outline" className="font-mono" onClick={onBack}>
-          <ChevronLeft className="h-4 w-4 mr-1" /> Quay lại Hub
+          <ChevronLeft className="h-4 w-4 mr-1" /> Back to Hub
         </Button>
       </div>
     );
@@ -119,7 +119,7 @@ function FlashcardPracticeSession({ cards, onBack }: { cards: Flashcard[]; onBac
         <Card className="glass-card p-8 text-center">
           <CheckCircle2 className="h-12 w-12 text-accent mx-auto mb-4" />
           <h2 className="text-2xl font-mono font-bold mb-2">Session Complete!</h2>
-          <p className="text-muted-foreground mb-6">Bạn đã ôn tập xong {cards.length} thẻ ghi nhớ.</p>
+          <p className="text-muted-foreground mb-6">You've completed {cards.length} flashcards.</p>
           <Button className="w-full glow-cyan font-mono" onClick={onBack}>
             Finish Session
           </Button>

--- a/src/components/training/HubView.tsx
+++ b/src/components/training/HubView.tsx
@@ -62,8 +62,8 @@ export function HubView({ certFilter, setCertFilter, onModeSelect }: HubViewProp
         <div>
           <h1 className="text-3xl font-mono font-bold text-gradient-cyan mb-2">Training Hub</h1>
           <p className="text-muted-foreground w-full md:w-3/4">
-            Rèn luyện kỹ năng với các chế độ luyện tập thông minh. 
-            Hệ thống phân tích điểm yếu và tối ưu hóa lộ trình học của bạn.
+            Train skills with smart practice modes. 
+            The system analyzes weak areas and optimizes your learning path.
           </p>
         </div>
 
@@ -78,9 +78,9 @@ export function HubView({ certFilter, setCertFilter, onModeSelect }: HubViewProp
             </div>
             <div>
               <div className="text-2xl font-mono font-bold text-orange-500 leading-none mb-1">
-                {streak.currentStreak} <span className="text-sm font-normal text-muted-foreground">ngày</span>
+                {streak.currentStreak} <span className="text-sm font-normal text-muted-foreground">days</span>
               </div>
-              <div className="text-xs text-muted-foreground">Kỷ lục: {streak.longestStreak} ngày</div>
+              <div className="text-xs text-muted-foreground">Record: {streak.longestStreak} days</div>
             </div>
           </Card>
         </motion.div>
@@ -106,7 +106,7 @@ export function HubView({ certFilter, setCertFilter, onModeSelect }: HubViewProp
         <ModeCard
           icon={TrendingDown}
           title="Weakness Targeting"
-          desc="Tập trung luyện tập vào các Knowledge Domain mà bạn có tỷ lệ trả lời đúng thấp nhất (<75%)."
+          desc="Focus on Knowledge Domains where your correct answer rate is lowest (<75%)."
           accentClass="text-destructive"
           bgClass="bg-destructive/10"
           onClick={() => onModeSelect('weakness')}
@@ -115,7 +115,7 @@ export function HubView({ certFilter, setCertFilter, onModeSelect }: HubViewProp
         <ModeCard
           icon={Calendar}
           title="Daily Review"
-          desc="Ôn tập 10-15 câu hỏi mỗi ngày theo phương pháp Spaced Repetition System (SRS)."
+          desc="Review 10-15 questions daily using the Spaced Repetition System (SRS)."
           accentClass="text-primary"
           bgClass="bg-primary/10"
           onClick={() => onModeSelect('daily')}
@@ -124,7 +124,7 @@ export function HubView({ certFilter, setCertFilter, onModeSelect }: HubViewProp
         <ModeCard
           icon={Layers}
           title="Flashcards"
-          desc={`Lật thẻ bài để ghi nhớ khái niệm. Thuật toán SuperMemo-2 tối ưu hóa thời điểm ôn tập lại.`}
+          desc={`Flip cards to memorize concepts. SuperMemo-2 algorithm optimizes review timing.`}
           accentClass="text-accent"
           bgClass="bg-accent/10"
           badge={dueCount > 0 ? `${dueCount} due` : undefined}

--- a/src/components/training/PracticeSession.tsx
+++ b/src/components/training/PracticeSession.tsx
@@ -107,10 +107,10 @@ export function PracticeSession({ questions, attemptId, modeLabel, modeIcon: Mod
     return (
       <div className="text-center py-20">
         <Target className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-        <h3 className="text-lg font-mono font-bold mb-2">Không có câu hỏi phù hợp</h3>
-        <p className="text-sm text-muted-foreground mb-4">Hãy hoàn thành vài bài thi trước để hệ thống xác định điểm yếu.</p>
+        <h3 className="text-lg font-mono font-bold mb-2">No suitable questions</h3>
+        <p className="text-sm text-muted-foreground mb-4">Complete a few practice exams first so the system can identify weak areas.</p>
         <Button variant="outline" className="font-mono" onClick={onBack}>
-          <ChevronLeft className="h-4 w-4 mr-1" /> Quay lại
+          <ChevronLeft className="h-4 w-4 mr-1" /> Back
         </Button>
       </div>
     );
@@ -125,7 +125,7 @@ export function PracticeSession({ questions, attemptId, modeLabel, modeIcon: Mod
         <Card className="glass-card p-8 text-center">
           <ModeIcon className="h-12 w-12 text-primary mx-auto mb-4" />
           <h2 className="text-2xl font-mono font-bold mb-2">Session Complete!</h2>
-          <p className="text-muted-foreground mb-6">{pool.length} câu hỏi đã hoàn thành</p>
+          <p className="text-muted-foreground mb-6">{pool.length} questions completed</p>
 
           <div className="grid grid-cols-3 gap-4 mb-6">
             <div className="p-4 rounded-lg bg-accent/10 border border-accent/20">

--- a/src/components/training/WeaknessMode.tsx
+++ b/src/components/training/WeaknessMode.tsx
@@ -65,7 +65,7 @@ export function WeaknessMode({ certFilter, onBack }: WeaknessModeProps) {
             <TrendingDown className="h-8 w-8 text-destructive" />
           </div>
           <h2 className="text-2xl font-mono font-bold mb-2">Weakness Targeting</h2>
-          <p className="text-muted-foreground mb-4">Tập trung vào các chủ đề bạn hay sai nhất</p>
+          <p className="text-muted-foreground mb-4">Focus on the topics you get wrong most</p>
 
           {!certFilter && (
             <p className="text-xs text-warning mb-6">⚠️ Please select a certification in the Hub first.</p>

--- a/src/data/mockLeaderboardData.ts
+++ b/src/data/mockLeaderboardData.ts
@@ -13,16 +13,16 @@ export interface LeaderboardEntry {
 }
 
 export const leaderboardData: LeaderboardEntry[] = [
-  { id: '1', rank: 1, displayName: 'Minh Trí', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 96, totalExams: 12, avgScore: 91, streak: 7 },
-  { id: '2', rank: 2, displayName: 'Thanh Hà', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 94, totalExams: 8, avgScore: 88, streak: 5 },
-  { id: '3', rank: 3, displayName: 'Đức Anh', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 92, totalExams: 15, avgScore: 85, streak: 3 },
-  { id: '4', rank: 4, displayName: 'Phương Linh', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 90, totalExams: 6, avgScore: 84, streak: 4 },
-  { id: '5', rank: 5, displayName: 'Hoàng Nam', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 88, totalExams: 10, avgScore: 82, streak: 2 },
-  { id: '6', rank: 6, displayName: 'Khánh Vy', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 85, totalExams: 4, avgScore: 80, streak: 1 },
-  { id: '7', rank: 7, displayName: 'Tuấn Kiệt', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 83, totalExams: 9, avgScore: 78, streak: 2 },
-  { id: '8', rank: 1, displayName: 'Minh Trí', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 98, totalExams: 5, avgScore: 93, streak: 5 },
-  { id: '9', rank: 2, displayName: 'Bảo Ngọc', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 95, totalExams: 7, avgScore: 90, streak: 4 },
-  { id: '10', rank: 3, displayName: 'Thanh Hà', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 91, totalExams: 3, avgScore: 87, streak: 3 },
-  { id: '11', rank: 4, displayName: 'Quốc Bảo', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 89, totalExams: 6, avgScore: 83, streak: 2 },
-  { id: '12', rank: 5, displayName: 'Hải Yến', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 86, totalExams: 4, avgScore: 81, streak: 1 },
+  { id: '1', rank: 1, displayName: 'Michael Tran', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 96, totalExams: 12, avgScore: 91, streak: 7 },
+  { id: '2', rank: 2, displayName: 'Jenny Thanh', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 94, totalExams: 8, avgScore: 88, streak: 5 },
+  { id: '3', rank: 3, displayName: 'Alex Duc', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 92, totalExams: 15, avgScore: 85, streak: 3 },
+  { id: '4', rank: 4, displayName: 'Lisa Phuong', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 90, totalExams: 6, avgScore: 84, streak: 4 },
+  { id: '5', rank: 5, displayName: 'Nam Hoang', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 88, totalExams: 10, avgScore: 82, streak: 2 },
+  { id: '6', rank: 6, displayName: 'Ivy Khanh', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 85, totalExams: 4, avgScore: 80, streak: 1 },
+  { id: '7', rank: 7, displayName: 'Tuan Kiet', certCode: 'SAA-C03', certId: 'aws-saa', icon: '☁️', bestScore: 83, totalExams: 9, avgScore: 78, streak: 2 },
+  { id: '8', rank: 1, displayName: 'Michael Tran', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 98, totalExams: 5, avgScore: 93, streak: 5 },
+  { id: '9', rank: 2, displayName: 'Natalie Bao', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 95, totalExams: 7, avgScore: 90, streak: 4 },
+  { id: '10', rank: 3, displayName: 'Jenny Thanh', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 91, totalExams: 3, avgScore: 87, streak: 3 },
+  { id: '11', rank: 4, displayName: 'Bao Quoc', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 89, totalExams: 6, avgScore: 83, streak: 2 },
+  { id: '12', rank: 5, displayName: 'Haley Yen', certCode: 'AZ-900', certId: 'azure-az900', icon: '🔷', bestScore: 86, totalExams: 4, avgScore: 81, streak: 1 },
 ];

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -100,13 +100,13 @@ const Dashboard = () => {
         <div className="text-center">
           <Brain className="h-12 w-12 text-primary mx-auto mb-4" />
           <h2 className="text-xl font-mono font-bold mb-2">
-            Đăng nhập để xem Dashboard
+            Sign in to view Dashboard
           </h2>
           <Button
             className="glow-cyan font-mono"
             onClick={() => navigate("/auth")}
           >
-            Đăng nhập
+            Sign in
           </Button>
         </div>
       </div>

--- a/src/pages/ExamResults.tsx
+++ b/src/pages/ExamResults.tsx
@@ -70,8 +70,8 @@ const ExamResults = () => {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center space-y-4">
-          <p className="text-muted-foreground">Không tìm thấy kết quả thi.</p>
-          <Button onClick={() => navigate('/')} className="font-mono">Về trang chủ</Button>
+          <p className="text-muted-foreground">No exam results found.</p>
+          <Button onClick={() => navigate('/')} className="font-mono">Back to Home</Button>
         </div>
       </div>
     );
@@ -238,7 +238,7 @@ const ExamResults = () => {
         <div className="space-y-3">
           {filteredQuestions.length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-8">
-              Không có câu hỏi nào trong filter này.
+              No questions found in this filter.
             </p>
           )}
           {filteredQuestions.map((q, i) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -23,7 +23,7 @@ const features = [
   {
     icon: Target,
     title: "Exam Simulation",
-    desc: "Timer, navigation, mark for review — giống exam thật.",
+    desc: "Timer, navigation, mark for review — like real exams.",
   },
   {
     icon: BarChart3,
@@ -48,7 +48,7 @@ const features = [
   {
     icon: Brain,
     title: "Adaptive Exam",
-    desc: "Câu đúng → khó hơn. Câu sai → dễ hơn.",
+    desc: "Right questions → harder. Wrong → easier.",
   },
 ];
 

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -81,7 +81,7 @@ const Leaderboard = () => {
         ) : entries.length === 0 ? (
           <div className="text-center py-16 text-muted-foreground">
             <Trophy className="h-12 w-12 mx-auto mb-4 opacity-30" />
-            <p className="font-mono">Chưa có dữ liệu. Hãy hoàn thành bài thi đầu tiên!</p>
+            <p className="font-mono">No data yet. Complete your first exam!</p>
           </div>
         ) : (
           <>

--- a/src/pages/QuestionDetail.tsx
+++ b/src/pages/QuestionDetail.tsx
@@ -98,11 +98,11 @@ const QuestionDetail = () => {
   const reportMutation = useMutation({
     mutationFn: () => reportQuestion(id!, reportReason, reportDesc || undefined),
     onSuccess: () => {
-      toast.success('Báo cáo đã được gửi');
+      toast.success('Report submitted');
       setReportOpen(false);
       setReportDesc('');
     },
-    onError: (err: any) => toast.error(err.response?.data?.message || 'Không thể gửi báo cáo'),
+    onError: (err: any) => toast.error(err.response?.data?.message || 'Unable to submit report'),
   });
 
   if (isLoading) {

--- a/src/pages/QuestionForm.tsx
+++ b/src/pages/QuestionForm.tsx
@@ -176,7 +176,7 @@ export default function QuestionForm() {
             <Sparkles className="inline h-5 w-5 text-primary mr-2" />
             Contribute Question
           </h1>
-          <p className="text-sm text-muted-foreground mt-1">Tạo câu hỏi mới cho cộng đồng luyện thi.</p>
+          <p className="text-sm text-muted-foreground mt-1">Create new questions for the exam prep community.</p>
         </div>
 
         <div className={`grid gap-6 ${showPreview ? 'lg:grid-cols-2' : 'max-w-3xl'}`}>
@@ -188,7 +188,7 @@ export default function QuestionForm() {
               <div className="grid grid-cols-2 gap-3">
                 <Select value={certificationId || undefined} onValueChange={(v) => { setCertificationId(v); setDomainId(''); }}>
                   <SelectTrigger className="bg-secondary border-border">
-                    <SelectValue placeholder="Chọn chứng chỉ" />
+                    <SelectValue placeholder="Select Certificate" />
                   </SelectTrigger>
                   <SelectContent>
                     {certifications.map(c => (
@@ -201,7 +201,7 @@ export default function QuestionForm() {
 
                 <Select value={domainId || undefined} onValueChange={setDomainId} disabled={!domains.length}>
                   <SelectTrigger className="bg-secondary border-border">
-                    <SelectValue placeholder="Chọn domain" />
+                    <SelectValue placeholder="Select Domain" />
                   </SelectTrigger>
                   <SelectContent>
                     {domains.map(d => (
@@ -260,7 +260,7 @@ export default function QuestionForm() {
               <Textarea
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                placeholder="Nội dung câu hỏi chính..."
+                placeholder="Main question content..."
                 className="bg-secondary border-border min-h-[80px] text-sm"
               />
               <div className={`space-y-2 transition-all duration-300 ${isScenario ? 'p-3 rounded-lg bg-accent/5 border border-accent/20' : ''}`}>
@@ -272,7 +272,7 @@ export default function QuestionForm() {
                 <Textarea
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  placeholder={isScenario ? "Mô tả chi tiết tình huống / scenario..." : "Mô tả thêm / context (optional)..."}
+                  placeholder={isScenario ? "Detailed scenario description..." : "Additional description / context (optional)..."}
                   className={`bg-secondary border-border text-sm transition-all duration-300 ${isScenario ? 'min-h-[140px] border-accent/30' : 'min-h-[60px]'}`}
                 />
               </div>
@@ -317,7 +317,7 @@ export default function QuestionForm() {
                         next[i].content = e.target.value;
                         setChoices(next);
                       }}
-                      placeholder={`Lựa chọn ${choice.label.toUpperCase()}`}
+                      placeholder={`Option ${choice.label.toUpperCase()}`}
                       className={`bg-secondary border-border text-sm ${choice.isCorrect ? 'border-accent/30' : ''}`}
                     />
                     {choices.length > 2 && (
@@ -328,7 +328,7 @@ export default function QuestionForm() {
                   </motion.div>
                 ))}
               </AnimatePresence>
-              <p className="text-xs text-muted-foreground">Click vào chữ cái để đánh dấu đáp án đúng</p>
+              <p className="text-xs text-muted-foreground">Click on the letter to mark the correct answer</p>
             </div>
 
             {/* Explanation & Reference */}
@@ -337,7 +337,7 @@ export default function QuestionForm() {
               <Textarea
                 value={explanation}
                 onChange={(e) => setExplanation(e.target.value)}
-                placeholder="Giải thích tại sao đáp án đúng là đúng, và các đáp án khác sai ở đâu..."
+                placeholder="Explain why the correct answer is right, and why the other options are wrong..."
                 className="bg-secondary border-border min-h-[100px] text-sm"
               />
               <Input
@@ -358,7 +358,7 @@ export default function QuestionForm() {
                   value={tagInput}
                   onChange={(e) => setTagInput(e.target.value)}
                   onKeyDown={handleTagKeyDown}
-                  placeholder="Nhập tag rồi Enter..."
+                  placeholder="Enter tag and press Enter..."
                   className="bg-secondary border-border text-sm"
                 />
                 <Button type="button" variant="outline" size="sm" onClick={addTag} className="shrink-0 font-mono">

--- a/src/pages/StudyMode.tsx
+++ b/src/pages/StudyMode.tsx
@@ -138,7 +138,7 @@ const StudyMode = () => {
           <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="glass-card p-8 text-center">
             <BookOpen className="h-12 w-12 text-primary mx-auto mb-4" />
             <h2 className="text-2xl font-mono font-bold mb-2">Session Complete!</h2>
-            <p className="text-muted-foreground mb-6">Bạn đã hoàn thành {pool.length} câu hỏi</p>
+            <p className="text-muted-foreground mb-6">You've completed {pool.length} questions</p>
 
             <div className="grid grid-cols-3 gap-4 mb-6">
               <div className="p-4 rounded-lg bg-accent/10 border border-accent/20">


### PR DESCRIPTION
## Summary
- Translated all user-facing text and UI labels from Vietnamese to English
- Updated 19 component and page files with English translations
- Replaced mock leaderboard user names with English equivalents
- Maintains full functionality while improving i18n preparation

## Changes Made
- **Training modes**: Updated flashcard review, daily review, weakness focus, practice session labels
- **Dashboard**: Translated analytics labels, exam history, readiness score messages
- **Question management**: Updated form labels, placeholders, explanations
- **Navigation**: Translated button labels and page messages
- **Mock data**: Updated leaderboard user display names

## Test Plan
- [x] Verify no remaining Vietnamese characters in source code
- [x] All 19 modified files reviewed
- [] Test application UI in browser to confirm English text displays correctly
- [ ] Verify form inputs and placeholders work with English text
- [ ] Check responsive design with English text lengths

🤖 Generated with [Claude Code](https://claude.ai/code)