### PR TITLE
feat: Display real database-backed statistics on landing page

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -117,6 +117,16 @@ export class AnalyticsController {
     );
   }
 
+  @Get('platform/stats')
+  @Public()
+  @ApiOperation({
+    summary:
+      'Get platform-wide statistics (total questions, certifications, etc)',
+  })
+  getPlatformStats() {
+    return this.analyticsService.getPlatformStats();
+  }
+
   @Get('questions/:id/stats')
   @Public()
   @ApiOperation({

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -5,7 +5,12 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { AttemptStatus, MistakeType, Prisma } from '@prisma/client';
+import {
+  AttemptStatus,
+  MistakeType,
+  Prisma,
+  QuestionStatus,
+} from '@prisma/client';
 import { UpdateMistakeTypeDto } from './dto/update-mistake-type.dto';
 import {
   AnalyticsSummaryResponse,
@@ -430,5 +435,37 @@ export class AnalyticsService {
       .sort((a, b) => b.hesitationRatio - a.hesitationRatio);
 
     return { data: hesitating, total: hesitating.length };
+  }
+
+  async getPlatformStats() {
+    const [totalQuestions, totalCertifications, totalExamAttempts] =
+      await Promise.all([
+        this.prisma.question.count({
+          where: { status: QuestionStatus.APPROVED },
+        }),
+        this.prisma.certification.count(),
+        this.prisma.examAttempt.count({
+          where: { status: AttemptStatus.SUBMITTED },
+        }),
+      ]);
+
+    const passedAttempts = await this.prisma.examAttempt.count({
+      where: {
+        status: AttemptStatus.SUBMITTED,
+        score: { gte: 70 },
+      },
+    });
+
+    const averagePassRate =
+      totalExamAttempts > 0
+        ? Math.round((passedAttempts / totalExamAttempts) * 100)
+        : 0;
+
+    return {
+      totalQuestions,
+      totalCertifications,
+      totalExamAttempts,
+      averagePassRate,
+    };
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { useQuery } from "@tanstack/react-query";
 import { getCertifications } from "@/services/certifications";
 import { getMyPoints } from "@/services/gamification";
+import { getPlatformStats, type PlatformStats } from "@/services/analytics";
 import { useNavigate, Link } from "react-router-dom";
 import {
   Brain,
@@ -18,6 +19,12 @@ import { CardSkeleton } from "@/components/PageSkeleton";
 import { useAuthStore } from "@/stores/auth.store";
 import { fallbackCertifications } from "@/data/fallbackCertifications";
 import Navbar from "@/components/Navbar";
+
+const formatStat = (value: number): string => {
+  if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M+`;
+  if (value >= 1000) return `${(value / 1000).toFixed(0)}K+`;
+  return value.toString();
+};
 
 const features = [
   {
@@ -52,11 +59,11 @@ const features = [
   },
 ];
 
-const stats = [
-  { value: "10K+", label: "Questions" },
-  { value: "5", label: "Certifications" },
-  { value: "50K+", label: "Exams Taken" },
-  { value: "89%", label: "Pass Rate" },
+const StatFallback = [
+  { value: "—", label: "Questions" },
+  { value: "—", label: "Certifications" },
+  { value: "—", label: "Exams Taken" },
+  { value: "—", label: "Pass Rate" },
 ];
 
 const Index = () => {
@@ -72,6 +79,28 @@ const Index = () => {
     queryFn: getMyPoints,
     enabled: isAuthenticated,
   });
+  const { data: platformStats } = useQuery<PlatformStats>({
+    queryKey: ["platform-stats"],
+    queryFn: getPlatformStats,
+  });
+
+  const stats = platformStats
+    ? [
+        { value: formatStat(platformStats.totalQuestions), label: "Questions" },
+        {
+          value: formatStat(platformStats.totalCertifications),
+          label: "Certifications",
+        },
+        {
+          value: formatStat(platformStats.totalExamAttempts),
+          label: "Exams Taken",
+        },
+        {
+          value: `${platformStats.averagePassRate}%`,
+          label: "Pass Rate",
+        },
+      ]
+    : StatFallback;
 
   return (
     <main id="main-content" className="min-h-screen bg-background">
@@ -109,10 +138,14 @@ const Index = () => {
               </span>
             </div>
             <h1 className="text-4xl md:text-6xl lg:text-7xl font-extrabold font-mono tracking-tight leading-[1.1] mb-8">
-              <span className="block text-foreground">Master your certification</span>
+              <span className="block text-foreground">
+                Master your certification
+              </span>
               <span
                 className="block text-transparent bg-clip-text bg-gradient-to-r from-primary via-accent to-primary"
-                style={{ filter: "drop-shadow(0 0 18px hsl(var(--primary) / 0.35))" }}
+                style={{
+                  filter: "drop-shadow(0 0 18px hsl(var(--primary) / 0.35))",
+                }}
               >
                 with the community
               </span>
@@ -228,7 +261,8 @@ const Index = () => {
             className="text-center mb-12"
           >
             <h2 className="text-3xl font-bold font-mono mb-3">
-              More than just <span className="text-gradient-cyan">practice tests</span>
+              More than just{" "}
+              <span className="text-gradient-cyan">practice tests</span>
             </h2>
             <p className="text-muted-foreground">
               A complete certification training ecosystem

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -95,3 +95,15 @@ export const getMistakePatterns = async (
   );
   return response.data;
 };
+
+export interface PlatformStats {
+  totalQuestions: number;
+  totalCertifications: number;
+  totalExamAttempts: number;
+  averagePassRate: number;
+}
+
+export const getPlatformStats = async (): Promise<PlatformStats> => {
+  const response = await api.get<PlatformStats>("/analytics/platform/stats");
+  return response.data;
+};


### PR DESCRIPTION
## Summary
Replaced hardcoded placeholder statistics with real, database-backed values on the landing page.

## What Changed
- **Backend**: Added `getPlatformStats()` method in analytics service that queries:
  - Count of approved questions
  - Count of certifications
  - Count of submitted exam attempts
  - Calculated average pass rate (attempts with score >= 70)
- **API Endpoint**: Exposed data via `GET /api/v1/analytics/platform/stats` with @Public() decorator for unauthenticated access
- **Frontend**: 
  - Updated landing page (Index.tsx) to fetch real statistics using React Query
  - Implemented number formatting utility (`formatStat()`) to display large numbers as K+ or M+
  - Added fallback placeholder stats (`—`) during loading state

## Test Plan
- [x] Backend endpoint returns correct JSON structure with real database values
- [x] Frontend correctly fetches and displays statistics via React Query
- [x] Fallback placeholders show while data is loading
- [x] Landing page displays real statistics instead of hardcoded values
- [ ] Verify on production-like deployment with real seed data
- [ ] Test loading states and error handling edge cases

## Notes
- Uses existing database schema; no migrations required
- Pass rate is calculated as percentage of submitted attempts with score >= 70
- Endpoint is public (no authentication required) to display stats on unauthenticated landing page