### PR TITLE
feat: user profile page with avatar upload and password change

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1055.0",
+        "@aws-sdk/s3-request-presigner": "^3.1055.0",
         "@bull-board/api": "^7.0.0",
         "@bull-board/express": "^7.0.0",
         "@bull-board/nestjs": "^7.0.0",
@@ -206,6 +208,517 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1055.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1055.0.tgz",
+      "integrity": "sha512-FxVwuw86c2Mw4p+0tOtoE+1sDTk+eOBZD/NwwK+wwx1gHkdO/EYSv231O9A1YM8HPjUrI0vZ/hP/szckBxHW0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/credential-provider-node": "^3.972.45",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.16",
+        "@aws-sdk/middleware-expect-continue": "^3.972.13",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.22",
+        "@aws-sdk/middleware-location-constraint": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.43",
+        "@aws-sdk/middleware-ssec": "^3.972.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
+      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.3",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
+      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
+      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
+      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
+      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/credential-provider-env": "^3.972.40",
+        "@aws-sdk/credential-provider-http": "^3.972.42",
+        "@aws-sdk/credential-provider-login": "^3.972.44",
+        "@aws-sdk/credential-provider-process": "^3.972.40",
+        "@aws-sdk/credential-provider-sso": "^3.972.44",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
+        "@aws-sdk/nested-clients": "^3.997.12",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.44.tgz",
+      "integrity": "sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/nested-clients": "^3.997.12",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
+      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.40",
+        "@aws-sdk/credential-provider-http": "^3.972.42",
+        "@aws-sdk/credential-provider-ini": "^3.972.44",
+        "@aws-sdk/credential-provider-process": "^3.972.40",
+        "@aws-sdk/credential-provider-sso": "^3.972.44",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
+      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
+      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/nested-clients": "^3.997.12",
+        "@aws-sdk/token-providers": "3.1054.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
+      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/nested-clients": "^3.997.12",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.16.tgz",
+      "integrity": "sha512-FhasMTBDBmMN7EEa1hUeHwo5p5Mv3Dm8w0VEbdXX/6ola/uyhRuJt8zGkH09mLTmab20USTzEpPqyqEoe1MqNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.13.tgz",
+      "integrity": "sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.22.tgz",
+      "integrity": "sha512-ot1kZ1JGHUxcXPOARhej/n/+Odfx9VPt60pNrUq8Lf/U2blIF3+uj5v56gw76VD70dZvrfeLNo9jKz6pQJfOlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/crc64-nvme": "^3.972.9",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
+      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.43.tgz",
+      "integrity": "sha512-CBmixMY36JdAdt9ALgm7yVlvOXGUCHt9Z2kn5p9XVO5StO6HCH+cayV7YYV1CDLsXvVyebaXgBmif9wHoxCeNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
+      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
+      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1055.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1055.0.tgz",
+      "integrity": "sha512-/qbh/nG6PQG4CxFYS9IDkUXtPsDcYCjuPaLejhyG7Cw2Ary6XqIshtrWlUjLPIc163IueHXQR/aq2WQt9f0OxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.29.tgz",
+      "integrity": "sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1054.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
+      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "@aws-sdk/nested-clients": "^3.997.12",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3596,6 +4109,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -3738,6 +4263,126 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
+      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.5.tgz",
+      "integrity": "sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
+      "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
+      "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
+      "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -5009,6 +5654,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -6638,6 +7289,43 @@
           "url": "https://opencollective.com/fastify"
         }
       ]
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -10821,6 +11509,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -11741,6 +12444,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
@@ -12779,6 +13494,21 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,8 @@
     "seed": "npm run seed"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1055.0",
+    "@aws-sdk/s3-request-presigner": "^3.1055.0",
     "@bull-board/api": "^7.0.0",
     "@bull-board/express": "^7.0.0",
     "@bull-board/nestjs": "^7.0.0",

--- a/backend/src/common/storage/avatar-upload.interceptor.ts
+++ b/backend/src/common/storage/avatar-upload.interceptor.ts
@@ -1,0 +1,49 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  BadRequestException,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import multer from 'multer';
+import { StorageService } from './storage.service';
+
+/** Used only in local-dev mode (no S3 configured). Saves the file to disk. */
+@Injectable()
+export class AvatarUploadInterceptor implements NestInterceptor {
+  constructor(private readonly storageService: StorageService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+
+    const upload = multer({
+      storage: this.storageService.buildLocalDiskStorage(),
+      fileFilter: (_req, file, cb) => {
+        if (!file.mimetype.match(/^image\/(jpeg|png|gif|webp)$/)) {
+          return cb(
+            new BadRequestException('Only image files are allowed') as any,
+            false,
+          );
+        }
+        cb(null, true);
+      },
+      limits: { fileSize: 2 * 1024 * 1024 },
+    }).single('file');
+
+    return new Observable((observer) => {
+      upload(req, res, (err) => {
+        if (err) {
+          observer.error(
+            err instanceof BadRequestException
+              ? err
+              : new BadRequestException(err.message),
+          );
+        } else {
+          next.handle().subscribe(observer);
+        }
+      });
+    });
+  }
+}

--- a/backend/src/common/storage/storage.service.ts
+++ b/backend/src/common/storage/storage.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { StorageEngine } from 'multer';
+import { diskStorage } from 'multer';
+import { extname, join } from 'path';
+import { existsSync, mkdirSync } from 'fs';
+
+export interface PresignResult {
+  mode: 's3';
+  uploadUrl: string;
+  key: string;
+  /** Full public URL after upload completes */
+  publicUrl: string;
+}
+
+export interface LocalUploadResult {
+  mode: 'local';
+  /** URL the frontend should POST multipart/form-data to */
+  uploadUrl: string;
+}
+
+@Injectable()
+export class StorageService {
+  private readonly logger = new Logger(StorageService.name);
+  private readonly s3: S3Client | null;
+  readonly isS3: boolean;
+  private readonly bucket: string;
+  private readonly cdnBase: string;
+
+  constructor() {
+    this.bucket = process.env.AWS_S3_AVATARS_BUCKET ?? '';
+    this.cdnBase = (process.env.AWS_AVATARS_CDN_BASE_URL ?? '').replace(
+      /\/$/,
+      '',
+    );
+    const region = process.env.AWS_REGION;
+
+    if (this.bucket && region) {
+      // Credentials come from the ECS task IAM role — no static keys needed.
+      // Locally the SDK falls back to ~/.aws/credentials or env vars if set.
+      this.s3 = new S3Client({ region });
+      this.isS3 = true;
+      this.logger.log(`Storage: S3 (bucket=${this.bucket}, region=${region})`);
+    } else {
+      this.s3 = null;
+      this.isS3 = false;
+      this.logger.log('Storage: local disk (uploads/avatars)');
+    }
+  }
+
+  /** Generate a presigned PUT URL for direct browser → S3 upload (expires in 5 min). */
+  async presignAvatarUpload(
+    contentType: string,
+  ): Promise<PresignResult | LocalUploadResult> {
+    if (!this.isS3 || !this.s3) {
+      return {
+        mode: 'local',
+        uploadUrl: '/api/v1/users/me/avatar/upload-local',
+      };
+    }
+
+    const ext = contentType.split('/')[1] ?? 'jpg';
+    const key = `${Date.now()}-${Math.round(Math.random() * 1e9)}.${ext}`;
+
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      ContentType: contentType,
+    });
+
+    const uploadUrl = await getSignedUrl(this.s3, command, { expiresIn: 300 });
+    const publicUrl = `${this.cdnBase}/${key}`;
+
+    return { mode: 's3', uploadUrl, key, publicUrl };
+  }
+
+  /** Build the CloudFront public URL from a confirmed S3 key. */
+  resolvePublicUrl(key: string): string {
+    return `${this.cdnBase}/${key}`;
+  }
+
+  /** Disk storage engine for local-only uploads. */
+  buildLocalDiskStorage(): StorageEngine {
+    return diskStorage({
+      destination: (_req, _file, cb) => {
+        const dir = join(process.cwd(), 'uploads', 'avatars');
+        if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+        cb(null, dir);
+      },
+      filename: (_req, file, cb) => {
+        const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+        cb(null, unique + extname(file.originalname));
+      },
+    });
+  }
+
+  async deleteAvatar(avatarUrl: string): Promise<void> {
+    if (!this.isS3 || !this.s3) return;
+    if (!avatarUrl.includes(this.cdnBase)) return;
+
+    const key = avatarUrl.replace(`${this.cdnBase}/`, '');
+    try {
+      await this.s3.send(
+        new DeleteObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+    } catch (err) {
+      this.logger.warn(`Failed to delete S3 object ${key}: ${err}`);
+    }
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,7 +1,9 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { join } from 'path';
 
 function validateEnv() {
   const required = ['JWT_SECRET', 'JWT_REFRESH_SECRET', 'DATABASE_URL'];
@@ -15,7 +17,8 @@ function validateEnv() {
 async function bootstrap() {
   validateEnv();
 
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.useStaticAssets(join(process.cwd(), 'uploads'), { prefix: '/uploads' });
 
   // Global prefix
   app.setGlobalPrefix('api/v1');

--- a/backend/src/users/dto/change-password.dto.ts
+++ b/backend/src/users/dto/change-password.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @ApiProperty()
+  @IsString()
+  currentPassword: string;
+
+  @ApiProperty()
+  @IsString()
+  @MinLength(8)
+  newPassword: string;
+}

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { AuditService } from '../audit/audit.service';
+import { StorageService } from '../common/storage/storage.service';
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -20,6 +21,13 @@ describe('UsersController', () => {
         {
           provide: AuditService,
           useValue: { log: jest.fn() },
+        },
+        {
+          provide: StorageService,
+          useValue: {
+            presignAvatarUpload: jest.fn(),
+            resolvePublicUrl: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -2,22 +2,30 @@ import {
   Controller,
   Get,
   Put,
+  Post,
   Body,
   Param,
   Query,
   Req,
   UseGuards,
+  UseInterceptors,
+  BadRequestException,
 } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiBearerAuth,
   ApiQuery,
+  ApiConsumes,
+  ApiBody,
 } from '@nestjs/swagger';
 import { UsersService } from './users.service';
+import { StorageService } from '../common/storage/storage.service';
+import { AvatarUploadInterceptor } from '../common/storage/avatar-upload.interceptor';
 import { UpdateUserRoleDto } from './dto/update-user-role.dto';
 import { UpdateUserPlanDto } from './dto/update-user-plan.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import { SuspendUserDto } from './dto/suspend-user.dto';
 import { BanUserDto } from './dto/ban-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -34,6 +42,7 @@ export class UsersController {
   constructor(
     private readonly usersService: UsersService,
     private readonly auditService: AuditService,
+    private readonly storageService: StorageService,
   ) {}
 
   @Get('me')
@@ -52,6 +61,72 @@ export class UsersController {
   updateProfile(@Req() req: any, @Body() dto: UpdateProfileDto) {
     const userId = req.user.sub || req.user.id;
     return this.usersService.updateProfile(userId, dto);
+  }
+
+  @Post('me/avatar/presign')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get presigned PUT URL for avatar upload' })
+  @ApiBody({
+    schema: {
+      properties: { contentType: { type: 'string' } },
+      required: ['contentType'],
+    },
+  })
+  async presignAvatar(@Body('contentType') contentType: string) {
+    if (!contentType?.match(/^image\/(jpeg|png|gif|webp)$/)) {
+      throw new BadRequestException(
+        'contentType must be a valid image MIME type',
+      );
+    }
+    return this.storageService.presignAvatarUpload(contentType);
+  }
+
+  @Post('me/avatar/confirm')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Confirm avatar upload and save URL to profile' })
+  @ApiBody({
+    schema: { properties: { key: { type: 'string' } }, required: ['key'] },
+  })
+  async confirmAvatar(@Req() req: any, @Body('key') key: string) {
+    if (!key) throw new BadRequestException('key is required');
+    const userId = req.user.sub || req.user.id;
+    const avatarUrl = this.storageService.resolvePublicUrl(key);
+    const updated = await this.usersService.updateProfile(userId, {
+      avatarUrl,
+    });
+    return { avatarUrl: updated.avatarUrl };
+  }
+
+  @Post('me/avatar/upload-local')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Local-dev avatar upload (disk storage)' })
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(AvatarUploadInterceptor)
+  async uploadAvatarLocal(@Req() req: any) {
+    const file = req.file as Express.Multer.File;
+    if (!file) throw new BadRequestException('No file provided');
+    const userId = req.user.sub || req.user.id;
+    const avatarUrl = `/uploads/avatars/${file.filename}`;
+    const updated = await this.usersService.updateProfile(userId, {
+      avatarUrl,
+    });
+    return { avatarUrl: updated.avatarUrl };
+  }
+
+  @Put('me/password')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Change own password' })
+  changePassword(@Req() req: any, @Body() dto: ChangePasswordDto) {
+    const userId = req.user.sub || req.user.id;
+    return this.usersService.changePassword(
+      userId,
+      dto.currentPassword,
+      dto.newPassword,
+    );
   }
 
   @Get()

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { StorageService } from '../common/storage/storage.service';
+import { AvatarUploadInterceptor } from '../common/storage/avatar-upload.interceptor';
 
 @Module({
-  providers: [UsersService],
+  providers: [UsersService, StorageService, AvatarUploadInterceptor],
   controllers: [UsersController],
   exports: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   ForbiddenException,
+  BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -215,5 +216,29 @@ export class UsersService {
       data: { points: { increment: amount } },
       select: publicSelect,
     });
+  }
+
+  async changePassword(
+    userId: string,
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<{ message: string }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+    if (!user.passwordHash)
+      throw new BadRequestException(
+        'Password change not available for OAuth accounts',
+      );
+
+    const valid = await bcrypt.compare(currentPassword, user.passwordHash);
+    if (!valid) throw new BadRequestException('Current password is incorrect');
+
+    const salt = await bcrypt.genSalt();
+    const hash = await bcrypt.hash(newPassword, salt);
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { passwordHash: hash },
+    });
+    return { message: 'Password updated successfully' };
   }
 }

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -57,7 +57,10 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "PORT", value = "3000" },
         { name = "REDIS_HOST", value = aws_elasticache_replication_group.redis.primary_endpoint_address },
         { name = "REDIS_PORT", value = tostring(aws_elasticache_replication_group.redis.port) },
-        { name = "CORS_ORIGINS", value = "https://${var.domain_name},https://www.${var.domain_name},https://${aws_cloudfront_distribution.main.domain_name}" }
+        { name = "CORS_ORIGINS", value = "https://${var.domain_name},https://www.${var.domain_name},https://${aws_cloudfront_distribution.main.domain_name}" },
+        { name = "AWS_REGION", value = var.aws_region },
+        { name = "AWS_S3_AVATARS_BUCKET", value = aws_s3_bucket.avatars.bucket },
+        { name = "AWS_AVATARS_CDN_BASE_URL", value = "https://${aws_cloudfront_distribution.main.domain_name}/avatars" },
       ]
 
       secrets = [

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -62,6 +62,27 @@ resource "aws_iam_role" "ecs_task" {
   })
 }
 
+# Allow the ECS task to generate presigned PUT URLs and manage avatar objects.
+# No static access keys — the task inherits credentials from this role automatically.
+resource "aws_iam_role_policy" "ecs_task_avatars" {
+  name = "s3-avatars"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AvatarsBucket"
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+      ]
+      Resource = "${aws_s3_bucket.avatars.arn}/*"
+    }]
+  })
+}
+
 # ─────────────────────────────────────────────
 # GitHub Actions Deploy Role (OIDC)
 # Assumed by GitHub Actions via OIDC — no static

--- a/infra/s3_cloudfront.tf
+++ b/infra/s3_cloudfront.tf
@@ -92,7 +92,14 @@ resource "aws_cloudfront_distribution" "main" {
     origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
   }
 
-  # Origin 2: ALB (backend API)
+  # Origin 2: S3 avatars bucket (user-uploaded images)
+  origin {
+    domain_name              = aws_s3_bucket.avatars.bucket_regional_domain_name
+    origin_id                = "s3-avatars"
+    origin_access_control_id = aws_cloudfront_origin_access_control.avatars.id
+  }
+
+  # Origin 3: ALB (backend API)
   origin {
     domain_name = aws_lb.main.dns_name
     origin_id   = "alb-backend"
@@ -105,7 +112,28 @@ resource "aws_cloudfront_distribution" "main" {
     }
   }
 
-  # Behavior 1: /api/v1/* → ALB (no caching)
+  # Behavior 1: /avatars/* → S3 avatars (long-lived cache, immutable filenames)
+  ordered_cache_behavior {
+    path_pattern     = "/avatars/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "s3-avatars"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+  }
+
+  # Behavior 2: /api/v1/* → ALB (no caching)
   ordered_cache_behavior {
     path_pattern     = "/api/v1/*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -179,6 +207,89 @@ resource "aws_cloudfront_distribution" "main" {
   })
 }
 
+# ─────────────────────────────────────────────
+# S3 Bucket — Avatar uploads
+# Private; served publicly through CloudFront /avatars/*
+# Browsers upload directly via presigned PUT URLs
+# signed by the ECS task role (no static credentials)
+# ─────────────────────────────────────────────
+resource "aws_s3_bucket" "avatars" {
+  bucket = "${var.app_name}-${var.environment}-avatars"
+
+  tags = merge(var.common_tags, {
+    Name = "${var.app_name}-${var.environment}-avatars"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# CORS: allow browsers to PUT directly using presigned URLs
+resource "aws_s3_bucket_cors_configuration" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+
+  cors_rule {
+    allowed_headers = ["Content-Type", "Content-Length"]
+    allowed_methods = ["PUT"]
+    allowed_origins = [
+      "https://${var.domain_name}",
+      "https://www.${var.domain_name}",
+      "https://${aws_cloudfront_distribution.main.domain_name}",
+    ]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
+# OAC: let CloudFront read from the private avatars bucket
+resource "aws_cloudfront_origin_access_control" "avatars" {
+  name                              = "${var.app_name}-${var.environment}-avatars-oac"
+  description                       = "OAC for ${var.app_name} ${var.environment} avatars"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# Bucket policy: only CloudFront OAC can read objects
+resource "aws_s3_bucket_policy" "avatars" {
+  bucket = aws_s3_bucket.avatars.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AllowCloudFrontOAC"
+      Effect = "Allow"
+      Principal = {
+        Service = "cloudfront.amazonaws.com"
+      }
+      Action   = "s3:GetObject"
+      Resource = "${aws_s3_bucket.avatars.arn}/*"
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = aws_cloudfront_distribution.main.arn
+        }
+      }
+    }]
+  })
+
+  depends_on = [aws_cloudfront_distribution.main]
+}
+
 output "cloudfront_distribution_id" {
   value       = aws_cloudfront_distribution.main.id
   description = "CloudFront distribution ID — use as AWS_CLOUDFRONT_DISTRIBUTION_ID in GitHub secrets"
@@ -192,4 +303,14 @@ output "cloudfront_domain_name" {
 output "s3_bucket_name" {
   value       = aws_s3_bucket.frontend.bucket
   description = "S3 bucket name — use as AWS_S3_BUCKET in GitHub secrets"
+}
+
+output "s3_avatars_bucket_name" {
+  value       = aws_s3_bucket.avatars.bucket
+  description = "Avatars S3 bucket — use as AWS_S3_AVATARS_BUCKET in ECS env / GitHub secrets"
+}
+
+output "avatars_cdn_base_url" {
+  value       = "https://${aws_cloudfront_distribution.main.domain_name}/avatars"
+  description = "CloudFront base URL for avatar files — use as AWS_AVATARS_CDN_BASE_URL in ECS env"
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -20,6 +20,12 @@ server {
         proxy_set_header Host $host;
     }
 
+    # Local-dev avatar uploads served by NestJS static assets
+    location /uploads {
+        proxy_pass http://backend:3000/uploads;
+        proxy_set_header Host $host;
+    }
+
     # Frontend Proxy
     location / {
         proxy_pass http://frontend:80;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,9 @@ const ScenarioResults = lazy(() => import("./pages/ScenarioResults"));
 // Knowledge Graph page
 const KnowledgeGraph = lazy(() => import("./pages/KnowledgeGraph"));
 
+// Profile page
+const ProfilePage = lazy(() => import("./pages/Profile"));
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -428,6 +431,17 @@ const AnimatedRoutes = () => {
                 <Suspense fallback={<LoadingFallback />}>
                   <KnowledgeGraph />
                 </Suspense>
+              </ProtectedRoute>
+            </PageTransition>
+          }
+        />
+
+        <Route
+          path="/profile"
+          element={
+            <PageTransition>
+              <ProtectedRoute>
+                <ProfilePage />
               </ProtectedRoute>
             </PageTransition>
           }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,25 +7,28 @@ import {
   Plus,
   Shield,
   Menu,
-  X,
   BookOpen,
   BarChart3,
   Trophy,
   Target,
   Dumbbell,
   Layers,
-  Library,
   AlertTriangle,
   Bot,
   Building2,
+  UserCircle,
+  LogOut,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import {
-  Sheet,
-  SheetContent,
-  SheetTrigger,
-  SheetClose,
-} from "@/components/ui/sheet";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useAuthStore } from "@/stores/auth.store";
 import { useOrgStore } from "@/stores/org.store";
 import { getMyPoints } from "@/services/gamification";
@@ -55,16 +58,21 @@ const Navbar = ({ title, showBack, icon: LogoIcon = Brain }: NavbarProps) => {
   const [open, setOpen] = useState(false);
 
   const orgMemberships = user?.orgMemberships ?? [];
-  const belongsToCurrentOrg = orgMemberships.some(m => m.slug === currentOrg?.slug);
+  const belongsToCurrentOrg = orgMemberships.some(
+    (m) => m.slug === currentOrg?.slug,
+  );
   const orgHref =
     orgMemberships.length === 1
       ? `/org/${orgMemberships[0].slug}`
-      : currentOrg && (belongsToCurrentOrg || user?.role === 'ADMIN')
+      : currentOrg && (belongsToCurrentOrg || user?.role === "ADMIN")
         ? `/org/${currentOrg.slug}`
         : "/org";
   const navLinks = [
     ...staticNavLinks.slice(0, 7), // before Leaderboard
-    ...(orgMemberships.length > 0 || user?.plan === "PREMIUM" || user?.plan === "ENTERPRISE" || user?.role === "ADMIN"
+    ...(orgMemberships.length > 0 ||
+    user?.plan === "PREMIUM" ||
+    user?.plan === "ENTERPRISE" ||
+    user?.role === "ADMIN"
       ? [{ label: "Organization", href: orgHref, icon: Building2 }]
       : []),
     ...staticNavLinks.slice(7), // Leaderboard
@@ -154,14 +162,47 @@ const Navbar = ({ title, showBack, icon: LogoIcon = Brain }: NavbarProps) => {
                   <Shield className="w-3.5 h-3.5 mr-1" /> Admin
                 </Button>
               )}
-              <Button
-                size="sm"
-                variant="outline"
-                className="hidden md:flex border-destructive/50 text-destructive hover:bg-destructive/10 h-8 text-xs"
-                onClick={() => logout()}
-              >
-                Logout
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className="hidden md:flex items-center gap-1.5 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                    aria-label="User menu"
+                  >
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={user?.avatarUrl ?? undefined} />
+                      <AvatarFallback className="text-xs font-mono bg-primary/10 text-primary">
+                        {(user?.displayName ?? "U")
+                          .split(" ")
+                          .map((w) => w[0])
+                          .join("")
+                          .toUpperCase()
+                          .slice(0, 2)}
+                      </AvatarFallback>
+                    </Avatar>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <div className="px-2 py-1.5">
+                    <p className="text-xs font-mono font-medium truncate">
+                      {user?.displayName}
+                    </p>
+                    <p className="text-xs text-muted-foreground truncate">
+                      {user?.email}
+                    </p>
+                  </div>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => navigate("/profile")}>
+                    <UserCircle className="h-4 w-4 mr-2" /> Profile
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => logout()}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <LogOut className="h-4 w-4 mr-2" /> Logout
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </>
           ) : (
             <Button
@@ -248,6 +289,13 @@ const Navbar = ({ title, showBack, icon: LogoIcon = Brain }: NavbarProps) => {
                           points
                         </div>
                       )}
+                      <button
+                        onClick={() => handleNav("/profile")}
+                        className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-mono text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                      >
+                        <UserCircle className="h-4 w-4" />
+                        Profile
+                      </button>
                       <Button
                         size="sm"
                         variant="outline"
@@ -257,7 +305,7 @@ const Navbar = ({ title, showBack, icon: LogoIcon = Brain }: NavbarProps) => {
                           logout();
                         }}
                       >
-                        Logout
+                        <LogOut className="h-4 w-4 mr-2" /> Logout
                       </Button>
                     </div>
                   ) : (

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,322 @@
+import { useRef, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Camera, KeyRound, User } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import Navbar from "@/components/Navbar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useToast } from "@/hooks/use-toast";
+import { useAuthStore } from "@/stores/auth.store";
+import {
+  getMyProfile,
+  updateProfile,
+  uploadAvatar,
+  changePassword,
+} from "@/services/user";
+
+const profileSchema = z.object({
+  displayName: z.string().min(1, "Display name is required").max(100),
+});
+
+const passwordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Current password is required"),
+    newPassword: z
+      .string()
+      .min(8, "New password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((d) => d.newPassword === d.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+type ProfileForm = z.infer<typeof profileSchema>;
+type PasswordForm = z.infer<typeof passwordSchema>;
+
+export default function Profile() {
+  const { toast } = useToast();
+  const qc = useQueryClient();
+  const { user, setAuth, accessToken, refreshToken } = useAuthStore();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+
+  const { data: profile, isLoading } = useQuery({
+    queryKey: ["my-profile"],
+    queryFn: getMyProfile,
+  });
+
+  const profileForm = useForm<ProfileForm>({
+    resolver: zodResolver(profileSchema),
+    values: { displayName: profile?.displayName ?? "" },
+  });
+
+  const passwordForm = useForm<PasswordForm>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: {
+      currentPassword: "",
+      newPassword: "",
+      confirmPassword: "",
+    },
+  });
+
+  const updateProfileMutation = useMutation({
+    mutationFn: updateProfile,
+    onSuccess: (updated) => {
+      qc.invalidateQueries({ queryKey: ["my-profile"] });
+      if (user && accessToken && refreshToken) {
+        setAuth(
+          {
+            ...user,
+            displayName: updated.displayName,
+            avatarUrl: updated.avatarUrl ?? user.avatarUrl,
+          },
+          accessToken,
+          refreshToken,
+        );
+      }
+      toast({ title: "Profile updated" });
+    },
+    onError: () =>
+      toast({ title: "Failed to update profile", variant: "destructive" }),
+  });
+
+  const uploadAvatarMutation = useMutation({
+    mutationFn: uploadAvatar,
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ["my-profile"] });
+      if (user && accessToken && refreshToken) {
+        setAuth(
+          { ...user, avatarUrl: res.avatarUrl },
+          accessToken,
+          refreshToken,
+        );
+      }
+      setAvatarPreview(null);
+      toast({ title: "Avatar updated" });
+    },
+    onError: () =>
+      toast({ title: "Failed to upload avatar", variant: "destructive" }),
+  });
+
+  const changePasswordMutation = useMutation({
+    mutationFn: changePassword,
+    onSuccess: () => {
+      passwordForm.reset();
+      toast({ title: "Password changed successfully" });
+    },
+    onError: (err: any) => {
+      const msg = err?.response?.data?.message ?? "Failed to change password";
+      toast({ title: msg, variant: "destructive" });
+    },
+  });
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setAvatarPreview(URL.createObjectURL(file));
+    uploadAvatarMutation.mutate(file);
+  };
+
+  const initials = (profile?.displayName ?? user?.displayName ?? "U")
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+  const avatarSrc = avatarPreview ?? profile?.avatarUrl ?? user?.avatarUrl;
+
+  if (isLoading) return null;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar title="Profile" />
+      <main id="main-content" className="container max-w-2xl px-4 pt-24 pb-20">
+        <Tabs defaultValue="info">
+          <TabsList className="w-full mb-8">
+            <TabsTrigger value="info" className="flex-1 gap-2">
+              <User className="h-4 w-4" /> Personal Info
+            </TabsTrigger>
+            <TabsTrigger value="security" className="flex-1 gap-2">
+              <KeyRound className="h-4 w-4" /> Security
+            </TabsTrigger>
+          </TabsList>
+
+          {/* Personal Info */}
+          <TabsContent value="info">
+            <div className="space-y-8">
+              {/* Avatar */}
+              <div className="flex flex-col items-center gap-3">
+                <div className="relative group">
+                  <Avatar className="h-24 w-24 ring-2 ring-border">
+                    <AvatarImage src={avatarSrc} />
+                    <AvatarFallback className="text-2xl font-mono bg-primary/10 text-primary">
+                      {initials}
+                    </AvatarFallback>
+                  </Avatar>
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploadAvatarMutation.isPending}
+                    className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity"
+                    aria-label="Upload avatar"
+                  >
+                    <Camera className="h-6 w-6 text-white" />
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground font-mono">
+                  {uploadAvatarMutation.isPending
+                    ? "Uploading…"
+                    : "Click to change avatar · Max 2 MB"}
+                </p>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/gif,image/webp"
+                  className="hidden"
+                  onChange={handleFileChange}
+                />
+              </div>
+
+              {/* Profile form */}
+              <form
+                onSubmit={profileForm.handleSubmit((data) =>
+                  updateProfileMutation.mutate(data),
+                )}
+                className="space-y-5"
+              >
+                <div className="space-y-1.5">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    value={profile?.email ?? ""}
+                    disabled
+                    className="bg-muted/40 font-mono text-sm"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Email cannot be changed.
+                  </p>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="displayName">Display Name</Label>
+                  <Input
+                    id="displayName"
+                    {...profileForm.register("displayName")}
+                    className="font-mono text-sm"
+                  />
+                  {profileForm.formState.errors.displayName && (
+                    <p className="text-xs text-destructive">
+                      {profileForm.formState.errors.displayName.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label>Role</Label>
+                  <Input
+                    value={profile?.role ?? ""}
+                    disabled
+                    className="bg-muted/40 font-mono text-sm capitalize"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label>Plan</Label>
+                  <Input
+                    value={profile?.plan ?? ""}
+                    disabled
+                    className="bg-muted/40 font-mono text-sm capitalize"
+                  />
+                </div>
+
+                <Button
+                  type="submit"
+                  className="w-full glow-cyan"
+                  disabled={updateProfileMutation.isPending}
+                >
+                  {updateProfileMutation.isPending ? "Saving…" : "Save Changes"}
+                </Button>
+              </form>
+            </div>
+          </TabsContent>
+
+          {/* Security */}
+          <TabsContent value="security">
+            <form
+              onSubmit={passwordForm.handleSubmit((data) =>
+                changePasswordMutation.mutate({
+                  currentPassword: data.currentPassword,
+                  newPassword: data.newPassword,
+                }),
+              )}
+              className="space-y-5"
+            >
+              <div className="space-y-1.5">
+                <Label htmlFor="currentPassword">Current Password</Label>
+                <Input
+                  id="currentPassword"
+                  type="password"
+                  {...passwordForm.register("currentPassword")}
+                  className="font-mono text-sm"
+                />
+                {passwordForm.formState.errors.currentPassword && (
+                  <p className="text-xs text-destructive">
+                    {passwordForm.formState.errors.currentPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="newPassword">New Password</Label>
+                <Input
+                  id="newPassword"
+                  type="password"
+                  {...passwordForm.register("newPassword")}
+                  className="font-mono text-sm"
+                />
+                {passwordForm.formState.errors.newPassword && (
+                  <p className="text-xs text-destructive">
+                    {passwordForm.formState.errors.newPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="confirmPassword">Confirm New Password</Label>
+                <Input
+                  id="confirmPassword"
+                  type="password"
+                  {...passwordForm.register("confirmPassword")}
+                  className="font-mono text-sm"
+                />
+                {passwordForm.formState.errors.confirmPassword && (
+                  <p className="text-xs text-destructive">
+                    {passwordForm.formState.errors.confirmPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <Button
+                type="submit"
+                className="w-full"
+                variant="outline"
+                disabled={changePasswordMutation.isPending}
+              >
+                {changePasswordMutation.isPending
+                  ? "Updating…"
+                  : "Change Password"}
+              </Button>
+            </form>
+          </TabsContent>
+        </Tabs>
+      </main>
+    </div>
+  );
+}

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,4 +1,5 @@
 import api from "./api";
+import { useAuthStore } from "@/stores/auth.store";
 
 export interface UserProfile {
   id: string;
@@ -52,11 +53,12 @@ export const uploadAvatar = async (
   // Local-dev path: multipart POST to backend disk endpoint
   const form = new FormData();
   form.append("file", file);
+  const token = useAuthStore.getState().accessToken;
   const localRes = await fetch(presign.uploadUrl, {
     method: "POST",
     body: form,
     headers: {
-      Authorization: api.defaults.headers.common["Authorization"] as string,
+      Authorization: `Bearer ${token}`,
     },
   });
   return localRes.json();

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,0 +1,71 @@
+import api from "./api";
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  displayName: string;
+  avatarUrl?: string;
+  role: string;
+  plan: string;
+  points: number;
+  createdAt: string;
+}
+
+export const getMyProfile = async (): Promise<UserProfile> => {
+  const res = await api.get("/users/me");
+  return res.data;
+};
+
+export const updateProfile = async (data: {
+  displayName?: string;
+  avatarUrl?: string;
+}): Promise<UserProfile> => {
+  const res = await api.put("/users/me", data);
+  return res.data;
+};
+
+export const uploadAvatar = async (
+  file: File,
+): Promise<{ avatarUrl: string }> => {
+  // Step 1: get upload destination from the backend
+  const presignRes = await api.post("/users/me/avatar/presign", {
+    contentType: file.type,
+  });
+  const presign = presignRes.data as
+    | { mode: "s3"; uploadUrl: string; key: string; publicUrl: string }
+    | { mode: "local"; uploadUrl: string };
+
+  if (presign.mode === "s3") {
+    // Step 2a: PUT directly to S3 (no auth header — URL is already signed)
+    await fetch(presign.uploadUrl, {
+      method: "PUT",
+      body: file,
+      headers: { "Content-Type": file.type },
+    });
+    // Step 2b: tell the backend which key was uploaded so it updates the DB
+    const confirmRes = await api.post("/users/me/avatar/confirm", {
+      key: presign.key,
+    });
+    return confirmRes.data;
+  }
+
+  // Local-dev path: multipart POST to backend disk endpoint
+  const form = new FormData();
+  form.append("file", file);
+  const localRes = await fetch(presign.uploadUrl, {
+    method: "POST",
+    body: form,
+    headers: {
+      Authorization: api.defaults.headers.common["Authorization"] as string,
+    },
+  });
+  return localRes.json();
+};
+
+export const changePassword = async (data: {
+  currentPassword: string;
+  newPassword: string;
+}): Promise<{ message: string }> => {
+  const res = await api.put("/users/me/password", data);
+  return res.data;
+};


### PR DESCRIPTION
## Summary

- Add `/profile` page with two tabs: **Personal Info** (display name + avatar upload) and **Security** (change password)
- Add user avatar dropdown in the Navbar with links to Profile and Logout
- Avatar upload is environment-aware: presigned S3 PUT in staging/prod, local disk (`uploads/avatars/`) in Docker dev — toggled automatically by `AWS_S3_AVATARS_BUCKET` env var
- Terraform provisions a private S3 bucket + CloudFront OAC distribution for permanent avatar URLs; ECS task IAM role gets `s3:PutObject/GetObject/DeleteObject` on the bucket (no static credentials)

## New backend endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/users/me/avatar/presign` | JWT | Returns presign info (`mode: s3` or `mode: local`) |
| POST | `/users/me/avatar/confirm` | JWT | Saves CloudFront URL after S3 upload |
| POST | `/users/me/avatar/upload-local` | JWT | Multipart upload to disk (local dev only) |
| PUT  | `/users/me/password` | JWT | Change own password |

## Test plan

- [x] Frontend unit tests: 175 passed
- [x] Backend unit tests: 479 passed
- [x] Frontend build: clean
- [x] Backend build: clean
- [x] Docker Compose build: all images built successfully
- [x] `POST /users/me/avatar/presign` returns `{"mode":"local","uploadUrl":"/api/v1/users/me/avatar/upload-local"}` in local Docker env
- [x] `POST /users/me/avatar/upload-local` stores avatar and returns `{"avatarUrl":"/uploads/avatars/<filename>"}`
- [x] `PUT /users/me/password` returns success on correct current password, 400 on wrong current password
- [ ] In staging: verify presign returns `mode: s3` and CloudFront URL is served

🤖 Generated with [Claude Code](https://claude.ai/claude-code)