### PR TITLE
feat: mount DDS variant review queue in admin DDS tab

### DIFF
--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -35,6 +35,7 @@ import { AiGenerationTab } from "./AiGenerationTab";
 import { ExamsTab } from "./ExamsTab";
 import OrganizationsTab from "./OrganizationsTab";
 import { DdsAutoApplyPanel } from "@/components/admin/DdsAutoApplyPanel";
+import { DdsVariantReview } from "@/components/admin/DdsVariantReview";
 import { ReputationTab } from "./ReputationTab";
 
 const AdminPage = () => {
@@ -160,7 +161,10 @@ const AdminPage = () => {
             <AuditLogTab />
           </TabsContent>
           <TabsContent value="dds">
-            <DdsAutoApplyPanel />
+            <div className="space-y-6">
+              <DdsAutoApplyPanel />
+              <DdsVariantReview />
+            </div>
           </TabsContent>
           <TabsContent value="reputation">
             <ReputationTab />


### PR DESCRIPTION
## What changed

Rendered the existing `DdsVariantReview` component inside the **Admin → DDS** tab, above… alongside `DdsAutoApplyPanel`.

## Why

`DdsVariantReview` (the pending-variant **Approve/Reject** queue) was fully implemented but never imported or mounted anywhere. As a result, the DDS tab only showed the read-only readiness panel — admins had no on-screen way to approve variants, which is the only action that increases `cleanApprovals` toward the Gate 2 promotion threshold (default 30).

Now both surfaces live in the same tab:
- `DdsAutoApplyPanel` — readiness `cleanApprovals/threshold` + Promote button
- `DdsVariantReview` — pending queue with Approve/Reject per variant (`PATCH /ai-question-bank/dds/variants/:id/approve`)

## Reviewer notes

- No backend/API changes; both components and their endpoints already existed.
- Approving a variant invalidates the `dds-pending` query so the readiness panel refreshes.
- If the queue is empty ("All caught up"), pending variants still need to be created via `POST .../questions/:id/propose` or the DDS pipeline — there is no propose button in the UI yet.

## Test plan

- [x] Open Admin → DDS tab; confirm both the readiness panel and the review queue render.
- [x] With a pending variant present, click Approve and verify `cleanApprovals` increments.
- [x] Verify Reject removes the item without affecting the approval count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)