### PR TITLE
fix: correct critic score parsing in AI gen processor

### DIFF
--- a/backend/src/queues/ai-gen/ai-gen.processor.ts
+++ b/backend/src/queues/ai-gen/ai-gen.processor.ts
@@ -165,11 +165,15 @@ export class AiGenProcessor extends WorkerHost {
     const jsonMatch = content.match(/```json\s*([\s\S]*?)\s*```/);
     const raw = jsonMatch ? jsonMatch[1] : content;
     const parsed = JSON.parse(raw);
-    const scores: number[] = Array.isArray(parsed)
-      ? parsed.map((s: unknown) => Number(s))
-      : (parsed.scores ?? []).map((s: unknown) => Number(s));
-    while (scores.length < expectedCount) scores.push(0.7);
-    return scores.slice(0, expectedCount);
+    const scores: number[] = Array(expectedCount).fill(0.7);
+    if (parsed?.results && Array.isArray(parsed.results)) {
+      for (const r of parsed.results) {
+        if (typeof r.index === 'number' && typeof r.score === 'number') {
+          scores[r.index] = Math.max(0, Math.min(1, r.score));
+        }
+      }
+    }
+    return scores;
   }
 
   private mapToPreview(


### PR DESCRIPTION
## Summary

- `parseCriticResponse` in `AiGenProcessor` was reading `parsed.scores` — a field that does not exist in the critic LLM response
- The critic prompt (`quality-critic.prompt.ts`) returns `{ results: [{ index, score, feedback }] }` but the parser expected `{ scores: [] }`
- This caused **all quality scores to silently fall back to 0.7** (MEDIUM tier) regardless of actual LLM evaluation, explaining why generated questions consistently showed ~70% quality

## What changed

`backend/src/queues/ai-gen/ai-gen.processor.ts` — `parseCriticResponse`:
- Pre-fill scores array with `0.7` as default
- Parse `parsed.results[]` by index, matching the actual critic schema
- Clamp each score to `[0, 1]`

## Test plan

- [x] Generate questions with a material uploaded — verify quality scores now vary (some HIGH ≥ 0.85, some MEDIUM, some rejected)
- [x] Simulate critic LLM failure — verify fallback still uses `confidence_hint` from generator response
- [x] Verify no regression on job completion flow