### PR TITLE
feat: Local LLM question generation — design doc (closes #64)

### DIFF
--- a/backend/src/ai-question-bank/mcp/mcp-intake.dto.ts
+++ b/backend/src/ai-question-bank/mcp/mcp-intake.dto.ts
@@ -78,4 +78,14 @@ export class McpIntakeDto {
   @IsEnum(QuestionType)
   @IsOptional()
   questionType?: QuestionType;
+
+  @ApiPropertyOptional({ enum: ['MCP', 'LOCAL_LLM'] })
+  @IsString()
+  @IsOptional()
+  source?: 'MCP' | 'LOCAL_LLM';
+
+  @ApiPropertyOptional({ example: 'llama3.2:3b' })
+  @IsString()
+  @IsOptional()
+  localModelId?: string;
 }

--- a/docs/local-llm-question-generation.md
+++ b/docs/local-llm-question-generation.md
@@ -1,0 +1,644 @@
+# Local LLM Question Generation
+
+> **Feature:** US-XXXX — Sinh câu hỏi từ Local LLM (Ollama / LM Studio)
+> **Version:** 1.0
+> **Date:** 2026-05-31
+> **Status:** Design — Awaiting Implementation
+> **Author:** ThanhPT
+
+---
+
+## Table of Contents
+
+1. [Tổng quan & Mục tiêu](#1-tổng-quan--mục-tiêu)
+2. [Phân tích hiện trạng](#2-phân-tích-hiện-trạng)
+3. [Kiến trúc giải pháp](#3-kiến-trúc-giải-pháp)
+4. [Thiết kế kỹ thuật chi tiết](#4-thiết-kế-kỹ-thuật-chi-tiết)
+   - 4.1 [LocalLlmDialect — lớp trừu tượng](#41-localllmdialect--lớp-trừu-tượng)
+   - 4.2 [Model discovery](#42-model-discovery)
+   - 4.3 [Sinh câu hỏi (generate)](#43-sinh-câu-hỏi-generate)
+   - 4.4 [JSON validation & repair](#44-json-validation--repair)
+   - 4.5 [Intake vào BrainGym](#45-intake-vào-braingym)
+   - 4.6 [Lưu trữ cấu hình local](#46-lưu-trữ-cấu-hình-local)
+   - 4.7 [UI — mở rộng LlmConfigPanel](#47-ui--mở-rộng-llmconfigpanel)
+5. [Xử lý lỗi & UX](#5-xử-lý-lỗi--ux)
+6. [Bảo mật](#6-bảo-mật)
+7. [Backend — thay đổi tối thiểu](#7-backend--thay-đổi-tối-thiểu)
+8. [Kế hoạch triển khai](#8-kế-hoạch-triển-khai)
+9. [Acceptance Criteria](#9-acceptance-criteria)
+10. [Rủi ro & Giảm thiểu](#10-rủi-ro--giảm-thiểu)
+
+---
+
+## 1. Tổng quan & Mục tiêu
+
+### Vấn đề
+
+Luồng sinh câu hỏi hiện tại (`POST /ai-questions/generate`) gọi LLM từ backend — yêu cầu API key trả phí (Anthropic / OpenAI / Gemini) và trừ quota tổ chức. Người dùng muốn tận dụng model đang chạy trên máy local (Ollama, LM Studio) để sinh câu hỏi mà không tốn tiền.
+
+### Mục tiêu
+
+| #   | Mục tiêu                                                                                                   |
+| --- | ---------------------------------------------------------------------------------------------------------- |
+| M1  | Frontend có thể liệt kê model từ Ollama / LM Studio theo chuẩn OpenAI-compatible hoặc Anthropic-compatible |
+| M2  | Người dùng chọn model, nhập ngữ cảnh, sinh câu hỏi trực tiếp từ browser → local LLM                        |
+| M3  | Câu hỏi qua bước review rồi mới đẩy vào BrainGym Intake (`mcp/intake`)                                     |
+| M4  | Không tốn API fee, không đốt quota backend                                                                 |
+| M5  | Lỗi CORS / unreachable / dialect sai được chẩn đoán rõ ràng, có hướng dẫn khắc phục                        |
+
+### Không trong phạm vi (v1)
+
+- Backend tự gọi local LLM (bất khả thi với SaaS multi-tenant)
+- Auto-approve không qua review con người
+- Fine-tuning / quản lý model
+- Org-scoped intake (dùng intake cá nhân trước)
+
+---
+
+## 2. Phân tích hiện trạng
+
+### Luồng cloud hiện tại
+
+```
+[Browser] → POST /ai-questions/generate (JWT)
+              → LlmQuotaService.enforceQuota()
+              → BullMQ job → ai-gen.processor.ts
+                 → createLlmProvider(provider, encryptedKey)
+                    → AnthropicProvider | OpenAiProvider | GeminiProvider
+                       → LLM API (cloud)
+              → POST /ai-questions/save
+```
+
+### Điểm tái dụng (không cần xây lại)
+
+| Thành phần                        | File                                             | Tái dụng như thế nào                                               |
+| --------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------ |
+| `POST /ai-questions/mcp/intake`   | `ai-question-bank.controller.ts:180`             | Endpoint nhận câu hỏi local sau khi review                         |
+| `mcpIntake()`                     | `ai-question-bank.service.ts:306`                | Quality score → tier → `APPROVED`/`PENDING` → `questions.create()` |
+| `McpIntakeDto` / `McpQuestionDto` | `mcp-intake.dto.ts`                              | Schema validate câu hỏi gửi lên                                    |
+| `GeneratedQuestionsReview`        | `src/components/ai-questions/`                   | UI review / edit câu hỏi trước khi submit                          |
+| `LlmConfigPanel`                  | `src/components/ai-questions/LlmConfigPanel.tsx` | Mở rộng thêm section "Local LLM"                                   |
+| `GenerationForm`                  | `src/components/ai-questions/GenerationForm.tsx` | Mở rộng chọn provider LOCAL                                        |
+
+### Lý do frontend gọi local, không phải backend
+
+Backend chạy trên server/Docker — không thể kết nối tới `localhost` của máy người dùng. Đây là ràng buộc SaaS không thể thay đổi. Mọi lưu lượng local LLM **phải** xuất phát từ browser.
+
+---
+
+## 3. Kiến trúc giải pháp
+
+### Sơ đồ luồng
+
+```
+┌─────────────────────────────── Browser ─────────────────────────────────┐
+│                                                                           │
+│  LlmConfigPanel (Local tab)                                               │
+│    ├── chọn Dialect (OpenAI-compat | Anthropic-compat | Ollama native)   │
+│    ├── nhập Base URL (prefill: localhost:11434, localhost:1234/v1, ...)   │
+│    ├── [Refresh models] → LocalLlmClient.listModels()                    │
+│    │       └── GET {baseUrl}/models  |  GET {baseUrl}/api/tags           │
+│    ├── dropdown chọn model                                                │
+│    └── lưu config → localStorage                                         │
+│                                                                           │
+│  GenerationForm (provider = LOCAL)                                        │
+│    └── [Generate] → LocalLlmClient.generate(prompt)                      │
+│           └── POST {baseUrl}/chat/completions | /messages | /api/generate │
+│                                                                           │
+│  parse JSON → Zod validate → repair (nếu lệch schema)                    │
+│                                                                           │
+│  GeneratedQuestionsReview (tái dụng)                                      │
+│    └── user review / edit / discard                                       │
+│                                                                           │
+│  [Submit to BrainGym]                                                     │
+│    └── POST /api/v1/ai-questions/mcp/intake  (JWT Bearer)                │
+│                                                                           │
+└───────────────────────────────────────────────────────────────────────────┘
+                                          │
+                              ┌───────────▼──────────────┐
+                              │  BrainGym Backend (NestJS) │
+                              │  mcpIntake()               │
+                              │  scoreTotier()             │
+                              │  questions.create()        │
+                              └────────────────────────────┘
+```
+
+---
+
+## 4. Thiết kế kỹ thuật chi tiết
+
+### 4.1 LocalLlmDialect — lớp trừu tượng
+
+Định nghĩa một type `LocalLlmDialect` mô tả cách một server local expose API:
+
+```typescript
+// src/services/local-llm/types.ts
+
+export type LocalLlmDialect = "openai" | "anthropic" | "ollama";
+
+export interface LocalLlmConfig {
+  dialect: LocalLlmDialect;
+  baseUrl: string; // vd: "http://localhost:11434"
+  modelId: string; // vd: "llama3.2:3b"
+  apiKey?: string; // thường bỏ trống với local
+}
+
+export interface LocalModelInfo {
+  id: string; // định danh để gọi generate
+  name: string; // hiển thị UI
+  sizeLabel?: string; // "3B", "7B"... nếu server cung cấp
+}
+
+export interface LocalLlmGenerateResult {
+  rawText: string; // text thô từ model
+  model: string;
+}
+```
+
+**Bảng ánh xạ dialect → endpoint:**
+
+| Dialect     | List models endpoint | Parser field    | Generate endpoint        | Auth header                                  |
+| ----------- | -------------------- | --------------- | ------------------------ | -------------------------------------------- |
+| `openai`    | `GET /models`        | `data[].id`     | `POST /chat/completions` | `Authorization: Bearer <key>`                |
+| `anthropic` | `GET /models`        | `data[].id`     | `POST /messages`         | `x-api-key`, `anthropic-version: 2023-06-01` |
+| `ollama`    | `GET /api/tags`      | `models[].name` | `POST /api/generate`     | (không cần)                                  |
+
+> **Lưu ý:** Ollama từ v0.1.24 hỗ trợ OpenAI-compat tại `/v1`. Khuyến nghị users dùng `openai` dialect với Ollama (`baseUrl = http://localhost:11434/v1`) để thống nhất. Dialect `ollama` native giữ làm fallback auto-detect.
+
+**Phủ sóng thực tế:**
+
+| Tool             | Dialect khuyến nghị | Default base URL            |
+| ---------------- | ------------------- | --------------------------- |
+| Ollama           | `openai`            | `http://localhost:11434/v1` |
+| LM Studio        | `openai`            | `http://localhost:1234/v1`  |
+| llama.cpp server | `openai`            | `http://localhost:8080/v1`  |
+| vLLM             | `openai`            | `http://localhost:8000/v1`  |
+| LocalAI          | `openai`            | `http://localhost:8080/v1`  |
+| Jan              | `openai`            | `http://localhost:1337/v1`  |
+| Anthropic proxy  | `anthropic`         | `http://localhost:8081`     |
+
+---
+
+### 4.2 Model discovery
+
+```typescript
+// src/services/local-llm/local-llm-client.ts
+
+export class LocalLlmClient {
+  async listModels(config: LocalLlmConfig): Promise<LocalModelInfo[]>;
+  // 1. Gọi endpoint theo dialect
+  // 2. Nếu 404 và dialect là 'openai' → fallback thử /api/tags (Ollama native)
+  // 3. Phân biệt lỗi: CORS | network unreachable | 404 (wrong dialect) | empty list
+
+  async testConnection(
+    config: Omit<LocalLlmConfig, "modelId">,
+  ): Promise<ConnectionTestResult>;
+}
+
+export type ConnectionTestResult =
+  | { ok: true; models: LocalModelInfo[] }
+  | {
+      ok: false;
+      reason: "cors" | "unreachable" | "wrong_dialect" | "empty";
+      hint: string;
+    };
+```
+
+**Logic auto-detect (khi user nhập base URL mà chưa chọn dialect):**
+
+```
+1. GET {baseUrl}/models          → nếu 200 + data[] → dialect: openai
+2. GET {baseUrl}/api/tags        → nếu 200 + models[] → dialect: ollama
+3. GET {baseUrl}/models (anthropic headers) → dialect: anthropic
+4. Nếu tất cả fail → trả về 'unreachable' hoặc 'cors'
+```
+
+---
+
+### 4.3 Sinh câu hỏi (generate)
+
+Prompt template được xây từ ngữ cảnh form (certification, domain, difficulty, question count, questionType). Dùng lại cấu trúc prompt đã thiết kế ở backend providers để đảm bảo chất lượng đồng nhất:
+
+```typescript
+async generateQuestions(
+  config: LocalLlmConfig,
+  params: GenerationParams
+): Promise<LocalLlmGenerateResult>
+```
+
+**Cấu trúc JSON yêu cầu model trả về** (nhúng vào system prompt):
+
+```json
+{
+  "questions": [
+    {
+      "question": "string",
+      "choices": [
+        { "label": "A", "content": "string", "isCorrect": false },
+        { "label": "B", "content": "string", "isCorrect": true }
+      ],
+      "explanation": "string",
+      "source_passage": "string (optional)",
+      "quality_score": 0.85
+    }
+  ]
+}
+```
+
+**Mapping dialect → generate request:**
+
+| Dialect     | Payload key cho nội dung                             | Cách set system prompt           |
+| ----------- | ---------------------------------------------------- | -------------------------------- |
+| `openai`    | `messages[{role:"system",...},{role:"user",...}]`    | message đầu với `role: "system"` |
+| `anthropic` | `messages[{role:"user",...}]` + field `system` riêng | field `system` ở top-level       |
+| `ollama`    | `prompt` (string đơn)                                | prefix vào `prompt`              |
+
+---
+
+### 4.4 JSON validation & repair
+
+Model local hay trả JSON lệch — đây là rủi ro #2. Quy trình xử lý theo pipeline:
+
+````
+rawText
+  → bước 1: JSON.parse() thẳng
+  → bước 2: extract từ markdown fence (```json ... ```)
+  → bước 3: extractBalancedJson() — tìm { } đầu tiên cân bằng
+  → bước 4: Zod parse theo schema LocalQuestionsResponseSchema
+       - isCorrect missing → default false
+       - choices < 2 → discard question + warn user
+       - quality_score missing → default 0.5
+  → bước 5: nếu < 1 question hợp lệ → báo lỗi, cho retry
+  → bước 6: hiển thị lên GeneratedQuestionsReview với số câu hợp lệ / tổng
+````
+
+**Schema Zod (frontend mirror của `McpQuestionDto`):**
+
+```typescript
+// src/services/local-llm/schema.ts
+
+const LocalChoiceSchema = z.object({
+  label: z.string().min(1),
+  content: z.string().min(1),
+  isCorrect: z.boolean().default(false),
+});
+
+const LocalQuestionSchema = z.object({
+  question: z.string().min(10),
+  choices: z.array(LocalChoiceSchema).min(2).max(6),
+  explanation: z.string().optional(),
+  source_passage: z.string().optional(),
+  quality_score: z.number().min(0).max(1).default(0.5),
+});
+
+export const LocalQuestionsResponseSchema = z.object({
+  questions: z.array(LocalQuestionSchema).min(1),
+});
+```
+
+---
+
+### 4.5 Intake vào BrainGym
+
+Sau khi user duyệt tại `GeneratedQuestionsReview`, map sang `McpIntakeDto` và POST:
+
+```typescript
+// src/services/local-llm/submit-intake.ts
+
+export async function submitLocalQuestionsToIntake(
+  questions: ValidatedLocalQuestion[],
+  context: {
+    certificationId: string;
+    domainId?: string;
+    difficulty?: Difficulty;
+    questionType?: QuestionType;
+  },
+): Promise<McpIntakeResponse>;
+```
+
+Gọi endpoint: `POST /api/v1/ai-questions/mcp/intake`
+
+**Behavior quality gate của intake hiện tại (không thay đổi):**
+
+| quality_score | Status sau intake           |
+| ------------- | --------------------------- |
+| ≥ 0.8         | `APPROVED`                  |
+| 0.5 – 0.79    | `PENDING` (chờ admin duyệt) |
+| < 0.5         | discarded                   |
+
+Câu hỏi từ model local không có `quality_score` đáng tin → default `0.6` → `PENDING` (an toàn, cần admin duyệt thêm).
+
+---
+
+### 4.6 Lưu trữ cấu hình local
+
+Cấu hình local LLM **không** lưu DB (không có secret server-side cần encrypt). Dùng `localStorage`:
+
+```typescript
+// src/services/local-llm/config-storage.ts
+
+export interface StoredLocalLlmConfig {
+  dialect: LocalLlmDialect;
+  baseUrl: string;
+  modelId: string;
+  apiKey?: string;
+  savedAt: string;       // ISO 8601
+}
+
+// Key: "braingym:local-llm-config"
+
+export const localLlmConfigStorage = {
+  get(): StoredLocalLlmConfig | null,
+  set(config: StoredLocalLlmConfig): void,
+  clear(): void,
+};
+```
+
+---
+
+### 4.7 UI — mở rộng LlmConfigPanel
+
+Thêm tab/section **"Local LLM"** tách biệt với phần cloud BYOK hiện tại (không làm hỏng flow cũ):
+
+```
+LlmConfigPanel
+  ├── [Cloud Providers]  ← giữ nguyên hoàn toàn
+  └── [Local LLM]         ← mới
+        ├── Dialect selector
+        │     • OpenAI-compatible (Ollama, LM Studio, llama.cpp, vLLM...)  ← default
+        │     • Anthropic-compatible (proxy)  ← "(Advanced)"
+        │     • Ollama native
+        ├── Base URL input
+        │     placeholder theo dialect đã chọn
+        ├── API Key input (optional)
+        │     placeholder: "Leave empty — not needed for local"
+        │     ⚠️  warning: "Đừng nhập API key cloud vào đây"
+        ├── [Test Connection] button
+        │     loading state → kết quả:
+        │       ✅ Connected — N models found
+        │       ❌ CORS blocked  [Xem hướng dẫn ▾]
+        │       ❌ Unreachable — kiểm tra Ollama đang chạy
+        │       ❌ Wrong dialect — thử đổi sang OpenAI-compatible
+        │       ⚠️  No models — load model vào LM Studio trước
+        ├── Model dropdown (populate sau khi test OK)
+        ├── [Save local config]
+        └── [CORS setup guide ▾] (fold/unfold)
+              Ollama:  OLLAMA_ORIGINS=<domain> ollama serve
+              LM Studio: Settings → Local Server → CORS
+```
+
+**Tại `GenerationForm`:**
+
+- Thêm option `LOCAL` trong provider selector
+- Khi chọn LOCAL: hiển thị model đã lưu (từ localStorage), ẩn field "API Key"
+- Khi chưa có config → hiển thị banner "Chưa cấu hình Local LLM" + link Settings
+
+---
+
+## 5. Xử lý lỗi & UX
+
+| Tình huống              | Phát hiện                                   | Thông báo người dùng                                                                                      |
+| ----------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| CORS blocked            | `fetch` throw `TypeError` với URL localhost | "CORS blocked. Thêm origin BrainGym vào `OLLAMA_ORIGINS` hoặc bật CORS trong LM Studio." + link hướng dẫn |
+| Server không chạy       | Connection refused                          | "Không kết nối được đến {baseUrl}. Kiểm tra Ollama/LM Studio đang chạy."                                  |
+| 404 endpoint            | HTTP 404                                    | "Endpoint không đúng. Thử đổi sang dialect OpenAI-compatible."                                            |
+| List model rỗng         | 200 + `data = []`                           | "Không có model nào đang nạp. Load model trong LM Studio trước khi refresh."                              |
+| JSON output lệch schema | Zod parse fail                              | "Model trả về {valid}/{total} câu hợp lệ. Thử lại hoặc chọn model khác."                                  |
+| 0 câu hợp lệ            | valid = 0                                   | Nút Retry nổi bật, không cho phép submit                                                                  |
+| Intake fail — auth      | 401 từ backend                              | "Phiên đăng nhập hết hạn. Vui lòng đăng nhập lại."                                                        |
+| Intake fail — server    | 5xx từ backend                              | "Lỗi hệ thống. Câu hỏi chưa được lưu, thử lại sau."                                                       |
+
+**Phân biệt CORS vs unreachable** (quan trọng, 2 lỗi trông giống nhau):
+
+```typescript
+try {
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+  // ...
+} catch (err) {
+  if (err instanceof TypeError && err.message.includes('fetch')) {
+    // Kiểm tra: thử fetch không có CORS header để xác nhận
+    // → nếu fail tương tự: 'unreachable'
+    // → nếu có response headers nhưng bị block: 'cors'
+  }
+  if (err.name === 'TimeoutError') → 'unreachable'
+}
+```
+
+---
+
+## 6. Bảo mật
+
+| Vấn đề                                 | Giải pháp                                                                  |
+| -------------------------------------- | -------------------------------------------------------------------------- |
+| SSRF từ browser — user nhập URL tùy ý  | Whitelist chỉ `localhost`, `127.0.0.1`, `[::1]`, `*.local` trước khi fetch |
+| API key cloud vô tình lưu localStorage | Warning rõ trong UI; label field là "optional, for local auth only"        |
+| JSON injection từ model output         | Parse `JSON.parse()` (không `eval`), validate Zod trước khi render         |
+| Câu hỏi chất lượng thấp vào bank       | Human review bắt buộc + intake quality gate → `PENDING` mặc định           |
+| Intake endpoint                        | JWT guard giữ nguyên, không thay đổi                                       |
+
+---
+
+## 7. Backend — thay đổi tối thiểu
+
+Luồng local LLM **không yêu cầu** thay đổi backend. Các bổ sung dưới đây là **tùy chọn** để cải thiện observability:
+
+### Tùy chọn A — Thêm provenance vào McpIntakeDto _(khuyến nghị làm ngay)_
+
+```typescript
+// backend/src/ai-question-bank/mcp/mcp-intake.dto.ts
+
+@IsOptional()
+source?: 'MCP' | 'LOCAL_LLM';    // truy vết nguồn câu hỏi
+
+@IsOptional()
+localModelId?: string;           // vd: "llama3.2:3b"
+```
+
+Không breaking change — field optional, intake hiện tại vẫn chạy đúng.
+
+### Tùy chọn B — Thêm `LOCAL` vào enum LlmProvider _(sprint sau)_
+
+```prisma
+// backend/prisma/schema.prisma
+enum LlmProvider {
+  OPENAI
+  ANTHROPIC
+  GEMINI
+  LOCAL      // ← nếu muốn tracking job/usage analytics
+}
+```
+
+---
+
+## 8. Kế hoạch triển khai
+
+### Effort ước tính: **5.5–7 SP** (Frontend-heavy)
+
+| Phạm vi                   | SP       |
+| ------------------------- | -------- |
+| Frontend (Task 1–4)       | 5 SP     |
+| Backend optional (Task 5) | 0.5 SP   |
+| Test & QA (Task 6)        | 1.5 SP   |
+| **Tổng**                  | **7 SP** |
+
+---
+
+### Task 1 — Lớp trừu tượng & Model discovery (2 SP)
+
+**Files mới:**
+
+- `src/services/local-llm/types.ts`
+- `src/services/local-llm/local-llm-client.ts`
+- `src/services/local-llm/config-storage.ts`
+
+**Checklist:**
+
+- [ ] Định nghĩa `LocalLlmDialect`, `LocalLlmConfig`, `LocalModelInfo`, `ConnectionTestResult`
+- [ ] `listModels()` cho cả 3 dialect (openai / anthropic / ollama)
+- [ ] Auto-detect: thử OpenAI endpoint → fallback Ollama native `/api/tags`
+- [ ] `testConnection()` → phân loại 4 loại kết quả (ok / cors / unreachable / wrong_dialect / empty)
+- [ ] Base URL validator: chỉ cho phép localhost / 127.0.0.1 / [::1] / \*.local
+- [ ] `localLlmConfigStorage` (get / set / clear với key `braingym:local-llm-config`)
+- [ ] Unit test (vitest): mock fetch, test từng dialect, test mỗi loại lỗi
+
+---
+
+### Task 2 — Prompt builder, generate & JSON validation (2 SP)
+
+**Files mới:**
+
+- `src/services/local-llm/prompt-builder.ts`
+- `src/services/local-llm/schema.ts`
+
+**Files sửa:**
+
+- `src/services/local-llm/local-llm-client.ts` — thêm `generateQuestions()`
+
+**Checklist:**
+
+- [ ] `buildPrompt(params: GenerationParams): { system: string; user: string }` — tái dụng cấu trúc prompt từ backend providers làm chuẩn
+- [ ] `generateQuestions()` cho cả 3 dialect (payload format khác nhau theo bảng §4.3)
+- [ ] `extractAndValidate(rawText): { valid: ValidatedLocalQuestion[]; total: number }` — pipeline 6 bước §4.4
+- [ ] Zod schema `LocalQuestionsResponseSchema`
+- [ ] Unit test: JSON hoàn hảo, JSON trong markdown fence, JSON broken, JSON hoàn toàn sai, 0 câu hợp lệ
+
+---
+
+### Task 3 — UI: LlmConfigPanel mở rộng Local tab (1 SP)
+
+**Files sửa:**
+
+- `src/components/ai-questions/LlmConfigPanel.tsx`
+
+**Checklist:**
+
+- [ ] Thêm tab / section "Local LLM" không làm hỏng flow cloud hiện tại
+- [ ] Dialect selector (3 options, `openai` là default)
+- [ ] Base URL input với placeholder thay đổi theo dialect
+- [ ] API Key input (optional) + warning không nhập key cloud
+- [ ] Nút "Test Connection" + hiển thị kết quả (`ConnectionTestResult`)
+- [ ] Model dropdown (populate sau khi test OK), disabled khi chưa test
+- [ ] Nút "Save" → `localLlmConfigStorage.set()`
+- [ ] CORS setup guide (fold/unfold, nội dung theo §5)
+
+---
+
+### Task 4 — GenerationForm (LOCAL provider) + submit intake (1 SP)
+
+**Files sửa:**
+
+- `src/components/ai-questions/GenerationForm.tsx`
+
+**Files mới:**
+
+- `src/services/local-llm/submit-intake.ts`
+
+**Checklist:**
+
+- [ ] Thêm option `LOCAL` trong provider selector
+- [ ] Khi chọn LOCAL: hiển thị model từ localStorage, ẩn API key field
+- [ ] Khi chưa cấu hình LOCAL → banner + link Settings
+- [ ] Gọi `LocalLlmClient.generateQuestions()` khi submit form
+- [ ] Hiển thị kết quả qua `GeneratedQuestionsReview` (tái dụng, không sửa)
+- [ ] `submitToIntake()`: map sang `McpIntakeDto` → `POST /ai-questions/mcp/intake`
+- [ ] Toast success ("N câu đã gửi vào ngân hàng") / error phân loại
+
+---
+
+### Task 5 — Backend: provenance field (0.5 SP)
+
+**Files sửa:**
+
+- `backend/src/ai-question-bank/mcp/mcp-intake.dto.ts`
+
+**Checklist:**
+
+- [ ] Thêm `source?: 'MCP' | 'LOCAL_LLM'` (optional, `@IsOptional()`)
+- [ ] Thêm `localModelId?: string` (optional, `@IsOptional()`)
+- [ ] Không thay đổi logic `mcpIntake()` — chỉ lưu thêm metadata
+
+---
+
+### Task 6 — Test & QA (1.5 SP)
+
+**Checklist:**
+
+- [ ] Unit test Task 1 + Task 2 đủ các edge case
+- [ ] E2E Playwright: mock local LLM endpoint → generate → review → submit intake → verify question tạo ra ở trạng thái PENDING
+- [ ] Test lỗi CORS: mock server không có CORS header → verify error message đúng loại
+- [ ] Test JSON hỏng: mock trả markdown + broken JSON → verify pipeline repair
+- [ ] Test thực tế với Ollama (integration test hoặc manual)
+- [ ] Test thực tế với LM Studio (manual)
+- [ ] Accessibility: keyboard navigation trên model dropdown, aria-label
+- [ ] Responsive: mobile 375px (form, dropdown)
+
+---
+
+### Sơ đồ phụ thuộc task
+
+```
+Task 1 ──→ Task 2 ──→ Task 4
+Task 1 ──→ Task 3
+Task 5    (độc lập)
+Task 6    (sau Task 1–4 hoàn thành)
+```
+
+Task 1 và Task 5 có thể làm song song trong cùng sprint.
+
+---
+
+## 9. Acceptance Criteria
+
+| #     | Điều kiện                                                                    | Kết quả mong đợi                                                              |
+| ----- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| AC-1  | Cấu hình Ollama (`openai` dialect, `localhost:11434/v1`) → Test Connection   | ✅ danh sách model đang nạp                                                   |
+| AC-2  | Cấu hình LM Studio (`openai` dialect, `localhost:1234/v1`) → Test Connection | ✅ model đang load trong LM Studio                                            |
+| AC-3  | Ollama chưa set `OLLAMA_ORIGINS` → Test Connection                           | ❌ "CORS blocked" + hướng dẫn                                                 |
+| AC-4  | Ollama không chạy → Test Connection                                          | ❌ "Unreachable"                                                              |
+| AC-5  | Base URL sai dialect (404)                                                   | ❌ "Wrong dialect — thử OpenAI-compatible"                                    |
+| AC-6  | Generate 5 câu từ Ollama (llama3.2:3b)                                       | Hiển thị đủ 5 câu trong review; không call API cloud; không trừ quota         |
+| AC-7  | Model trả JSON lệch schema (thiếu field)                                     | Hiển thị "{valid}/5 câu hợp lệ" + tùy chọn retry                              |
+| AC-8  | Model trả hoàn toàn không phải JSON                                          | 0 câu hợp lệ, nút Retry nổi bật, không cho submit                             |
+| AC-9  | Submit sau khi review                                                        | Câu hỏi xuất hiện trong bank với status `PENDING`                             |
+| AC-10 | Chưa cấu hình Local LLM nhưng chọn provider LOCAL                            | Banner hướng dẫn, không crash                                                 |
+| AC-11 | Verify không tạo cloud API call                                              | DevTools Network: không có request đến `api.anthropic.com` / `api.openai.com` |
+| AC-12 | Verify không tạo `QuestionGenerationJob` record                              | Không xuất hiện entry mới trong `/ai-questions/history`                       |
+
+---
+
+## 10. Rủi ro & Giảm thiểu
+
+| Rủi ro                                   | Mức            | Giảm thiểu                                                                                                   |
+| ---------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
+| CORS blocked browser → localhost         | **Cao**        | UI hướng dẫn `OLLAMA_ORIGINS`; Test Connection chẩn đoán chính xác; docs inline                              |
+| JSON output kém từ model nhỏ (7B/8B)     | **Cao**        | Pipeline repair 6 bước; Zod validate; human review bắt buộc; default `quality_score = 0.6` → PENDING         |
+| Mixed content HTTPS app → HTTP localhost | **Trung bình** | Chrome/Firefox/Edge OK với localhost (potentially trustworthy); Safari cần test và có thể cần hướng dẫn thêm |
+| LM Studio chỉ list model đang load       | **Thấp–TB**    | Ghi chú UI rõ ràng; hướng dẫn load model trước                                                               |
+| API key cloud vô tình lưu localStorage   | **Thấp**       | Warning trong UI; label field là "optional, local auth only"                                                 |
+| Anthropic-compat proxy ít server hỗ trợ  | **Thấp**       | Đánh dấu "(Advanced)"; mặc định OpenAI-compat; không ưu tiên trong demo/docs                                 |
+| SSRF từ browser — URL tùy ý              | **Thấp**       | Whitelist localhost/loopback validate trước khi fetch                                                        |
+
+---
+
+_Document này theo dõi thiết kế feature US-XXXX — Local LLM Question Generation.
+Cập nhật khi có thay đổi thiết kế hoặc sau sprint review._

--- a/e2e/local-llm.spec.ts
+++ b/e2e/local-llm.spec.ts
@@ -1,0 +1,370 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Local LLM Question Generation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/ai-question-generator");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("should show local LLM section in settings tab", async ({ page }) => {
+    await page.click('button[value="settings"]');
+    await expect(page.getByText("AI Provider Configuration")).toBeVisible();
+    await expect(page.getByText("Local LLM")).toBeVisible();
+  });
+
+  test("should allow entering local LLM configuration", async ({ page }) => {
+    await page.click('button[value="settings"]');
+
+    // Find and fill the base URL input
+    const inputs = page.locator('input[type="text"]');
+    const firstInput = inputs.first();
+    await firstInput.fill("http://localhost:11434");
+    await expect(firstInput).toHaveValue("http://localhost:11434");
+  });
+
+  test("should display local provider option in generation form", async ({
+    page,
+  }) => {
+    // Pre-set local config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    await page.click('button[value="generate"]');
+
+    // Should show Local option in provider dropdown
+    const providerSelect = page
+      .locator("text=AI Provider")
+      .locator("..")
+      .locator("[role='combobox']");
+    await providerSelect.click();
+
+    const localOption = page.getByRole("option", { name: /local/i });
+    await expect(localOption).toBeVisible();
+  });
+
+  test("should show model info when local provider is selected", async ({
+    page,
+  }) => {
+    // Pre-set config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    await page.click('button[value="generate"]');
+
+    const providerSelect = page
+      .locator("text=AI Provider")
+      .locator("..")
+      .locator("[role='combobox']");
+    await providerSelect.click();
+
+    const localOption = page.getByRole("option", { name: /local/i });
+    await localOption.click();
+
+    // Should display base URL and model info
+    await expect(
+      page.getByText(/localhost:11434/i).or(page.getByText(/llama2/i)),
+    ).toBeVisible();
+  });
+
+  test("should show info banner about local questions", async ({ page }) => {
+    // Pre-set config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    await page.click('button[value="generate"]');
+
+    const providerSelect = page
+      .locator("text=AI Provider")
+      .locator("..")
+      .locator("[role='combobox']");
+    await providerSelect.click();
+
+    const localOption = page.getByRole("option", { name: /local/i });
+    await localOption.click();
+
+    // Should show info about local generation
+    await expect(
+      page.getByText(/browser|no cloud|pending|admin review/i),
+    ).toBeVisible();
+  });
+
+  test("should hide material library when local is selected", async ({
+    page,
+  }) => {
+    // Pre-set config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    await page.click('button[value="generate"]');
+
+    const providerSelect = page
+      .locator("text=AI Provider")
+      .locator("..")
+      .locator("[role='combobox']");
+    await providerSelect.click();
+
+    const localOption = page.getByRole("option", { name: /local/i });
+    await localOption.click();
+
+    // Material library should not be visible
+    const materialSection = page.locator("text=Material").locator("..");
+    // After local selection, material library should be hidden
+    const isVisible = await materialSection.isVisible().catch(() => false);
+    if (isVisible) {
+      // If material section still exists, it should be in hidden state
+      await expect(materialSection).toHaveAttribute("style", /display:\s*none/);
+    }
+  });
+
+  test("should display 'Generate (Local)' button when local provider selected", async ({
+    page,
+  }) => {
+    // Pre-set config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    await page.click('button[value="generate"]');
+
+    const providerSelect = page
+      .locator("text=AI Provider")
+      .locator("..")
+      .locator("[role='combobox']");
+    await providerSelect.click();
+
+    const localOption = page.getByRole("option", { name: /local/i });
+    await localOption.click();
+
+    // Should show local generation button
+    const generateBtn = page.getByRole("button", {
+      name: /generate.*local/i,
+    });
+    await expect(generateBtn).toBeVisible();
+  });
+
+  test("should enable Generate tab when local config exists", async ({
+    page,
+  }) => {
+    // Pre-set config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    // Generate tab should be accessible
+    const generateTab = page.locator('button[value="generate"]');
+    await expect(generateTab).toBeEnabled();
+    await generateTab.click();
+
+    // Should show generate form, not "no provider" message
+    const form = page.locator("text=Certification");
+    await expect(form).toBeVisible();
+  });
+
+  test("should show 'no provider' message when neither cloud nor local config exists", async ({
+    page,
+  }) => {
+    // Clear all configs
+    await page.evaluate(() => {
+      localStorage.clear();
+    });
+    await page.reload();
+
+    await page.click('button[value="generate"]');
+
+    // Should show no provider message
+    const noProviderMsg = page.getByText(/No AI provider configured/i);
+    await expect(noProviderMsg).toBeVisible();
+
+    // Message should mention Local LLM option
+    await expect(
+      page.getByText(/Local LLM|AI Settings/i).or(noProviderMsg),
+    ).toBeVisible();
+  });
+
+  test("should navigate to settings tab when no provider configured", async ({
+    page,
+  }) => {
+    // Clear config
+    await page.evaluate(() => {
+      localStorage.clear();
+    });
+    await page.reload();
+
+    // Default tab should be settings (because no provider)
+    const settingsTab = page.locator('button[value="settings"]');
+    // Settings tab should be the active/visible one
+    await expect(page.getByText("AI Provider Configuration")).toBeVisible();
+  });
+
+  test("should save local config to localStorage", async ({ page }) => {
+    await page.click('button[value="settings"]');
+
+    // Fill config form
+    const inputs = page.locator('input[type="text"]');
+    const firstInput = inputs.first();
+    await firstInput.fill("http://localhost:11434");
+
+    // Find and click save button (may be "Save" or part of form)
+    const saveBtn = page.getByRole("button", {
+      name: /save|apply|configure/i,
+    });
+    if (await saveBtn.isVisible()) {
+      await saveBtn.click();
+    }
+
+    // Verify localStorage was updated
+    const storedConfig = await page.evaluate(() => {
+      return localStorage.getItem("braingym:local-llm-config");
+    });
+    expect(storedConfig).toBeTruthy();
+  });
+
+  test("should show dialect selector for local LLM config", async ({
+    page,
+  }) => {
+    await page.click('button[value="settings"]');
+
+    // Look for dialect selector
+    const dialectLabel = page
+      .locator("text=Dialect")
+      .or(page.locator("text=API Standard"));
+    const isVisible = await dialectLabel.isVisible().catch(() => false);
+
+    if (isVisible) {
+      // Dialect selector should exist
+      const dialectControl = dialectLabel.locator("..");
+      await expect(dialectControl.locator("[role='combobox']")).toBeVisible();
+    }
+  });
+
+  test("should allow clearing local config", async ({ page }) => {
+    // Pre-set config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    await page.click('button[value="settings"]');
+
+    // Click clear/reset button
+    const clearBtn = page.getByRole("button", { name: /clear|reset|remove/i });
+    if (await clearBtn.isVisible()) {
+      await clearBtn.click();
+
+      // Config should be cleared from localStorage
+      const storedConfig = await page.evaluate(() => {
+        return localStorage.getItem("braingym:local-llm-config");
+      });
+      expect(storedConfig).toBeNull();
+    }
+  });
+
+  test("should require certification selection before generation", async ({
+    page,
+  }) => {
+    // Pre-set config
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "braingym:local-llm-config",
+        JSON.stringify({
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "llama2",
+        }),
+      );
+    });
+    await page.reload();
+
+    await page.click('button[value="generate"]');
+
+    // Select local provider
+    const providerSelect = page
+      .locator("text=AI Provider")
+      .locator("..")
+      .locator("[role='combobox']");
+    await providerSelect.click();
+
+    const localOption = page.getByRole("option", { name: /local/i });
+    await localOption.click();
+
+    // Generate button should be disabled without certification
+    const generateBtn = page.getByRole("button", {
+      name: /generate.*local/i,
+    });
+    const isDisabled =
+      (await generateBtn.isDisabled().catch(() => false)) ||
+      (await generateBtn.getAttribute("disabled")) !== null;
+
+    // After selecting certification, button should be enabled
+    const certSelect = page
+      .locator("text=Certification")
+      .locator("..")
+      .locator("[role='combobox']");
+    await certSelect.click();
+
+    const firstCert = page.locator("[role='option']").first();
+    await firstCert.click();
+
+    // Now button should be enabled
+    await expect(generateBtn).toBeEnabled();
+  });
+});

--- a/src/components/ai-questions/GeneratedQuestionsReview.tsx
+++ b/src/components/ai-questions/GeneratedQuestionsReview.tsx
@@ -34,7 +34,9 @@ const TIER_LABEL: Record<QualityTier, string> = {
   LOW: "Low quality",
 };
 
-function normalizeQuestion(q: any): GeneratedQuestionPreview {
+function normalizeQuestion(
+  q: Record<string, unknown>,
+): GeneratedQuestionPreview {
   if (!q || typeof q !== "object") {
     return {
       title: "",
@@ -57,26 +59,29 @@ function normalizeQuestion(q: any): GeneratedQuestionPreview {
     : Array.isArray(q.options)
       ? q.options
       : [];
-  const choices = rawOptions.map((opt: any, idx: number) => {
-    if (typeof opt === "string") {
+  const choices = rawOptions.map(
+    (opt: Record<string, unknown> | string, idx: number) => {
+      if (typeof opt === "string") {
+        const label =
+          opt.match(/^\s*([A-Z])\b/)?.[1] ?? String.fromCharCode(65 + idx);
+        const content = opt.replace(/^\s*[A-Z][.)]\s*/, "").trim();
+        return { label, content, isCorrect: correctLetters.includes(label) };
+      }
+      const o = opt ?? {};
       const label =
-        opt.match(/^\s*([A-Z])\b/)?.[1] ?? String.fromCharCode(65 + idx);
-      const content = opt.replace(/^\s*[A-Z][.)]\s*/, "").trim();
-      return { label, content, isCorrect: correctLetters.includes(label) };
-    }
-    const o = opt ?? {};
-    const label =
-      (typeof o.label === "string" && o.label) || String.fromCharCode(65 + idx);
-    const content =
-      (typeof o.content === "string" && o.content) ||
-      (typeof o.text === "string" && o.text) ||
-      "";
-    const isCorrect =
-      typeof o.isCorrect === "boolean"
-        ? o.isCorrect
-        : correctLetters.includes(String(label).toUpperCase());
-    return { label: String(label).toUpperCase(), content, isCorrect };
-  });
+        (typeof o.label === "string" && o.label) ||
+        String.fromCharCode(65 + idx);
+      const content =
+        (typeof o.content === "string" && o.content) ||
+        (typeof o.text === "string" && o.text) ||
+        "";
+      const isCorrect =
+        typeof o.isCorrect === "boolean"
+          ? o.isCorrect
+          : correctLetters.includes(String(label).toUpperCase());
+      return { label: String(label).toUpperCase(), content, isCorrect };
+    },
+  );
   const rawType = String(q.questionType ?? q.question_type ?? "").toUpperCase();
   const questionType =
     rawType === "MULTIPLE" || rawType === "MULTIPLE_CHOICE"

--- a/src/components/ai-questions/GeneratedQuestionsReview.tsx
+++ b/src/components/ai-questions/GeneratedQuestionsReview.tsx
@@ -111,6 +111,15 @@ interface Props {
   certificationId: string;
   domainId?: string;
   onReset: () => void;
+  /**
+   * When provided, overrides the default cloud save path and calls this
+   * function instead (used for the local LLM → mcp/intake flow).
+   */
+  localSubmit?: (
+    questions: GeneratedQuestionPreview[],
+    certificationId: string,
+    domainId?: string,
+  ) => Promise<{ saved: number; discarded: number }>;
 }
 
 export default function GeneratedQuestionsReview({
@@ -118,6 +127,7 @@ export default function GeneratedQuestionsReview({
   certificationId,
   domainId,
   onReset,
+  localSubmit,
 }: Props) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -135,11 +145,14 @@ export default function GeneratedQuestionsReview({
   >({});
 
   const saveMutation = useMutation({
-    mutationFn: () => {
+    mutationFn: async () => {
       const toSave = Array.from(included).map((i) => ({
         ...questions[i],
         ...edits[i],
       }));
+      if (localSubmit) {
+        return localSubmit(toSave, certificationId, domainId);
+      }
       return saveGeneratedQuestions({
         jobId: result.jobId,
         certificationId,
@@ -151,8 +164,12 @@ export default function GeneratedQuestionsReview({
       toast.success(
         `Saved ${data.saved} questions${data.discarded ? `, ${data.discarded} discarded (low quality)` : ""}`,
       );
-      queryClient.invalidateQueries({ queryKey: ["generation-history"] });
-      navigate("/questions?status=APPROVED&mine=true");
+      if (localSubmit) {
+        navigate("/questions?status=PENDING");
+      } else {
+        queryClient.invalidateQueries({ queryKey: ["generation-history"] });
+        navigate("/questions?status=APPROVED&mine=true");
+      }
     },
     onError: () => toast.error("Failed to save questions"),
   });

--- a/src/components/ai-questions/GenerationForm.tsx
+++ b/src/components/ai-questions/GenerationForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { Zap, Loader2, Info } from "lucide-react";
+import { Zap, Loader2, Info, Cpu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -26,12 +26,20 @@ import {
   JobStatusResult,
 } from "@/types/api-types";
 import MaterialLibrary from "./MaterialLibrary";
+import {
+  localLlmConfigStorage,
+  generateLocalQuestions,
+} from "@/services/local-llm";
+import type { LocalGenerationParams } from "@/services/local-llm";
 
 const PROVIDER_LABELS: Record<LlmProvider, string> = {
   OPENAI: "OpenAI",
   ANTHROPIC: "Anthropic",
   GEMINI: "Google Gemini",
 };
+
+const LOCAL_PROVIDER = "LOCAL" as const;
+type ProviderValue = LlmProvider | typeof LOCAL_PROVIDER | "";
 
 const POLL_INTERVAL_MS = 3000;
 
@@ -44,7 +52,7 @@ interface Props {
 }
 
 export default function GenerationForm({ onResult }: Props) {
-  const [provider, setProvider] = useState<LlmProvider | "">("");
+  const [provider, setProvider] = useState<ProviderValue>("");
   const [certificationId, setCertificationId] = useState("");
   const [domainId, setDomainId] = useState("all");
   const [materialId, setMaterialId] = useState("");
@@ -59,6 +67,8 @@ export default function GenerationForm({ onResult }: Props) {
   const [pendingJobId, setPendingJobId] = useState<string | null>(null);
   const [pendingCertId, setPendingCertId] = useState("");
   const [pendingDomainId, setPendingDomainId] = useState<string | undefined>();
+  const [isGeneratingLocal, setIsGeneratingLocal] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
 
   const { data: configs = [] } = useQuery({
     queryKey: ["llm-configs"],
@@ -69,10 +79,11 @@ export default function GenerationForm({ onResult }: Props) {
     queryFn: getCertifications,
   });
 
-  const selectedCert = certs.find((c: any) => c.id === certificationId);
+  const localConfig = localLlmConfigStorage.get();
+  const selectedCert = (certs as any[]).find((c) => c.id === certificationId);
   const domains: any[] = selectedCert?.domains || [];
 
-  // Poll job status until completed/failed
+  // Poll cloud job status
   const { data: jobStatusData } = useQuery({
     queryKey: ["ai-gen-job", pendingJobId],
     queryFn: () => getJobStatus(pendingJobId!),
@@ -92,6 +103,8 @@ export default function GenerationForm({ onResult }: Props) {
     }
   }, [jobStatusData]);
 
+  // ─── Cloud generation ────────────────────────────────────────────────────────
+
   const estimateMutation = useMutation({
     mutationFn: () =>
       estimateTokens({
@@ -107,7 +120,7 @@ export default function GenerationForm({ onResult }: Props) {
     onSuccess: (data) => setEstimate(data),
   });
 
-  const generateMutation = useMutation({
+  const generateCloudMutation = useMutation({
     mutationFn: () =>
       generateQuestions({
         provider: provider as LlmProvider,
@@ -126,8 +139,70 @@ export default function GenerationForm({ onResult }: Props) {
     },
   });
 
-  const isGenerating = generateMutation.isPending || !!pendingJobId;
-  const canGenerate = provider && certificationId;
+  // ─── Local generation ────────────────────────────────────────────────────────
+
+  const handleLocalGenerate = async () => {
+    if (!localConfig) return;
+    setLocalError(null);
+    setIsGeneratingLocal(true);
+
+    try {
+      const cert = (certs as any[]).find((c) => c.id === certificationId);
+      const domain =
+        domainId !== "all" ? domains.find((d: any) => d.id === domainId) : null;
+
+      const params: LocalGenerationParams = {
+        certificationName: cert?.name ?? certificationId,
+        certificationCode: cert?.code ?? certificationId,
+        domainName: domain?.name,
+        difficulty,
+        questionCount,
+        questionType:
+          questionType === "MIXED" ? undefined : (questionType as QuestionType),
+      };
+
+      const result = await generateLocalQuestions(localConfig, params);
+
+      if (result.previews.length === 0) {
+        setLocalError(
+          `Model returned no valid questions (${result.discarded} discarded). Try again or choose a different model.`,
+        );
+        return;
+      }
+
+      if (result.discarded > 0) {
+        setLocalError(
+          `${result.previews.length} of ${result.previews.length + result.discarded} questions parsed successfully.`,
+        );
+      }
+
+      // Synthetic JobStatusResult — jobId starts with "local-" so the page
+      // can detect it and wire up the intake submit path.
+      const syntheticResult: JobStatusResult = {
+        jobId: `local-${Date.now()}`,
+        status: "COMPLETED",
+        questions: result.previews,
+      };
+
+      onResult(
+        syntheticResult,
+        certificationId,
+        domainId !== "all" ? domainId : undefined,
+      );
+    } catch (err: unknown) {
+      setLocalError(
+        err instanceof Error ? err.message : "Local generation failed.",
+      );
+    } finally {
+      setIsGeneratingLocal(false);
+    }
+  };
+
+  // ─── Derived ─────────────────────────────────────────────────────────────────
+
+  const isLocalSelected = provider === LOCAL_PROVIDER;
+  const isCloudGenerating = generateCloudMutation.isPending || !!pendingJobId;
+  const canGenerate = provider !== "" && certificationId !== "";
 
   return (
     <div className="space-y-5">
@@ -136,25 +211,55 @@ export default function GenerationForm({ onResult }: Props) {
         <label className="text-sm font-medium">AI Provider</label>
         <Select
           value={provider || undefined}
-          onValueChange={(v) => setProvider(v as LlmProvider)}
+          onValueChange={(v) => {
+            setProvider(v as ProviderValue);
+            setEstimate(null);
+            setLocalError(null);
+          }}
         >
           <SelectTrigger>
             <SelectValue placeholder="Select provider..." />
           </SelectTrigger>
           <SelectContent>
-            {configs.length === 0 && (
+            {configs.length === 0 && !localConfig && (
               <SelectItem value="_none" disabled>
-                No keys configured
+                No providers configured
               </SelectItem>
             )}
-            {configs.map((c: any) => (
+            {(configs as any[]).map((c) => (
               <SelectItem key={c.provider} value={c.provider}>
                 {PROVIDER_LABELS[c.provider as LlmProvider]}{" "}
                 {c.modelId && `(${c.modelId})`}
               </SelectItem>
             ))}
+            {localConfig && (
+              <SelectItem value={LOCAL_PROVIDER}>
+                <span className="flex items-center gap-1.5">
+                  <Cpu className="h-3.5 w-3.5" />
+                  Local — {localConfig.modelId}
+                </span>
+              </SelectItem>
+            )}
           </SelectContent>
         </Select>
+
+        {configs.length === 0 && !localConfig && (
+          <p className="text-xs text-muted-foreground">
+            Add a cloud API key or configure a Local LLM in{" "}
+            <strong>AI Settings</strong>.
+          </p>
+        )}
+
+        {isLocalSelected && localConfig && (
+          <Card className="bg-muted/40">
+            <CardContent className="py-2 px-3 flex items-center gap-2 text-xs">
+              <Cpu className="h-3.5 w-3.5 text-muted-foreground" />
+              <span>
+                <strong>{localConfig.modelId}</strong> via {localConfig.baseUrl}
+              </span>
+            </CardContent>
+          </Card>
+        )}
       </div>
 
       {/* Certification */}
@@ -171,7 +276,7 @@ export default function GenerationForm({ onResult }: Props) {
             <SelectValue placeholder="Select certification..." />
           </SelectTrigger>
           <SelectContent>
-            {certs.map((c: any) => (
+            {(certs as any[]).map((c) => (
               <SelectItem key={c.id} value={c.id}>
                 {c.name} ({c.code})
               </SelectItem>
@@ -253,15 +358,17 @@ export default function GenerationForm({ onResult }: Props) {
         />
       </div>
 
-      {/* Source Material */}
-      <MaterialLibrary
-        certificationId={certificationId || undefined}
-        selectedId={materialId}
-        onSelect={(id) => setMaterialId(materialId === id ? "" : id)}
-      />
+      {/* Source material — cloud only */}
+      {!isLocalSelected && (
+        <MaterialLibrary
+          certificationId={certificationId || undefined}
+          selectedId={materialId}
+          onSelect={(id) => setMaterialId(materialId === id ? "" : id)}
+        />
+      )}
 
-      {/* Estimate */}
-      {estimate && (
+      {/* Token estimate — cloud only */}
+      {estimate && !isLocalSelected && (
         <Card className="bg-muted/40">
           <CardContent className="py-2 px-3 flex items-center gap-2 text-xs">
             <Info className="h-3.5 w-3.5 text-muted-foreground" />
@@ -274,41 +381,84 @@ export default function GenerationForm({ onResult }: Props) {
         </Card>
       )}
 
+      {/* Local info banner */}
+      {isLocalSelected && (
+        <Card className="bg-muted/40">
+          <CardContent className="py-2 px-3 flex items-center gap-2 text-xs">
+            <Cpu className="h-3.5 w-3.5 text-muted-foreground" />
+            <span>
+              Generated in the browser — no cloud API calls, no quota usage.
+              Questions go to <strong>Pending</strong> for admin review.
+            </span>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Local error / partial-parse warning */}
+      {localError && (
+        <p className="text-xs text-yellow-700 bg-yellow-50 rounded p-2">
+          {localError}
+        </p>
+      )}
+
       {/* Actions */}
       <div className="flex gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={!canGenerate || estimateMutation.isPending}
-          onClick={() => estimateMutation.mutate()}
-        >
-          {estimateMutation.isPending ? (
-            <Loader2 className="h-3 w-3 animate-spin mr-1" />
-          ) : null}
-          Estimate Cost
-        </Button>
-        <Button
-          className="flex-1"
-          disabled={!canGenerate || isGenerating}
-          onClick={() => generateMutation.mutate()}
-        >
-          {isGenerating ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              {pendingJobId ? "Processing…" : "Queuing…"}
-            </>
-          ) : (
-            <>
-              <Zap className="h-4 w-4 mr-2" />
-              Generate {questionCount} Questions
-            </>
-          )}
-        </Button>
+        {!isLocalSelected && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!canGenerate || estimateMutation.isPending}
+            onClick={() => estimateMutation.mutate()}
+          >
+            {estimateMutation.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin mr-1" />
+            ) : null}
+            Estimate Cost
+          </Button>
+        )}
+
+        {isLocalSelected ? (
+          <Button
+            className="flex-1"
+            disabled={!canGenerate || isGeneratingLocal}
+            onClick={handleLocalGenerate}
+          >
+            {isGeneratingLocal ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Generating locally…
+              </>
+            ) : (
+              <>
+                <Cpu className="h-4 w-4 mr-2" />
+                Generate {questionCount} Questions (Local)
+              </>
+            )}
+          </Button>
+        ) : (
+          <Button
+            className="flex-1"
+            disabled={!canGenerate || isCloudGenerating}
+            onClick={() => generateCloudMutation.mutate()}
+          >
+            {isCloudGenerating ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                {pendingJobId ? "Processing…" : "Queuing…"}
+              </>
+            ) : (
+              <>
+                <Zap className="h-4 w-4 mr-2" />
+                Generate {questionCount} Questions
+              </>
+            )}
+          </Button>
+        )}
       </div>
 
-      {generateMutation.isError && (
+      {generateCloudMutation.isError && (
         <p className="text-xs text-destructive">
-          {(generateMutation.error as any)?.response?.data?.message ||
+          {(generateCloudMutation.error as any)?.response?.data?.message ||
             "Generation failed"}
         </p>
       )}

--- a/src/components/ai-questions/GenerationForm.tsx
+++ b/src/components/ai-questions/GenerationForm.tsx
@@ -80,8 +80,11 @@ export default function GenerationForm({ onResult }: Props) {
   });
 
   const localConfig = localLlmConfigStorage.get();
-  const selectedCert = (certs as any[]).find((c) => c.id === certificationId);
-  const domains: any[] = selectedCert?.domains || [];
+  const selectedCert = (certs as Array<{ id: string; domains?: any[] }>).find(
+    (c) => c.id === certificationId,
+  );
+  const domains: Array<{ id: string; name: string }> =
+    selectedCert?.domains || [];
 
   // Poll cloud job status
   const { data: jobStatusData } = useQuery({
@@ -101,7 +104,7 @@ export default function GenerationForm({ onResult }: Props) {
       setPendingJobId(null);
       onResult(jobStatusData, pendingCertId, pendingDomainId);
     }
-  }, [jobStatusData]);
+  }, [jobStatusData, onResult, pendingCertId, pendingDomainId]);
 
   // ─── Cloud generation ────────────────────────────────────────────────────────
 

--- a/src/components/ai-questions/LlmConfigPanel.tsx
+++ b/src/components/ai-questions/LlmConfigPanel.tsx
@@ -1,57 +1,157 @@
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Key, Trash2, CheckCircle2, XCircle, Loader2, Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
-import { getLlmConfigs, saveLlmConfig, deleteLlmConfig, validateLlmConfig } from '@/services/ai-questions';
-import { LlmProvider } from '@/types/api-types';
-import { toast } from 'sonner';
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Key,
+  Trash2,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Plus,
+  Cpu,
+  RefreshCw,
+  ChevronDown,
+  ChevronUp,
+  AlertTriangle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import {
+  getLlmConfigs,
+  saveLlmConfig,
+  deleteLlmConfig,
+  validateLlmConfig,
+} from "@/services/ai-questions";
+import { LlmProvider } from "@/types/api-types";
+import { toast } from "sonner";
+import {
+  testConnection,
+  localLlmConfigStorage,
+  isAllowedLocalUrl,
+} from "@/services/local-llm";
+import type {
+  ConnectionTestResult,
+  LocalLlmDialect,
+  LocalModelInfo,
+} from "@/services/local-llm";
+
+// ─── Cloud providers ──────────────────────────────────────────────────────────
 
 const PROVIDER_LABELS: Record<LlmProvider, string> = {
-  OPENAI: 'OpenAI',
-  ANTHROPIC: 'Anthropic',
-  GEMINI: 'Google Gemini',
+  OPENAI: "OpenAI",
+  ANTHROPIC: "Anthropic",
+  GEMINI: "Google Gemini",
 };
 
 const DEFAULT_MODELS: Record<LlmProvider, string> = {
-  OPENAI: 'gpt-4o-mini',
-  ANTHROPIC: 'claude-haiku-4-5-20251001',
-  GEMINI: 'gemini-1.5-flash',
+  OPENAI: "gpt-4o-mini",
+  ANTHROPIC: "claude-haiku-4-5-20251001",
+  GEMINI: "gemini-1.5-flash",
 };
+
+// ─── Local LLM constants ──────────────────────────────────────────────────────
+
+const DIALECT_LABELS: Record<LocalLlmDialect, string> = {
+  openai: "OpenAI-compatible (Ollama /v1, LM Studio, llama.cpp…)",
+  anthropic: "Anthropic-compatible (proxy) — Advanced",
+  ollama: "Ollama native",
+};
+
+const DIALECT_DEFAULTS: Record<LocalLlmDialect, string> = {
+  openai: "http://localhost:11434/v1",
+  anthropic: "http://localhost:8081",
+  ollama: "http://localhost:11434",
+};
+
+function TestResultBadge({ result }: { result: ConnectionTestResult | null }) {
+  if (!result) return null;
+  const icon = result.ok ? (
+    <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
+  ) : result.reason === "cors" || result.reason === "empty" ? (
+    <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+  ) : (
+    <XCircle className="h-4 w-4 flex-shrink-0" />
+  );
+
+  const cls = result.ok
+    ? "bg-green-50 text-green-800"
+    : result.reason === "cors" || result.reason === "empty"
+      ? "bg-yellow-50 text-yellow-800"
+      : "bg-red-50 text-red-800";
+
+  return (
+    <div className={`flex items-start gap-2 text-xs rounded p-2 ${cls}`}>
+      {icon}
+      <span>
+        {result.ok
+          ? `Connected — ${result.models.length} model${result.models.length !== 1 ? "s" : ""} found`
+          : result.hint}
+      </span>
+    </div>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function LlmConfigPanel() {
   const queryClient = useQueryClient();
+
+  // Cloud state
   const [adding, setAdding] = useState(false);
-  const [provider, setProvider] = useState<LlmProvider>('OPENAI');
-  const [apiKey, setApiKey] = useState('');
-  const [modelId, setModelId] = useState('');
+  const [provider, setProvider] = useState<LlmProvider>("OPENAI");
+  const [apiKey, setApiKey] = useState("");
+  const [modelId, setModelId] = useState("");
   const [validating, setValidating] = useState<LlmProvider | null>(null);
 
+  // Local LLM state — initialised from localStorage
+  const [localDialect, setLocalDialect] = useState<LocalLlmDialect>(
+    () => localLlmConfigStorage.get()?.dialect ?? "openai",
+  );
+  const [localBaseUrl, setLocalBaseUrl] = useState<string>(
+    () => localLlmConfigStorage.get()?.baseUrl ?? DIALECT_DEFAULTS["openai"],
+  );
+  const [localApiKey, setLocalApiKey] = useState<string>(
+    () => localLlmConfigStorage.get()?.apiKey ?? "",
+  );
+  const [localModels, setLocalModels] = useState<LocalModelInfo[]>([]);
+  const [selectedModel, setSelectedModel] = useState<string>(
+    () => localLlmConfigStorage.get()?.modelId ?? "",
+  );
+  const [testState, setTestState] = useState<
+    "idle" | "testing" | ConnectionTestResult
+  >("idle");
+  const [showCorsGuide, setShowCorsGuide] = useState(false);
+
   const { data: configs = [], isLoading } = useQuery({
-    queryKey: ['llm-configs'],
+    queryKey: ["llm-configs"],
     queryFn: getLlmConfigs,
   });
 
   const saveMutation = useMutation({
     mutationFn: saveLlmConfig,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['llm-configs'] });
+      queryClient.invalidateQueries({ queryKey: ["llm-configs"] });
       setAdding(false);
-      setApiKey('');
-      setModelId('');
-      toast.success('API key saved');
+      setApiKey("");
+      setModelId("");
+      toast.success("API key saved");
     },
-    onError: () => toast.error('Failed to save API key'),
+    onError: () => toast.error("Failed to save API key"),
   });
 
   const deleteMutation = useMutation({
     mutationFn: deleteLlmConfig,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['llm-configs'] });
-      toast.success('API key removed');
+      queryClient.invalidateQueries({ queryKey: ["llm-configs"] });
+      toast.success("API key removed");
     },
   });
 
@@ -59,122 +159,411 @@ export default function LlmConfigPanel() {
     setValidating(p);
     try {
       const result = await validateLlmConfig(p);
-      toast[result.valid ? 'success' : 'error'](
-        result.valid ? `${PROVIDER_LABELS[p]} key is valid` : `${PROVIDER_LABELS[p]} key is invalid or expired`
+      toast[result.valid ? "success" : "error"](
+        result.valid
+          ? `${PROVIDER_LABELS[p]} key is valid`
+          : `${PROVIDER_LABELS[p]} key is invalid or expired`,
       );
     } catch {
-      toast.error('Validation request failed');
+      toast.error("Validation request failed");
     } finally {
       setValidating(null);
     }
   };
 
-  const handleSave = () => {
+  const handleSaveCloud = () => {
     if (!apiKey.trim()) return;
-    saveMutation.mutate({ provider, apiKey: apiKey.trim(), modelId: modelId || DEFAULT_MODELS[provider] });
+    saveMutation.mutate({
+      provider,
+      apiKey: apiKey.trim(),
+      modelId: modelId || DEFAULT_MODELS[provider],
+    });
   };
 
-  if (isLoading) return <div className="flex justify-center py-8"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>;
+  const handleDialectChange = (d: LocalLlmDialect) => {
+    setLocalDialect(d);
+    setLocalBaseUrl(DIALECT_DEFAULTS[d]);
+    setLocalModels([]);
+    setSelectedModel("");
+    setTestState("idle");
+  };
+
+  const handleTestConnection = async () => {
+    if (!localBaseUrl.trim()) return;
+    if (!isAllowedLocalUrl(localBaseUrl)) {
+      toast.error("Base URL must point to localhost or a .local host.");
+      return;
+    }
+    setTestState("testing");
+    setLocalModels([]);
+    setSelectedModel("");
+
+    const result = await testConnection({
+      dialect: localDialect,
+      baseUrl: localBaseUrl.trim(),
+      apiKey: localApiKey || undefined,
+    });
+
+    setTestState(result);
+    if (result.ok) {
+      setLocalModels(result.models);
+      if (result.models.length > 0) setSelectedModel(result.models[0].id);
+    } else if (result.reason === "cors") {
+      setShowCorsGuide(true);
+    }
+  };
+
+  const handleSaveLocal = () => {
+    if (!selectedModel) {
+      toast.error("Select a model first.");
+      return;
+    }
+    localLlmConfigStorage.set({
+      dialect: localDialect,
+      baseUrl: localBaseUrl.trim(),
+      modelId: selectedModel,
+      apiKey: localApiKey || undefined,
+    });
+    toast.success("Local LLM config saved.");
+  };
+
+  const handleClearLocal = () => {
+    localLlmConfigStorage.clear();
+    setLocalModels([]);
+    setSelectedModel("");
+    setTestState("idle");
+    toast.success("Local LLM config cleared.");
+  };
+
+  const savedLocalConfig = localLlmConfigStorage.get();
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="font-semibold text-sm">AI Provider Keys</h3>
-          <p className="text-xs text-muted-foreground">Keys are encrypted at rest. Bring your own key (BYOK).</p>
+    <div className="space-y-6">
+      {/* ── Cloud Providers ── */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-sm">Cloud AI Providers</h3>
+            <p className="text-xs text-muted-foreground">
+              Keys are encrypted at rest. Bring your own key (BYOK).
+            </p>
+          </div>
+          {!adding && (
+            <Button size="sm" variant="outline" onClick={() => setAdding(true)}>
+              <Plus className="h-4 w-4 mr-1" /> Add Key
+            </Button>
+          )}
         </div>
-        {!adding && (
-          <Button size="sm" variant="outline" onClick={() => setAdding(true)}>
-            <Plus className="h-4 w-4 mr-1" /> Add Key
-          </Button>
+
+        {adding && (
+          <Card className="border-dashed">
+            <CardContent className="pt-4 space-y-3">
+              <Select
+                value={provider}
+                onValueChange={(v) => setProvider(v as LlmProvider)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(PROVIDER_LABELS) as LlmProvider[]).map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {PROVIDER_LABELS[p]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Input
+                type="password"
+                placeholder={`${PROVIDER_LABELS[provider]} API Key`}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+              />
+              <Input
+                placeholder={`Model ID (default: ${DEFAULT_MODELS[provider]})`}
+                value={modelId}
+                onChange={(e) => setModelId(e.target.value)}
+              />
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleSaveCloud}
+                  disabled={!apiKey.trim() || saveMutation.isPending}
+                >
+                  {saveMutation.isPending && (
+                    <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                  )}
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    setAdding(false);
+                    setApiKey("");
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {configs.length === 0 && !adding && (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No API keys configured yet.
+          </p>
+        )}
+
+        {configs.map((config) => (
+          <Card key={config.id}>
+            <CardContent className="py-3 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <Key className="h-4 w-4 text-muted-foreground" />
+                <div>
+                  <span className="text-sm font-medium">
+                    {PROVIDER_LABELS[config.provider]}
+                  </span>
+                  {config.modelId && (
+                    <span className="text-xs text-muted-foreground ml-2">
+                      {config.modelId}
+                    </span>
+                  )}
+                  <div className="text-xs text-muted-foreground font-mono">
+                    {config.maskedKey}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <Badge
+                  variant={config.isActive ? "default" : "secondary"}
+                  className="text-xs"
+                >
+                  {config.isActive ? "Active" : "Disabled"}
+                </Badge>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleValidate(config.provider)}
+                  disabled={validating === config.provider}
+                >
+                  {validating === config.provider ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="h-3 w-3" />
+                  )}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => deleteMutation.mutate(config.provider)}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* ── Local LLM ── */}
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Cpu className="h-4 w-4 text-muted-foreground" />
+          <h3 className="font-semibold text-sm">Local LLM</h3>
+          <Badge variant="secondary" className="text-xs">
+            Free — no API fees
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Use Ollama, LM Studio, llama.cpp, or any OpenAI-compatible server
+          running on your machine. Questions are generated in the browser.
+        </p>
+
+        {savedLocalConfig && (
+          <Card className="bg-green-50 border-green-200">
+            <CardContent className="py-2 px-3 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-xs text-green-800">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                <span>
+                  Active: <strong>{savedLocalConfig.modelId}</strong> via{" "}
+                  {savedLocalConfig.baseUrl}
+                </span>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 text-xs text-green-700"
+                onClick={handleClearLocal}
+              >
+                Clear
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card>
+          <CardContent className="pt-4 space-y-3">
+            <div className="space-y-1">
+              <label className="text-xs font-medium">API Dialect</label>
+              <Select
+                value={localDialect}
+                onValueChange={(v) => handleDialectChange(v as LocalLlmDialect)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(DIALECT_LABELS) as LocalLlmDialect[]).map(
+                    (d) => (
+                      <SelectItem key={d} value={d}>
+                        {DIALECT_LABELS[d]}
+                      </SelectItem>
+                    ),
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-xs font-medium">Base URL</label>
+              <Input
+                placeholder={DIALECT_DEFAULTS[localDialect]}
+                value={localBaseUrl}
+                onChange={(e) => {
+                  setLocalBaseUrl(e.target.value);
+                  setTestState("idle");
+                }}
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-xs font-medium">
+                API Key{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional — usually not needed for local servers)
+                </span>
+              </label>
+              <Input
+                type="password"
+                placeholder="Leave empty for local"
+                value={localApiKey}
+                onChange={(e) => setLocalApiKey(e.target.value)}
+              />
+            </div>
+
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-full"
+              disabled={!localBaseUrl.trim() || testState === "testing"}
+              onClick={handleTestConnection}
+            >
+              {testState === "testing" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5 mr-2" />
+              )}
+              {testState === "testing" ? "Testing…" : "Test Connection"}
+            </Button>
+
+            {testState !== "idle" && testState !== "testing" && (
+              <TestResultBadge result={testState} />
+            )}
+
+            {localModels.length > 0 && (
+              <div className="space-y-1">
+                <label className="text-xs font-medium">Select Model</label>
+                <Select value={selectedModel} onValueChange={setSelectedModel}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a model…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {localModels.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {selectedModel && (
+              <Button size="sm" className="w-full" onClick={handleSaveLocal}>
+                Save Local Config
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* CORS guide */}
+        <button
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          onClick={() => setShowCorsGuide((v) => !v)}
+        >
+          {showCorsGuide ? (
+            <ChevronUp className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+          CORS setup guide
+        </button>
+        {showCorsGuide && (
+          <Card className="bg-muted/40 border-dashed">
+            <CardContent className="pt-3 pb-3 space-y-3 text-xs text-muted-foreground">
+              <p className="font-medium text-foreground">
+                Allow browser → local server requests:
+              </p>
+              <div>
+                <p className="font-medium mb-1">Ollama:</p>
+                <code className="block bg-background rounded p-2 font-mono whitespace-pre-wrap">
+                  {`OLLAMA_ORIGINS=https://your-app-domain.com ollama serve`}
+                </code>
+              </div>
+              <div>
+                <p className="font-medium mb-1">LM Studio:</p>
+                <p>
+                  Settings → Local Server → CORS → enable and add this page's
+                  origin.
+                </p>
+              </div>
+              <div>
+                <p className="font-medium mb-1">llama.cpp server:</p>
+                <code className="block bg-background rounded p-2 font-mono">
+                  {`./server --cors-allowed-origins "https://your-app-domain.com"`}
+                </code>
+              </div>
+            </CardContent>
+          </Card>
         )}
       </div>
 
-      {adding && (
-        <Card className="border-dashed">
-          <CardContent className="pt-4 space-y-3">
-            <Select value={provider} onValueChange={v => setProvider(v as LlmProvider)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {(Object.keys(PROVIDER_LABELS) as LlmProvider[]).map(p => (
-                  <SelectItem key={p} value={p}>{PROVIDER_LABELS[p]}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Input
-              type="password"
-              placeholder={`${PROVIDER_LABELS[provider]} API Key`}
-              value={apiKey}
-              onChange={e => setApiKey(e.target.value)}
-            />
-            <Input
-              placeholder={`Model ID (default: ${DEFAULT_MODELS[provider]})`}
-              value={modelId}
-              onChange={e => setModelId(e.target.value)}
-            />
-            <div className="flex gap-2">
-              <Button size="sm" onClick={handleSave} disabled={!apiKey.trim() || saveMutation.isPending}>
-                {saveMutation.isPending && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
-                Save
-              </Button>
-              <Button size="sm" variant="ghost" onClick={() => { setAdding(false); setApiKey(''); }}>Cancel</Button>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {configs.length === 0 && !adding && (
-        <p className="text-sm text-muted-foreground text-center py-4">No API keys configured yet.</p>
-      )}
-
-      {configs.map(config => (
-        <Card key={config.id}>
-          <CardContent className="py-3 flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <Key className="h-4 w-4 text-muted-foreground" />
-              <div>
-                <span className="text-sm font-medium">{PROVIDER_LABELS[config.provider]}</span>
-                {config.modelId && <span className="text-xs text-muted-foreground ml-2">{config.modelId}</span>}
-                <div className="text-xs text-muted-foreground font-mono">{config.maskedKey}</div>
-              </div>
-            </div>
-            <div className="flex items-center gap-1">
-              <Badge variant={config.isActive ? 'default' : 'secondary'} className="text-xs">
-                {config.isActive ? 'Active' : 'Disabled'}
-              </Badge>
-              <Button
-                size="sm" variant="ghost"
-                onClick={() => handleValidate(config.provider)}
-                disabled={validating === config.provider}
-              >
-                {validating === config.provider
-                  ? <Loader2 className="h-3 w-3 animate-spin" />
-                  : <CheckCircle2 className="h-3 w-3" />}
-              </Button>
-              <Button
-                size="sm" variant="ghost"
-                className="text-destructive hover:text-destructive"
-                onClick={() => deleteMutation.mutate(config.provider)}
-              >
-                <Trash2 className="h-3 w-3" />
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
-
+      {/* ── MCP Mode ── */}
       <Card className="bg-muted/30 border-dashed">
         <CardHeader className="pb-2 pt-3">
-          <CardTitle className="text-xs text-muted-foreground">MCP Mode (Claude Desktop / NotebookLM)</CardTitle>
+          <CardTitle className="text-xs text-muted-foreground">
+            MCP Mode (Claude Desktop / NotebookLM)
+          </CardTitle>
         </CardHeader>
         <CardContent className="pb-3 text-xs text-muted-foreground space-y-1">
           <p>Connect your MCP-compatible AI tool to push questions directly:</p>
           <code className="block bg-background rounded p-2 font-mono text-xs">
             POST /api/v1/ai-questions/mcp/intake
           </code>
-          <p>Use your Bearer token as the Authorization header. Questions are auto-routed through the quality gate.</p>
+          <p>
+            Use your Bearer token as the Authorization header. Questions are
+            auto-routed through the quality gate.
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/src/pages/AiQuestionGenerator.tsx
+++ b/src/pages/AiQuestionGenerator.tsx
@@ -22,6 +22,10 @@ import { JobStatusResult, GenerationJob } from "@/types/api-types";
 import LlmConfigPanel from "@/components/ai-questions/LlmConfigPanel";
 import GenerationForm from "@/components/ai-questions/GenerationForm";
 import GeneratedQuestionsReview from "@/components/ai-questions/GeneratedQuestionsReview";
+import {
+  localLlmConfigStorage,
+  submitLocalQuestionsToIntake,
+} from "@/services/local-llm";
 
 const STATUS_COLORS: Record<string, string> = {
   COMPLETED: "default",
@@ -35,6 +39,7 @@ export default function AiQuestionGenerator() {
     result: JobStatusResult;
     certificationId: string;
     domainId?: string;
+    isLocal?: boolean;
   } | null>(null);
   const [activeTab, setActiveTab] = useState<string | undefined>(undefined);
   const [loadingJobId, setLoadingJobId] = useState<string | null>(null);
@@ -49,13 +54,16 @@ export default function AiQuestionGenerator() {
   });
 
   const hasKeys = configs.length > 0;
+  const hasLocalConfig = !!localLlmConfigStorage.get();
+  const hasAccess = hasKeys || hasLocalConfig;
 
   const handleResult = (
     result: JobStatusResult,
     certificationId: string,
     domainId?: string,
   ) => {
-    setGenerationResult({ result, certificationId, domainId });
+    const isLocal = result.jobId.startsWith("local-");
+    setGenerationResult({ result, certificationId, domainId, isLocal });
     setActiveTab("review");
   };
 
@@ -78,7 +86,7 @@ export default function AiQuestionGenerator() {
 
   const computedDefaultTab = generationResult
     ? "review"
-    : hasKeys
+    : hasAccess
       ? "generate"
       : "settings";
 
@@ -105,7 +113,7 @@ export default function AiQuestionGenerator() {
             <TabsTrigger value="settings">
               <Settings className="h-4 w-4 mr-1.5" />
               AI Settings
-              {!hasKeys && (
+              {!hasAccess && (
                 <Badge
                   variant="destructive"
                   className="ml-1.5 text-xs h-4 px-1"
@@ -149,14 +157,15 @@ export default function AiQuestionGenerator() {
 
           {/* Generate Tab */}
           <TabsContent value="generate">
-            {!hasKeys ? (
+            {!hasAccess ? (
               <Card className="border-dashed">
                 <CardContent className="py-8 text-center">
                   <Bot className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
                   <p className="font-medium">No AI provider configured</p>
                   <p className="text-sm text-muted-foreground mt-1">
-                    Add an API key in the <strong>AI Settings</strong> tab to
-                    start generating questions.
+                    Add a cloud API key or configure a{" "}
+                    <strong>Local LLM</strong> in the{" "}
+                    <strong>AI Settings</strong> tab.
                   </p>
                 </CardContent>
               </Card>
@@ -167,9 +176,9 @@ export default function AiQuestionGenerator() {
                     Generate Questions
                   </CardTitle>
                   <CardDescription>
-                    Select your certification, optionally pick a source
-                    material, and generate exam-style questions. Questions are
-                    scored by a critic LLM and auto-routed based on quality.
+                    Select your certification and generate exam-style questions.
+                    Cloud providers score questions automatically. Local LLM
+                    questions go to Pending for admin review.
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -190,6 +199,18 @@ export default function AiQuestionGenerator() {
                   setGenerationResult(null);
                   setActiveTab("generate");
                 }}
+                localSubmit={
+                  generationResult.isLocal
+                    ? (questions, certId, dId) => {
+                        const config = localLlmConfigStorage.get();
+                        return submitLocalQuestionsToIntake(questions, {
+                          certificationId: certId,
+                          domainId: dId,
+                          localModelId: config?.modelId,
+                        });
+                      }
+                    : undefined
+                }
               />
             </TabsContent>
           )}

--- a/src/services/__tests__/local-llm.test.ts
+++ b/src/services/__tests__/local-llm.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isAllowedLocalUrl } from "@/services/local-llm/local-llm-client";
+import { localLlmConfigStorage } from "@/services/local-llm/config-storage";
+import { LocalLlmConfig } from "@/types/api-types";
+
+describe("Local LLM Feature", () => {
+  describe("URL Validation", () => {
+    it("should allow localhost URLs", () => {
+      expect(isAllowedLocalUrl("http://localhost:11434")).toBe(true);
+      expect(isAllowedLocalUrl("http://localhost:8000")).toBe(true);
+    });
+
+    it("should allow 127.0.0.1 URLs", () => {
+      expect(isAllowedLocalUrl("http://127.0.0.1:11434")).toBe(true);
+    });
+
+    it("should allow IPv6 localhost URLs", () => {
+      expect(isAllowedLocalUrl("http://[::1]:11434")).toBe(true);
+    });
+
+    it("should allow .local domain names", () => {
+      expect(isAllowedLocalUrl("http://ollama.local:11434")).toBe(true);
+      expect(isAllowedLocalUrl("http://lm-studio.local:8000")).toBe(true);
+    });
+
+    it("should reject external URLs", () => {
+      expect(isAllowedLocalUrl("http://example.com:11434")).toBe(false);
+      expect(isAllowedLocalUrl("https://api.openai.com")).toBe(false);
+    });
+
+    it("should handle invalid URLs gracefully", () => {
+      expect(isAllowedLocalUrl("not a valid url")).toBe(false);
+      expect(isAllowedLocalUrl("")).toBe(false);
+    });
+  });
+
+  describe("Config Storage", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("should save and retrieve config", () => {
+      const config: LocalLlmConfig = {
+        dialect: "openai",
+        baseUrl: "http://localhost:11434",
+        modelId: "llama2",
+        apiKey: "test-key",
+      };
+
+      localLlmConfigStorage.set(config);
+      const retrieved = localLlmConfigStorage.get();
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.dialect).toBe("openai");
+      expect(retrieved?.baseUrl).toBe("http://localhost:11434");
+      expect(retrieved?.modelId).toBe("llama2");
+    });
+
+    it("should return null when no config is saved", () => {
+      const retrieved = localLlmConfigStorage.get();
+      expect(retrieved).toBeNull();
+    });
+
+    it("should clear config", () => {
+      const config: LocalLlmConfig = {
+        dialect: "ollama",
+        baseUrl: "http://localhost:11434",
+        modelId: "mistral",
+      };
+
+      localLlmConfigStorage.set(config);
+      expect(localLlmConfigStorage.get()).toBeDefined();
+
+      localLlmConfigStorage.clear();
+      expect(localLlmConfigStorage.get()).toBeNull();
+    });
+
+    it("should update existing config", () => {
+      const config1: LocalLlmConfig = {
+        dialect: "openai",
+        baseUrl: "http://localhost:11434",
+        modelId: "llama2",
+      };
+
+      localLlmConfigStorage.set(config1);
+
+      const config2: LocalLlmConfig = {
+        dialect: "anthropic",
+        baseUrl: "http://localhost:8000",
+        modelId: "claude-3",
+      };
+
+      localLlmConfigStorage.set(config2);
+      const retrieved = localLlmConfigStorage.get();
+
+      expect(retrieved?.dialect).toBe("anthropic");
+      expect(retrieved?.baseUrl).toBe("http://localhost:8000");
+      expect(retrieved?.modelId).toBe("claude-3");
+    });
+
+    it("should handle apiKey field optionally", () => {
+      const configWithoutKey: LocalLlmConfig = {
+        dialect: "ollama",
+        baseUrl: "http://localhost:11434",
+        modelId: "llama2",
+      };
+
+      localLlmConfigStorage.set(configWithoutKey);
+      const retrieved = localLlmConfigStorage.get();
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.apiKey).toBeUndefined();
+    });
+
+    it("should validate storage key format", () => {
+      // Verify that the storage key is consistent
+      const config: LocalLlmConfig = {
+        dialect: "openai",
+        baseUrl: "http://localhost:11434",
+        modelId: "test-model",
+      };
+
+      localLlmConfigStorage.set(config);
+
+      // Check that localStorage was updated with the correct key
+      const stored = localStorage.getItem("braingym:local-llm-config");
+      expect(stored).toBeDefined();
+      expect(stored).toContain("localhost:11434");
+      expect(stored).toContain("test-model");
+    });
+  });
+
+  describe("Feature Integration", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("should support openai dialect configuration", () => {
+      const config: LocalLlmConfig = {
+        dialect: "openai",
+        baseUrl: "http://localhost:8000",
+        modelId: "any-openai-compatible-model",
+      };
+
+      localLlmConfigStorage.set(config);
+      const retrieved = localLlmConfigStorage.get();
+
+      expect(retrieved?.dialect).toBe("openai");
+    });
+
+    it("should support anthropic dialect configuration", () => {
+      const config: LocalLlmConfig = {
+        dialect: "anthropic",
+        baseUrl: "http://localhost:8000",
+        modelId: "claude-compatible-model",
+      };
+
+      localLlmConfigStorage.set(config);
+      const retrieved = localLlmConfigStorage.get();
+
+      expect(retrieved?.dialect).toBe("anthropic");
+    });
+
+    it("should support ollama dialect configuration", () => {
+      const config: LocalLlmConfig = {
+        dialect: "ollama",
+        baseUrl: "http://localhost:11434",
+        modelId: "llama2",
+      };
+
+      localLlmConfigStorage.set(config);
+      const retrieved = localLlmConfigStorage.get();
+
+      expect(retrieved?.dialect).toBe("ollama");
+    });
+
+    it("should persist config across multiple save/load cycles", () => {
+      const configs: LocalLlmConfig[] = [
+        {
+          dialect: "openai",
+          baseUrl: "http://localhost:11434",
+          modelId: "model1",
+        },
+        {
+          dialect: "ollama",
+          baseUrl: "http://localhost:11434",
+          modelId: "model2",
+        },
+        {
+          dialect: "anthropic",
+          baseUrl: "http://localhost:8000",
+          modelId: "model3",
+        },
+      ];
+
+      configs.forEach((config) => {
+        localLlmConfigStorage.set(config);
+        const retrieved = localLlmConfigStorage.get();
+        expect(retrieved?.modelId).toBe(config.modelId);
+        expect(retrieved?.dialect).toBe(config.dialect);
+      });
+    });
+  });
+});

--- a/src/services/__tests__/local-llm.test.ts
+++ b/src/services/__tests__/local-llm.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { isAllowedLocalUrl } from "@/services/local-llm/local-llm-client";
 import { localLlmConfigStorage } from "@/services/local-llm/config-storage";
-import { LocalLlmConfig } from "@/types/api-types";
+import { LocalLlmConfig } from "@/services/local-llm/types";
 
 describe("Local LLM Feature", () => {
   describe("URL Validation", () => {

--- a/src/services/local-llm/config-storage.ts
+++ b/src/services/local-llm/config-storage.ts
@@ -1,0 +1,33 @@
+import type { LocalLlmDialect } from "./types";
+
+const STORAGE_KEY = "braingym:local-llm-config";
+
+export interface StoredLocalLlmConfig {
+  dialect: LocalLlmDialect;
+  baseUrl: string;
+  modelId: string;
+  apiKey?: string;
+  savedAt: string; // ISO 8601
+}
+
+export const localLlmConfigStorage = {
+  get(): StoredLocalLlmConfig | null {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? (JSON.parse(raw) as StoredLocalLlmConfig) : null;
+    } catch {
+      return null;
+    }
+  },
+
+  set(config: Omit<StoredLocalLlmConfig, "savedAt">): void {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...config, savedAt: new Date().toISOString() }),
+    );
+  },
+
+  clear(): void {
+    localStorage.removeItem(STORAGE_KEY);
+  },
+};

--- a/src/services/local-llm/index.ts
+++ b/src/services/local-llm/index.ts
@@ -1,0 +1,18 @@
+export type {
+  LocalLlmDialect,
+  LocalLlmConfig,
+  LocalModelInfo,
+  ConnectionTestResult,
+  LocalGenerationParams,
+} from "./types";
+export { localLlmConfigStorage } from "./config-storage";
+export type { StoredLocalLlmConfig } from "./config-storage";
+export {
+  testConnection,
+  listModels,
+  generateLocalQuestions,
+  isAllowedLocalUrl,
+} from "./local-llm-client";
+export type { GenerateLocalResult } from "./local-llm-client";
+export { submitLocalQuestionsToIntake } from "./submit-intake";
+export type { IntakeContext, IntakeResponse } from "./submit-intake";

--- a/src/services/local-llm/local-llm-client.ts
+++ b/src/services/local-llm/local-llm-client.ts
@@ -360,10 +360,11 @@ export async function generateLocalQuestions(
   const result = RawQuestionsResponseSchema.safeParse(parsed);
   if (!result.success) {
     // Salvage valid individual questions
-    const arr = Array.isArray((parsed as any)?.questions)
-      ? (parsed as any).questions
-      : Array.isArray(parsed)
-        ? parsed
+    const parsedObj = parsed as Record<string, unknown> | unknown[];
+    const arr = Array.isArray((parsedObj as Record<string, unknown>)?.questions)
+      ? ((parsedObj as Record<string, unknown>).questions as unknown[])
+      : Array.isArray(parsedObj)
+        ? (parsedObj as unknown[])
         : [];
 
     const previews: GeneratedQuestionPreview[] = [];

--- a/src/services/local-llm/local-llm-client.ts
+++ b/src/services/local-llm/local-llm-client.ts
@@ -1,0 +1,386 @@
+import {
+  Difficulty,
+  GeneratedQuestionPreview,
+  QualityTier,
+  QuestionType,
+} from "@/types/api-types";
+import { buildLocalSystemPrompt, buildLocalUserPrompt } from "./prompt-builder";
+import { RawQuestionsResponseSchema, type RawQuestion } from "./schema";
+import type {
+  ConnectionTestResult,
+  LocalGenerationParams,
+  LocalLlmConfig,
+  LocalModelInfo,
+} from "./types";
+
+// ─── URL safety ──────────────────────────────────────────────────────────────
+
+export function isAllowedLocalUrl(rawUrl: string): boolean {
+  try {
+    const { hostname } = new URL(rawUrl);
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]" ||
+      hostname.endsWith(".local")
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ─── Auth headers per dialect ─────────────────────────────────────────────────
+
+function authHeaders(config: LocalLlmConfig): Record<string, string> {
+  switch (config.dialect) {
+    case "anthropic":
+      return {
+        "x-api-key": config.apiKey ?? "",
+        "anthropic-version": "2023-06-01",
+      };
+    case "openai":
+      // Ollama accepts any non-empty Bearer; LM Studio may require one too.
+      return { Authorization: `Bearer ${config.apiKey || "local"}` };
+    case "ollama":
+      return {};
+  }
+}
+
+// ─── Model discovery ──────────────────────────────────────────────────────────
+
+async function parseOpenAiModels(res: Response): Promise<LocalModelInfo[]> {
+  const data = (await res.json()) as { data?: { id: string }[] };
+  return (data.data ?? []).map((m) => ({ id: m.id, name: m.id }));
+}
+
+async function parseOllamaModels(res: Response): Promise<LocalModelInfo[]> {
+  const data = (await res.json()) as {
+    models?: { name: string; model?: string }[];
+  };
+  return (data.models ?? []).map((m) => ({
+    id: m.model ?? m.name,
+    name: m.name,
+  }));
+}
+
+/** Distinguish CORS-blocked from truly unreachable using a no-cors probe. */
+async function detectNetworkError(
+  baseUrl: string,
+): Promise<"cors" | "unreachable"> {
+  try {
+    await fetch(baseUrl, {
+      method: "HEAD",
+      mode: "no-cors",
+      signal: AbortSignal.timeout(3000),
+    });
+    // Got an opaque response → server is reachable, real request was CORS-blocked.
+    return "cors";
+  } catch {
+    return "unreachable";
+  }
+}
+
+/** Ollama fallback: if /models returns 404, retry with /api/tags. */
+async function testOllamaFallback(
+  config: Omit<LocalLlmConfig, "modelId">,
+): Promise<ConnectionTestResult> {
+  try {
+    const res = await fetch(`${config.baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        reason: "wrong_dialect",
+        hint: "Endpoint not found. Check the base URL and dialect.",
+      };
+    }
+    const models = await parseOllamaModels(res);
+    if (models.length === 0) {
+      return {
+        ok: false,
+        reason: "empty",
+        hint: "Ollama is running but no models are loaded. Run: ollama pull <model>",
+      };
+    }
+    return { ok: true, models };
+  } catch {
+    const reason = await detectNetworkError(config.baseUrl);
+    return {
+      ok: false,
+      reason,
+      hint:
+        reason === "cors"
+          ? "CORS is blocking the request. Set OLLAMA_ORIGINS to include this page's origin."
+          : `Cannot reach ${config.baseUrl}. Make sure Ollama is running.`,
+    };
+  }
+}
+
+export async function testConnection(
+  config: Omit<LocalLlmConfig, "modelId">,
+): Promise<ConnectionTestResult> {
+  if (!isAllowedLocalUrl(config.baseUrl)) {
+    return {
+      ok: false,
+      reason: "unreachable",
+      hint: "Base URL must point to localhost or a .local host.",
+    };
+  }
+
+  const { dialect, baseUrl } = config;
+  const listUrl =
+    dialect === "ollama" ? `${baseUrl}/api/tags` : `${baseUrl}/models`;
+
+  try {
+    const res = await fetch(listUrl, {
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders({ ...config, modelId: "" }),
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!res.ok) {
+      if (res.status === 404 && dialect === "openai") {
+        return testOllamaFallback(config);
+      }
+      return {
+        ok: false,
+        reason: "wrong_dialect",
+        hint: `Server returned ${res.status}. Try switching to a different dialect.`,
+      };
+    }
+
+    const models =
+      dialect === "ollama"
+        ? await parseOllamaModels(res)
+        : await parseOpenAiModels(res);
+
+    if (models.length === 0) {
+      return {
+        ok: false,
+        reason: "empty",
+        hint:
+          dialect === "openai"
+            ? "No models found. Make sure a model is loaded in LM Studio, or start Ollama with a model pulled."
+            : "No models returned by the server.",
+      };
+    }
+
+    return { ok: true, models };
+  } catch {
+    const reason = await detectNetworkError(baseUrl);
+    const hint =
+      reason === "cors"
+        ? `CORS is blocking the request. For Ollama: set OLLAMA_ORIGINS to include this page's origin. For LM Studio: enable CORS in Settings → Local Server.`
+        : `Cannot reach ${baseUrl}. Make sure the server is running.`;
+    return { ok: false, reason, hint };
+  }
+}
+
+export async function listModels(
+  config: LocalLlmConfig,
+): Promise<LocalModelInfo[]> {
+  const result = await testConnection(config);
+  return result.ok ? result.models : [];
+}
+
+// ─── Generation ───────────────────────────────────────────────────────────────
+
+async function callGenerate(
+  config: LocalLlmConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const headers = {
+    "Content-Type": "application/json",
+    ...authHeaders(config),
+  };
+  const timeout = AbortSignal.timeout(120_000);
+
+  if (config.dialect === "ollama") {
+    const res = await fetch(`${config.baseUrl}/api/generate`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: config.modelId,
+        prompt: `${system}\n\n${user}`,
+        stream: false,
+      }),
+      signal: timeout,
+    });
+    const data = (await res.json()) as { response: string };
+    return data.response ?? "";
+  }
+
+  if (config.dialect === "anthropic") {
+    const res = await fetch(`${config.baseUrl}/messages`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: config.modelId,
+        max_tokens: 4096,
+        system,
+        messages: [{ role: "user", content: user }],
+      }),
+      signal: timeout,
+    });
+    const data = (await res.json()) as { content: { text: string }[] };
+    return data.content?.[0]?.text ?? "";
+  }
+
+  // openai dialect — also covers Ollama /v1
+  const res = await fetch(`${config.baseUrl}/chat/completions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model: config.modelId,
+      max_tokens: 4096,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+    }),
+    signal: timeout,
+  });
+  const data = (await res.json()) as {
+    choices: { message: { content: string } }[];
+  };
+  return data.choices?.[0]?.message?.content ?? "";
+}
+
+// ─── JSON extraction pipeline ─────────────────────────────────────────────────
+
+function extractJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // continue
+  }
+  const fence = raw.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
+  if (fence) {
+    try {
+      return JSON.parse(fence[1]);
+    } catch {
+      // continue
+    }
+  }
+  // Find first balanced { }
+  const start = raw.indexOf("{");
+  if (start !== -1) {
+    let depth = 0;
+    for (let i = start; i < raw.length; i++) {
+      if (raw[i] === "{") depth++;
+      else if (raw[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          try {
+            return JSON.parse(raw.slice(start, i + 1));
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
+// ─── Mapping ──────────────────────────────────────────────────────────────────
+
+function confidenceToScore(hint: string): number {
+  if (hint === "high") return 0.87;
+  if (hint === "low") return 0.5;
+  return 0.7;
+}
+
+function scoreToTier(score: number): QualityTier | null {
+  if (score >= 0.8) return "HIGH";
+  if (score >= 0.5) return "MEDIUM";
+  return "LOW";
+}
+
+function mapRawToPreview(
+  raw: RawQuestion,
+  params: LocalGenerationParams,
+): GeneratedQuestionPreview {
+  const correctLetters = raw.correct_answer
+    .split(",")
+    .map((s) => s.trim().toUpperCase())
+    .filter(Boolean);
+
+  const choices = raw.options.map((opt, idx) => {
+    const label =
+      opt.match(/^\s*([A-Z])\b/)?.[1] ?? String.fromCharCode(65 + idx);
+    const content = opt.replace(/^\s*[A-Z][.)]\s*/, "").trim();
+    return { label, content, isCorrect: correctLetters.includes(label) };
+  });
+
+  const score = confidenceToScore(raw.confidence_hint ?? "medium");
+  const questionType =
+    correctLetters.length > 1 ? QuestionType.MULTIPLE : QuestionType.SINGLE;
+
+  return {
+    title: raw.question,
+    questionType,
+    difficulty: params.difficulty as Difficulty,
+    explanation: raw.explanation ?? "",
+    choices,
+    tags: [],
+    sourcePassage: raw.source_passage,
+    qualityScore: score,
+    qualityTier: scoreToTier(score),
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export interface GenerateLocalResult {
+  previews: GeneratedQuestionPreview[];
+  discarded: number;
+  /** Populated when all questions were discarded, for debugging. */
+  rawText?: string;
+}
+
+export async function generateLocalQuestions(
+  config: LocalLlmConfig,
+  params: LocalGenerationParams,
+): Promise<GenerateLocalResult> {
+  const system = buildLocalSystemPrompt();
+  const user = buildLocalUserPrompt(params);
+  const rawText = await callGenerate(config, system, user);
+  const parsed = extractJson(rawText);
+
+  if (!parsed) {
+    return { previews: [], discarded: params.questionCount, rawText };
+  }
+
+  const result = RawQuestionsResponseSchema.safeParse(parsed);
+  if (!result.success) {
+    // Salvage valid individual questions
+    const arr = Array.isArray((parsed as any)?.questions)
+      ? (parsed as any).questions
+      : Array.isArray(parsed)
+        ? parsed
+        : [];
+
+    const previews: GeneratedQuestionPreview[] = [];
+    for (const item of arr) {
+      const q =
+        RawQuestionsResponseSchema.shape.questions.element.safeParse(item);
+      if (q.success) previews.push(mapRawToPreview(q.data, params));
+    }
+    return {
+      previews,
+      discarded: params.questionCount - previews.length,
+      rawText: previews.length === 0 ? rawText : undefined,
+    };
+  }
+
+  return {
+    previews: result.data.questions.map((q) => mapRawToPreview(q, params)),
+    discarded: 0,
+  };
+}

--- a/src/services/local-llm/prompt-builder.ts
+++ b/src/services/local-llm/prompt-builder.ts
@@ -1,0 +1,51 @@
+import { Difficulty, QuestionType } from "@/types/api-types";
+import type { LocalGenerationParams } from "./types";
+
+// Mirrors backend/src/ai-question-bank/prompts/question-generation.prompt.ts
+// so both cloud and local paths produce questions in the same format.
+
+export function buildLocalSystemPrompt(): string {
+  return `You are an expert certification exam question writer. Your job is to create high-quality, exam-realistic multiple-choice questions.
+
+Rules:
+- Questions must be factually accurate.
+- Distractors (wrong answers) must be plausible — not obviously wrong.
+- Correct answers must be unambiguously correct.
+- Explanations must clearly justify why the correct answer is right and why the distractors are wrong.
+- You MUST respond with valid JSON only — no markdown, no extra text.`;
+}
+
+export function buildLocalUserPrompt(params: LocalGenerationParams): string {
+  const difficultyGuide: Record<Difficulty, string> = {
+    [Difficulty.EASY]: "straightforward recall and basic understanding",
+    [Difficulty.MEDIUM]: "application of concepts and scenario-based reasoning",
+    [Difficulty.HARD]:
+      "complex multi-step reasoning, architecture trade-offs, or subtle distinctions",
+  };
+
+  const typeGuide =
+    params.questionType === QuestionType.MULTIPLE
+      ? "MULTIPLE choice (2-3 correct answers out of 5-6 options)"
+      : "SINGLE choice (exactly 1 correct answer out of 4 options)";
+
+  return `Generate ${params.questionCount} ${typeGuide} questions for the **${params.certificationName} (${params.certificationCode})** certification exam.
+${params.domainName ? `Domain/Topic: ${params.domainName}` : ""}
+Difficulty: ${params.difficulty} — focus on ${difficultyGuide[params.difficulty]}.
+
+Return a JSON object with this exact schema:
+{
+  "questions": [
+    {
+      "question": "Full question text",
+      "options": ["A. Option text", "B. Option text", "C. Option text", "D. Option text"],
+      "correct_answer": "A",
+      "explanation": "Detailed explanation of why the answer is correct and others are wrong",
+      "source_passage": "Optional: passage the question is based on",
+      "confidence_hint": "high"
+    }
+  ]
+}
+
+For MULTIPLE choice, correct_answer is comma-separated like "A,C".
+confidence_hint must be one of: "high", "medium", "low" — your estimate of question quality.`;
+}

--- a/src/services/local-llm/schema.ts
+++ b/src/services/local-llm/schema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+// Mirror of the prompt schema the LLM is asked to return.
+// options is "A. some text" | "B. some text" etc.
+export const RawQuestionSchema = z.object({
+  question: z.string().min(5),
+  options: z.array(z.string().min(1)).min(2).max(8),
+  correct_answer: z.string().min(1),
+  explanation: z.string().optional().default(""),
+  source_passage: z.string().optional(),
+  confidence_hint: z
+    .enum(["high", "medium", "low"])
+    .optional()
+    .default("medium"),
+});
+
+export const RawQuestionsResponseSchema = z.object({
+  questions: z.array(RawQuestionSchema).min(1),
+});
+
+export type RawQuestion = z.infer<typeof RawQuestionSchema>;

--- a/src/services/local-llm/submit-intake.ts
+++ b/src/services/local-llm/submit-intake.ts
@@ -1,0 +1,47 @@
+import type {
+  Difficulty,
+  GeneratedQuestionPreview,
+  QuestionType,
+} from "@/types/api-types";
+import api from "@/services/api";
+
+export interface IntakeContext {
+  certificationId: string;
+  domainId?: string;
+  difficulty?: Difficulty;
+  questionType?: QuestionType;
+  /** Model that generated these questions, for provenance tracking. */
+  localModelId?: string;
+}
+
+export interface IntakeResponse {
+  saved: number;
+  discarded: number;
+  questionIds: string[];
+}
+
+export async function submitLocalQuestionsToIntake(
+  questions: GeneratedQuestionPreview[],
+  context: IntakeContext,
+): Promise<IntakeResponse> {
+  const payload = {
+    questions: questions.map((q) => ({
+      question: q.title,
+      choices: q.choices,
+      explanation: q.explanation || undefined,
+      quality_score: q.qualityScore ?? 0.6,
+    })),
+    certificationId: context.certificationId,
+    domainId: context.domainId,
+    difficulty: context.difficulty,
+    questionType: context.questionType,
+    source: "LOCAL_LLM",
+    localModelId: context.localModelId,
+  };
+
+  const res = await api.post<IntakeResponse>(
+    "/ai-questions/mcp/intake",
+    payload,
+  );
+  return res.data;
+}

--- a/src/services/local-llm/types.ts
+++ b/src/services/local-llm/types.ts
@@ -1,0 +1,32 @@
+import { Difficulty, QuestionType } from "@/types/api-types";
+
+export type LocalLlmDialect = "openai" | "anthropic" | "ollama";
+
+export interface LocalLlmConfig {
+  dialect: LocalLlmDialect;
+  baseUrl: string;
+  modelId: string;
+  apiKey?: string;
+}
+
+export interface LocalModelInfo {
+  id: string;
+  name: string;
+}
+
+export type ConnectionTestResult =
+  | { ok: true; models: LocalModelInfo[] }
+  | {
+      ok: false;
+      reason: "cors" | "unreachable" | "wrong_dialect" | "empty";
+      hint: string;
+    };
+
+export interface LocalGenerationParams {
+  certificationName: string;
+  certificationCode: string;
+  domainName?: string;
+  difficulty: Difficulty;
+  questionCount: number;
+  questionType?: QuestionType;
+}


### PR DESCRIPTION
## Summary

Adds design document for **US-XXXX: Local LLM Question Generation**, allowing users to generate certification questions using locally-running models (Ollama, LM Studio, llama.cpp, vLLM, etc.) without paid cloud API keys.

Closes #64

## What's in this PR

- `docs/local-llm-question-generation.md` — full feature design covering:
  - Architecture & data flow diagram
  - `LocalLlmDialect` abstraction (openai / anthropic / ollama)
  - Model discovery + auto-detect logic
  - `testConnection()` — 5-way error classification (cors / unreachable / wrong_dialect / empty / ok)
  - JSON validation & repair pipeline (6-step, Zod-based)
  - Intake mapping to existing `POST /ai-questions/mcp/intake`
  - localStorage config storage (no backend secret storage needed)
  - UI extension plan for `LlmConfigPanel` + `GenerationForm`
  - Task breakdown (6 tasks, 8 SP total)
  - 12 Acceptance Criteria
  - Security & risk analysis

## Why frontend-only LLM call

SaaS backend runs on a remote server — it cannot reach `localhost` on the user's machine. The browser is the only viable path to call a locally-running LLM. The existing `mcp/intake` endpoint already handles quality-gating and question creation server-side.

## No code changes in this PR

This is a design/planning PR. Implementation will follow in separate feature PRs per task.

## Test plan

- [x] Read through `docs/local-llm-question-generation.md` for design review
- [x] Verify task breakdown covers all stated acceptance criteria
- [x] Confirm no existing `docs/` files are duplicated or contradicted