### PR TITLE
feat: expand self-hosted LLM support and dynamic CORS setup guide

### DIFF
--- a/docs/local-llm-question-generation.md
+++ b/docs/local-llm-question-generation.md
@@ -40,8 +40,8 @@ Luồng sinh câu hỏi hiện tại (`POST /ai-questions/generate`) gọi LLM t
 
 | #   | Mục tiêu                                                                                                   |
 | --- | ---------------------------------------------------------------------------------------------------------- |
-| M1  | Frontend có thể liệt kê model từ Ollama / LM Studio theo chuẩn OpenAI-compatible hoặc Anthropic-compatible |
-| M2  | Người dùng chọn model, nhập ngữ cảnh, sinh câu hỏi trực tiếp từ browser → local LLM                        |
+| M1  | Frontend có thể liệt kê model từ bất kỳ self-hosted LLM nào (Ollama, LM Studio, vLLM, Jan, v.v.) theo chuẩn OpenAI-compatible hoặc Anthropic-compatible |
+| M2  | Người dùng chọn model, nhập ngữ cảnh, sinh câu hỏi trực tiếp từ browser → self-hosted LLM                   |
 | M3  | Câu hỏi qua bước review rồi mới đẩy vào BrainGym Intake (`mcp/intake`)                                     |
 | M4  | Không tốn API fee, không đốt quota backend                                                                 |
 | M5  | Lỗi CORS / unreachable / dialect sai được chẩn đoán rõ ràng, có hướng dẫn khắc phục                        |
@@ -80,9 +80,15 @@ Luồng sinh câu hỏi hiện tại (`POST /ai-questions/generate`) gọi LLM t
 | `LlmConfigPanel`                  | `src/components/ai-questions/LlmConfigPanel.tsx` | Mở rộng thêm section "Local LLM"                                   |
 | `GenerationForm`                  | `src/components/ai-questions/GenerationForm.tsx` | Mở rộng chọn provider LOCAL                                        |
 
-### Lý do frontend gọi local, không phải backend
+### Lý do frontend gọi self-hosted LLM, không phải backend
 
-Backend chạy trên server/Docker — không thể kết nối tới `localhost` của máy người dùng. Đây là ràng buộc SaaS không thể thay đổi. Mọi lưu lượng local LLM **phải** xuất phát từ browser.
+Backend chạy trên server/Docker — không thể kết nối tới local network của người dùng. Đây là ràng buộc SaaS không thể thay đổi. Mọi lưu lượng self-hosted LLM (localhost, mDNS, hoặc private network) **phải** xuất phát từ browser.
+
+Hỗ trợ cho phép URL pointing tới:
+- **Localhost**: `localhost`, `127.0.0.1`, `::1`
+- **mDNS (.local domains)**: `myserver.local`, `gpu-box.local`, v.v.
+- **Private RFC 1918 networks**: `10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`
+- **Link-local IPv6**: `fe80::`
 
 ---
 
@@ -383,8 +389,11 @@ LlmConfigPanel
         ├── Model dropdown (populate sau khi test OK)
         ├── [Save local config]
         └── [CORS setup guide ▾] (fold/unfold)
-              Ollama:  OLLAMA_ORIGINS=<domain> ollama serve
-              LM Studio: Settings → Local Server → CORS
+              Hiển thị dynamic app origin (từ window.location.origin)
+              Ollama:  OLLAMA_ORIGINS=<origin> ollama serve
+              LM Studio: Settings → Local Server → CORS → add origin
+              llama.cpp: ./server --cors-allowed-origins "<origin>"
+              Other self-hosted: Refer to server docs for CORS config
 ```
 
 **Tại `GenerationForm`:**
@@ -430,7 +439,7 @@ try {
 
 | Vấn đề                                 | Giải pháp                                                                  |
 | -------------------------------------- | -------------------------------------------------------------------------- |
-| SSRF từ browser — user nhập URL tùy ý  | Whitelist chỉ `localhost`, `127.0.0.1`, `[::1]`, `*.local` trước khi fetch |
+| SSRF từ browser — user nhập URL tùy ý  | Whitelist: localhost, `127.0.0.1`, `::1`, `.local` domains, RFC 1918 ranges (10.x, 172.16-31.x, 192.168.x), link-local IPv6 (fe80::). Reject any other hostnames/IPs. |
 | API key cloud vô tình lưu localStorage | Warning rõ trong UI; label field là "optional, for local auth only"        |
 | JSON injection từ model output         | Parse `JSON.parse()` (không `eval`), validate Zod trước khi render         |
 | Câu hỏi chất lượng thấp vào bank       | Human review bắt buộc + intake quality gate → `PENDING` mặc định           |
@@ -630,7 +639,7 @@ Task 1 và Task 5 có thể làm song song trong cùng sprint.
 
 | Rủi ro                                   | Mức            | Giảm thiểu                                                                                                   |
 | ---------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
-| CORS blocked browser → localhost         | **Cao**        | UI hướng dẫn `OLLAMA_ORIGINS`; Test Connection chẩn đoán chính xác; docs inline                              |
+| CORS blocked browser → self-hosted LLM   | **Cao**        | UI hướng dẫn cấu hình CORS cho từng loại server; Test Connection chẩn đoán chính xác; docs inline           |
 | JSON output kém từ model nhỏ (7B/8B)     | **Cao**        | Pipeline repair 6 bước; Zod validate; human review bắt buộc; default `quality_score = 0.6` → PENDING         |
 | Mixed content HTTPS app → HTTP localhost | **Trung bình** | Chrome/Firefox/Edge OK với localhost (potentially trustworthy); Safari cần test và có thể cần hướng dẫn thêm |
 | LM Studio chỉ list model đang load       | **Thấp–TB**    | Ghi chú UI rõ ràng; hướng dẫn load model trước                                                               |

--- a/docs/local-llm-question-generation.md
+++ b/docs/local-llm-question-generation.md
@@ -80,15 +80,23 @@ Luồng sinh câu hỏi hiện tại (`POST /ai-questions/generate`) gọi LLM t
 | `LlmConfigPanel`                  | `src/components/ai-questions/LlmConfigPanel.tsx` | Mở rộng thêm section "Local LLM"                                   |
 | `GenerationForm`                  | `src/components/ai-questions/GenerationForm.tsx` | Mở rộng chọn provider LOCAL                                        |
 
-### Lý do frontend gọi self-hosted LLM, không phải backend
+### Lý do frontend gọi trực tiếp GenAI endpoint, không phải backend
 
-Backend chạy trên server/Docker — không thể kết nối tới local network của người dùng. Đây là ràng buộc SaaS không thể thay đổi. Mọi lưu lượng self-hosted LLM (localhost, mDNS, hoặc private network) **phải** xuất phát từ browser.
+Backend chạy trên server/Docker — không thể kết nối tới local network của người dùng. Đây là ràng buộc SaaS không thể thay đổi. Mọi request đến GenAI endpoint **phải** xuất phát từ browser.
 
-Hỗ trợ cho phép URL pointing tới:
-- **Localhost**: `localhost`, `127.0.0.1`, `::1`
-- **mDNS (.local domains)**: `myserver.local`, `gpu-box.local`, v.v.
-- **Private RFC 1918 networks**: `10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`
-- **Link-local IPv6**: `fe80::`
+**Bất kỳ URL `http://` hoặc `https://` nào đều được chấp nhận:**
+
+| Loại               | Ví dụ                                  |
+| ------------------ | -------------------------------------- |
+| Localhost          | `http://localhost:11434/v1`            |
+| LAN / private IP   | `http://192.168.1.100:8080/v1`         |
+| mDNS               | `http://gpu-box.local:11434/v1`        |
+| VPC / hostname nội bộ | `https://inference.company.com/v1`  |
+| Docker/K8s service | `http://ollama-svc:11434/v1`           |
+
+Không có whitelist IP/hostname — giới hạn duy nhất là **browser CORS policy**: nếu server không set `Access-Control-Allow-Origin`, browser sẽ block response trước khi data được đọc.
+
+**Lưu ý:** Nếu URL trùng với hostname của cloud provider chính thức (`api.openai.com`, `api.anthropic.com`...), UI sẽ cảnh báo dùng section Cloud Providers (BYOK) thay thế.
 
 ---
 
@@ -393,7 +401,8 @@ LlmConfigPanel
               Ollama:  OLLAMA_ORIGINS=<origin> ollama serve
               LM Studio: Settings → Local Server → CORS → add origin
               llama.cpp: ./server --cors-allowed-origins "<origin>"
-              Other self-hosted: Refer to server docs for CORS config
+              vLLM: --allowed-origins '["<origin>"]'
+              Custom: Set Access-Control-Allow-Origin response header
 ```
 
 **Tại `GenerationForm`:**
@@ -439,7 +448,7 @@ try {
 
 | Vấn đề                                 | Giải pháp                                                                  |
 | -------------------------------------- | -------------------------------------------------------------------------- |
-| SSRF từ browser — user nhập URL tùy ý  | Whitelist: localhost, `127.0.0.1`, `::1`, `.local` domains, RFC 1918 ranges (10.x, 172.16-31.x, 192.168.x), link-local IPv6 (fe80::). Reject any other hostnames/IPs. |
+| SSRF từ browser — user nhập URL tùy ý  | Không cần whitelist phía ứng dụng — browser tự enforce CORS. Ứng dụng chỉ validate URL hợp lệ (`http`/`https` scheme). Soft-warning nếu URL khớp cloud provider chính thức để tránh nhầm section. |
 | API key cloud vô tình lưu localStorage | Warning rõ trong UI; label field là "optional, for local auth only"        |
 | JSON injection từ model output         | Parse `JSON.parse()` (không `eval`), validate Zod trước khi render         |
 | Câu hỏi chất lượng thấp vào bank       | Human review bắt buộc + intake quality gate → `PENDING` mặc định           |

--- a/src/components/ai-questions/LlmConfigPanel.tsx
+++ b/src/components/ai-questions/LlmConfigPanel.tsx
@@ -103,6 +103,7 @@ function TestResultBadge({ result }: { result: ConnectionTestResult | null }) {
 
 export default function LlmConfigPanel() {
   const queryClient = useQueryClient();
+  const appOrigin = typeof window !== "undefined" ? window.location.origin : "";
 
   // Cloud state
   const [adding, setAdding] = useState(false);
@@ -191,7 +192,9 @@ export default function LlmConfigPanel() {
   const handleTestConnection = async () => {
     if (!localBaseUrl.trim()) return;
     if (!isAllowedLocalUrl(localBaseUrl)) {
-      toast.error("Base URL must point to localhost or a .local host.");
+      toast.error(
+        "Base URL must point to localhost, .local, or a private network address (10.x, 172.16-31.x, 192.168.x)"
+      );
       return;
     }
     setTestState("testing");
@@ -385,8 +388,9 @@ export default function LlmConfigPanel() {
           </Badge>
         </div>
         <p className="text-xs text-muted-foreground">
-          Use Ollama, LM Studio, llama.cpp, or any OpenAI-compatible server
-          running on your machine. Questions are generated in the browser.
+          Use any self-hosted LLM: Ollama, LM Studio, llama.cpp, vLLM, Jan, or
+          any OpenAI/Anthropic-compatible server. Questions are generated in the
+          browser.
         </p>
 
         {savedLocalConfig && (
@@ -522,26 +526,36 @@ export default function LlmConfigPanel() {
           <Card className="bg-muted/40 border-dashed">
             <CardContent className="pt-3 pb-3 space-y-3 text-xs text-muted-foreground">
               <p className="font-medium text-foreground">
-                Allow browser → local server requests:
+                Allow browser → self-hosted LLM requests:
+              </p>
+              <p className="text-muted-foreground italic">
+                Your app is running at: <code className="font-mono">{appOrigin}</code>
               </p>
               <div>
                 <p className="font-medium mb-1">Ollama:</p>
                 <code className="block bg-background rounded p-2 font-mono whitespace-pre-wrap">
-                  {`OLLAMA_ORIGINS=https://your-app-domain.com ollama serve`}
+                  {`OLLAMA_ORIGINS=${appOrigin} ollama serve`}
                 </code>
               </div>
               <div>
                 <p className="font-medium mb-1">LM Studio:</p>
                 <p>
-                  Settings → Local Server → CORS → enable and add this page's
-                  origin.
+                  Settings → Local Server → CORS → enable and add origin:{" "}
+                  <code className="font-mono">{appOrigin}</code>
                 </p>
               </div>
               <div>
                 <p className="font-medium mb-1">llama.cpp server:</p>
-                <code className="block bg-background rounded p-2 font-mono">
-                  {`./server --cors-allowed-origins "https://your-app-domain.com"`}
+                <code className="block bg-background rounded p-2 font-mono whitespace-pre-wrap">
+                  {`./server --cors-allowed-origins "${appOrigin}"`}
                 </code>
+              </div>
+              <div>
+                <p className="font-medium mb-1">Other self-hosted LLMs:</p>
+                <p>
+                  Refer to your server's documentation to enable CORS and add the
+                  following origin: <code className="font-mono">{appOrigin}</code>
+                </p>
               </div>
             </CardContent>
           </Card>

--- a/src/components/ai-questions/LlmConfigPanel.tsx
+++ b/src/components/ai-questions/LlmConfigPanel.tsx
@@ -35,7 +35,8 @@ import { toast } from "sonner";
 import {
   testConnection,
   localLlmConfigStorage,
-  isAllowedLocalUrl,
+  isValidLlmUrl,
+  isCloudProviderUrl,
 } from "@/services/local-llm";
 import type {
   ConnectionTestResult,
@@ -191,9 +192,14 @@ export default function LlmConfigPanel() {
 
   const handleTestConnection = async () => {
     if (!localBaseUrl.trim()) return;
-    if (!isAllowedLocalUrl(localBaseUrl)) {
-      toast.error(
-        "Base URL must point to localhost, .local, or a private network address (10.x, 172.16-31.x, 192.168.x)"
+    if (!isValidLlmUrl(localBaseUrl)) {
+      toast.error("Base URL must be a valid http:// or https:// URL.");
+      return;
+    }
+    if (isCloudProviderUrl(localBaseUrl)) {
+      toast.warning(
+        "This looks like an official cloud provider API. Use the Cloud Providers section above to add BYOK keys — this section is for custom / self-hosted endpoints.",
+        { duration: 6000 },
       );
       return;
     }
@@ -388,9 +394,10 @@ export default function LlmConfigPanel() {
           </Badge>
         </div>
         <p className="text-xs text-muted-foreground">
-          Use any self-hosted LLM: Ollama, LM Studio, llama.cpp, vLLM, Jan, or
-          any OpenAI/Anthropic-compatible server. Questions are generated in the
-          browser.
+          Connect to any GenAI-compatible endpoint: Ollama, LM Studio,
+          llama.cpp, vLLM, Jan, a private VPC endpoint, or any custom server
+          that implements the OpenAI or Anthropic protocol. Questions are
+          generated directly in the browser.
         </p>
 
         {savedLocalConfig && (
@@ -439,7 +446,12 @@ export default function LlmConfigPanel() {
             </div>
 
             <div className="space-y-1">
-              <label className="text-xs font-medium">Base URL</label>
+              <label className="text-xs font-medium">
+                Base URL
+                <span className="text-muted-foreground font-normal ml-1">
+                  (localhost, LAN, VPC, or any custom endpoint)
+                </span>
+              </label>
               <Input
                 placeholder={DIALECT_DEFAULTS[localDialect]}
                 value={localBaseUrl}
@@ -526,35 +538,45 @@ export default function LlmConfigPanel() {
           <Card className="bg-muted/40 border-dashed">
             <CardContent className="pt-3 pb-3 space-y-3 text-xs text-muted-foreground">
               <p className="font-medium text-foreground">
-                Allow browser → self-hosted LLM requests:
+                Enable CORS on your GenAI server
               </p>
-              <p className="text-muted-foreground italic">
-                Your app is running at: <code className="font-mono">{appOrigin}</code>
+              <p>
+                Browsers block cross-origin requests unless the server explicitly
+                allows them. Add this app's origin to your server's CORS allowlist:
               </p>
+              <code className="block bg-background rounded p-2 font-mono">
+                {appOrigin}
+              </code>
               <div>
-                <p className="font-medium mb-1">Ollama:</p>
+                <p className="font-medium text-foreground mb-1">Ollama</p>
                 <code className="block bg-background rounded p-2 font-mono whitespace-pre-wrap">
                   {`OLLAMA_ORIGINS=${appOrigin} ollama serve`}
                 </code>
               </div>
               <div>
-                <p className="font-medium mb-1">LM Studio:</p>
-                <p>
-                  Settings → Local Server → CORS → enable and add origin:{" "}
-                  <code className="font-mono">{appOrigin}</code>
-                </p>
+                <p className="font-medium text-foreground mb-1">LM Studio</p>
+                <p>Settings → Local Server → CORS → enable and add the origin above.</p>
               </div>
               <div>
-                <p className="font-medium mb-1">llama.cpp server:</p>
+                <p className="font-medium text-foreground mb-1">llama.cpp server</p>
                 <code className="block bg-background rounded p-2 font-mono whitespace-pre-wrap">
                   {`./server --cors-allowed-origins "${appOrigin}"`}
                 </code>
               </div>
               <div>
-                <p className="font-medium mb-1">Other self-hosted LLMs:</p>
+                <p className="font-medium text-foreground mb-1">vLLM</p>
+                <code className="block bg-background rounded p-2 font-mono whitespace-pre-wrap">
+                  {`python -m vllm.entrypoints.openai.api_server \\\n  --allowed-origins '["${appOrigin}"]' ...`}
+                </code>
+              </div>
+              <div>
+                <p className="font-medium text-foreground mb-1">
+                  Custom / other servers
+                </p>
                 <p>
-                  Refer to your server's documentation to enable CORS and add the
-                  following origin: <code className="font-mono">{appOrigin}</code>
+                  Set the{" "}
+                  <code className="font-mono">Access-Control-Allow-Origin: {appOrigin}</code>{" "}
+                  response header, or consult your server's documentation.
                 </p>
               </div>
             </CardContent>

--- a/src/services/__tests__/local-llm.test.ts
+++ b/src/services/__tests__/local-llm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { isAllowedLocalUrl } from "@/services/local-llm/local-llm-client";
+import { isAllowedLocalUrl, isCloudProviderUrl } from "@/services/local-llm/local-llm-client";
 import { localLlmConfigStorage } from "@/services/local-llm/config-storage";
 import { LocalLlmConfig } from "@/services/local-llm/types";
 
@@ -23,9 +23,19 @@ describe("Local LLM Feature", () => {
       expect(isAllowedLocalUrl("http://lm-studio.local:8000")).toBe(true);
     });
 
-    it("should reject external URLs", () => {
-      expect(isAllowedLocalUrl("http://example.com:11434")).toBe(false);
-      expect(isAllowedLocalUrl("https://api.openai.com")).toBe(false);
+    it("should accept any valid http/https URL (external endpoints now supported)", () => {
+      // isAllowedLocalUrl is now an alias for isValidLlmUrl — accepts any http/https URL
+      // including VPC endpoints, custom domain servers, etc.
+      expect(isAllowedLocalUrl("http://example.com:11434")).toBe(true);
+      expect(isAllowedLocalUrl("https://llm.mycompany.com/v1")).toBe(true);
+    });
+
+    it("should warn about official cloud provider URLs via isCloudProviderUrl", () => {
+      expect(isCloudProviderUrl("https://api.openai.com")).toBe(true);
+      expect(isCloudProviderUrl("https://api.anthropic.com")).toBe(true);
+      // Custom / self-hosted endpoints are not flagged
+      expect(isCloudProviderUrl("http://example.com:11434")).toBe(false);
+      expect(isCloudProviderUrl("http://localhost:11434")).toBe(false);
     });
 
     it("should handle invalid URLs gracefully", () => {

--- a/src/services/local-llm/index.ts
+++ b/src/services/local-llm/index.ts
@@ -11,6 +11,8 @@ export {
   testConnection,
   listModels,
   generateLocalQuestions,
+  isValidLlmUrl,
+  isCloudProviderUrl,
   isAllowedLocalUrl,
 } from "./local-llm-client";
 export type { GenerateLocalResult } from "./local-llm-client";

--- a/src/services/local-llm/local-llm-client.test.ts
+++ b/src/services/local-llm/local-llm-client.test.ts
@@ -1,81 +1,69 @@
 import { describe, it, expect } from "vitest";
-import { isAllowedLocalUrl } from "./local-llm-client";
+import { isValidLlmUrl, isCloudProviderUrl } from "./local-llm-client";
 
-describe("isAllowedLocalUrl", () => {
-  // Localhost variants
+describe("isValidLlmUrl", () => {
   it("allows localhost", () => {
-    expect(isAllowedLocalUrl("http://localhost:11434")).toBe(true);
-    expect(isAllowedLocalUrl("http://localhost:1234/v1")).toBe(true);
+    expect(isValidLlmUrl("http://localhost:11434")).toBe(true);
+    expect(isValidLlmUrl("http://localhost:1234/v1")).toBe(true);
+    expect(isValidLlmUrl("https://localhost:8443")).toBe(true);
   });
 
-  it("allows 127.0.0.1", () => {
-    expect(isAllowedLocalUrl("http://127.0.0.1:11434")).toBe(true);
-    expect(isAllowedLocalUrl("http://127.255.255.255")).toBe(true);
+  it("allows private network IPs (RFC 1918)", () => {
+    expect(isValidLlmUrl("http://192.168.1.100:8080")).toBe(true);
+    expect(isValidLlmUrl("http://10.0.0.5:11434")).toBe(true);
+    expect(isValidLlmUrl("http://172.16.0.1:3000")).toBe(true);
   });
 
-  it("allows ::1 IPv6 loopback", () => {
-    expect(isAllowedLocalUrl("http://[::1]:8080")).toBe(true);
-    // Note: IPv6 without brackets is invalid URL syntax; URL constructor requires [::1]
+  it("allows .local mDNS domains", () => {
+    expect(isValidLlmUrl("http://gpu-box.local:8080")).toBe(true);
+    expect(isValidLlmUrl("http://myserver.local/v1")).toBe(true);
   });
 
-  // .local domains (mDNS)
-  it("allows .local domains", () => {
-    expect(isAllowedLocalUrl("http://gpu-box.local:8080")).toBe(true);
-    expect(isAllowedLocalUrl("http://myserver.local")).toBe(true);
-    expect(isAllowedLocalUrl("http://deep.nested.local")).toBe(true);
+  it("allows any public domain (VPC endpoint, custom server, etc.)", () => {
+    expect(isValidLlmUrl("https://llm.mycompany.com/v1")).toBe(true);
+    expect(isValidLlmUrl("https://inference.example.org:8080")).toBe(true);
+    expect(isValidLlmUrl("http://203.0.113.42:8080")).toBe(true);
   });
 
-  // RFC 1918 private ranges
-  it("allows RFC 1918 range 10.0.0.0 – 10.255.255.255", () => {
-    expect(isAllowedLocalUrl("http://10.0.0.1")).toBe(true);
-    expect(isAllowedLocalUrl("http://10.255.255.255")).toBe(true);
-    expect(isAllowedLocalUrl("http://10.1.2.3:3000")).toBe(true);
+  it("allows https scheme", () => {
+    expect(isValidLlmUrl("https://ollama.internal/v1")).toBe(true);
   });
 
-  it("allows RFC 1918 range 172.16.0.0 – 172.31.255.255", () => {
-    expect(isAllowedLocalUrl("http://172.16.0.1")).toBe(true);
-    expect(isAllowedLocalUrl("http://172.31.255.255")).toBe(true);
-    expect(isAllowedLocalUrl("http://172.20.1.5")).toBe(true);
+  it("rejects non-http schemes", () => {
+    expect(isValidLlmUrl("ftp://example.com")).toBe(false);
+    expect(isValidLlmUrl("ws://example.com")).toBe(false);
   });
 
-  it("allows RFC 1918 range 192.168.0.0 – 192.168.255.255", () => {
-    expect(isAllowedLocalUrl("http://192.168.1.1")).toBe(true);
-    expect(isAllowedLocalUrl("http://192.168.255.255")).toBe(true);
-    expect(isAllowedLocalUrl("http://192.168.0.100:5000")).toBe(true);
+  it("rejects invalid / empty URLs", () => {
+    expect(isValidLlmUrl("not a url")).toBe(false);
+    expect(isValidLlmUrl("")).toBe(false);
+    expect(isValidLlmUrl("just-text")).toBe(false);
+    expect(isValidLlmUrl("localhost:11434")).toBe(false); // missing scheme
+  });
+});
+
+describe("isCloudProviderUrl", () => {
+  it("detects known cloud API endpoints", () => {
+    expect(isCloudProviderUrl("https://api.openai.com/v1")).toBe(true);
+    expect(isCloudProviderUrl("https://api.anthropic.com/v1")).toBe(true);
+    expect(isCloudProviderUrl("https://generativelanguage.googleapis.com")).toBe(true);
+    expect(isCloudProviderUrl("https://api.cohere.com")).toBe(true);
+    expect(isCloudProviderUrl("https://api.mistral.ai/v1")).toBe(true);
   });
 
-  it("rejects 172.15.x.x (outside the 172.16-31 range)", () => {
-    expect(isAllowedLocalUrl("http://172.15.0.1")).toBe(false);
-    expect(isAllowedLocalUrl("http://172.32.0.1")).toBe(false);
+  it("does not flag custom / self-hosted endpoints", () => {
+    expect(isCloudProviderUrl("http://localhost:11434")).toBe(false);
+    expect(isCloudProviderUrl("http://192.168.1.1:8080")).toBe(false);
+    expect(isCloudProviderUrl("https://llm.mycompany.com/v1")).toBe(false);
+    expect(isCloudProviderUrl("https://gpu-box.local:8080")).toBe(false);
   });
 
-  // Link-local IPv6 and Unique Local IPv6
-  it("allows link-local IPv6 (fe80::)", () => {
-    expect(isAllowedLocalUrl("http://[fe80::1]")).toBe(true);
-    expect(isAllowedLocalUrl("http://[fe80::1234:5678]")).toBe(true);
+  it("does not flag OpenAI-compatible servers that are not official", () => {
+    expect(isCloudProviderUrl("https://openai-proxy.mycompany.com/v1")).toBe(false);
   });
 
-  it("allows Unique Local IPv6 (fc00::)", () => {
-    expect(isAllowedLocalUrl("http://[fc00::1]")).toBe(true);
-    expect(isAllowedLocalUrl("http://[fc00::1234:5678]")).toBe(true);
-  });
-
-  // Public/external addresses (should reject)
-  it("rejects public internet addresses", () => {
-    expect(isAllowedLocalUrl("http://google.com")).toBe(false);
-    expect(isAllowedLocalUrl("http://8.8.8.8")).toBe(false);
-    expect(isAllowedLocalUrl("http://1.1.1.1:443")).toBe(false);
-  });
-
-  it("rejects 172.15.x.x and 192.167.x.x (edge cases)", () => {
-    expect(isAllowedLocalUrl("http://172.15.255.255")).toBe(false);
-    expect(isAllowedLocalUrl("http://192.167.255.255")).toBe(false);
-  });
-
-  // Invalid URLs
   it("returns false for invalid URLs", () => {
-    expect(isAllowedLocalUrl("not a url")).toBe(false);
-    expect(isAllowedLocalUrl("")).toBe(false);
-    expect(isAllowedLocalUrl("just-text")).toBe(false);
+    expect(isCloudProviderUrl("not a url")).toBe(false);
+    expect(isCloudProviderUrl("")).toBe(false);
   });
 });

--- a/src/services/local-llm/local-llm-client.test.ts
+++ b/src/services/local-llm/local-llm-client.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { isAllowedLocalUrl } from "./local-llm-client";
+
+describe("isAllowedLocalUrl", () => {
+  // Localhost variants
+  it("allows localhost", () => {
+    expect(isAllowedLocalUrl("http://localhost:11434")).toBe(true);
+    expect(isAllowedLocalUrl("http://localhost:1234/v1")).toBe(true);
+  });
+
+  it("allows 127.0.0.1", () => {
+    expect(isAllowedLocalUrl("http://127.0.0.1:11434")).toBe(true);
+    expect(isAllowedLocalUrl("http://127.255.255.255")).toBe(true);
+  });
+
+  it("allows ::1 IPv6 loopback", () => {
+    expect(isAllowedLocalUrl("http://[::1]:8080")).toBe(true);
+    // Note: IPv6 without brackets is invalid URL syntax; URL constructor requires [::1]
+  });
+
+  // .local domains (mDNS)
+  it("allows .local domains", () => {
+    expect(isAllowedLocalUrl("http://gpu-box.local:8080")).toBe(true);
+    expect(isAllowedLocalUrl("http://myserver.local")).toBe(true);
+    expect(isAllowedLocalUrl("http://deep.nested.local")).toBe(true);
+  });
+
+  // RFC 1918 private ranges
+  it("allows RFC 1918 range 10.0.0.0 – 10.255.255.255", () => {
+    expect(isAllowedLocalUrl("http://10.0.0.1")).toBe(true);
+    expect(isAllowedLocalUrl("http://10.255.255.255")).toBe(true);
+    expect(isAllowedLocalUrl("http://10.1.2.3:3000")).toBe(true);
+  });
+
+  it("allows RFC 1918 range 172.16.0.0 – 172.31.255.255", () => {
+    expect(isAllowedLocalUrl("http://172.16.0.1")).toBe(true);
+    expect(isAllowedLocalUrl("http://172.31.255.255")).toBe(true);
+    expect(isAllowedLocalUrl("http://172.20.1.5")).toBe(true);
+  });
+
+  it("allows RFC 1918 range 192.168.0.0 – 192.168.255.255", () => {
+    expect(isAllowedLocalUrl("http://192.168.1.1")).toBe(true);
+    expect(isAllowedLocalUrl("http://192.168.255.255")).toBe(true);
+    expect(isAllowedLocalUrl("http://192.168.0.100:5000")).toBe(true);
+  });
+
+  it("rejects 172.15.x.x (outside the 172.16-31 range)", () => {
+    expect(isAllowedLocalUrl("http://172.15.0.1")).toBe(false);
+    expect(isAllowedLocalUrl("http://172.32.0.1")).toBe(false);
+  });
+
+  // Link-local IPv6 and Unique Local IPv6
+  it("allows link-local IPv6 (fe80::)", () => {
+    expect(isAllowedLocalUrl("http://[fe80::1]")).toBe(true);
+    expect(isAllowedLocalUrl("http://[fe80::1234:5678]")).toBe(true);
+  });
+
+  it("allows Unique Local IPv6 (fc00::)", () => {
+    expect(isAllowedLocalUrl("http://[fc00::1]")).toBe(true);
+    expect(isAllowedLocalUrl("http://[fc00::1234:5678]")).toBe(true);
+  });
+
+  // Public/external addresses (should reject)
+  it("rejects public internet addresses", () => {
+    expect(isAllowedLocalUrl("http://google.com")).toBe(false);
+    expect(isAllowedLocalUrl("http://8.8.8.8")).toBe(false);
+    expect(isAllowedLocalUrl("http://1.1.1.1:443")).toBe(false);
+  });
+
+  it("rejects 172.15.x.x and 192.167.x.x (edge cases)", () => {
+    expect(isAllowedLocalUrl("http://172.15.255.255")).toBe(false);
+    expect(isAllowedLocalUrl("http://192.167.255.255")).toBe(false);
+  });
+
+  // Invalid URLs
+  it("returns false for invalid URLs", () => {
+    expect(isAllowedLocalUrl("not a url")).toBe(false);
+    expect(isAllowedLocalUrl("")).toBe(false);
+    expect(isAllowedLocalUrl("just-text")).toBe(false);
+  });
+});

--- a/src/services/local-llm/local-llm-client.ts
+++ b/src/services/local-llm/local-llm-client.ts
@@ -13,65 +13,54 @@ import type {
   LocalModelInfo,
 } from "./types";
 
-// ─── URL safety ──────────────────────────────────────────────────────────────
+// ─── URL validation ───────────────────────────────────────────────────────────
+
+/** Known official cloud API hostnames — warn user if they type these here. */
+const CLOUD_API_HOSTNAMES = [
+  "api.openai.com",
+  "api.anthropic.com",
+  "generativelanguage.googleapis.com",
+  "api.cohere.com",
+  "api.mistral.ai",
+];
 
 /**
- * Validate that a URL points to a safe local/private address:
- * - localhost / 127.x / ::1
- * - .local domain (mDNS)
- * - Private RFC 1918 ranges: 10.x, 172.16-31.x, 192.168.x
- * - Link-local IPv6: fe80::/10
- *
- * This allows self-hosted LLMs on any part of the local network,
- * not just the same machine.
+ * Return true if the URL looks like an official cloud provider endpoint.
+ * Used to surface a warning so the user doesn't confuse this section with
+ * the Cloud Providers (BYOK) section.
  */
-export function isAllowedLocalUrl(rawUrl: string): boolean {
+export function isCloudProviderUrl(rawUrl: string): boolean {
   try {
     const { hostname } = new URL(rawUrl);
-
-    // Localhost variants
-    if (hostname === "localhost" || hostname === "::1" || hostname === "[::1]") {
-      return true;
-    }
-
-    // .local mDNS domain
-    if (hostname.endsWith(".local")) {
-      return true;
-    }
-
-    // IPv4: check for private ranges (RFC 1918) and loopback
-    const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-    if (ipv4Match) {
-      const [, a, b] = ipv4Match;
-      const firstOctet = parseInt(a, 10);
-      const secondOctet = parseInt(b, 10);
-
-      // 127.0.0.0 – 127.255.255.255 (loopback)
-      if (firstOctet === 127) return true;
-      // 10.0.0.0 – 10.255.255.255
-      if (firstOctet === 10) return true;
-      // 172.16.0.0 – 172.31.255.255
-      if (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31) return true;
-      // 192.168.0.0 – 192.168.255.255
-      if (firstOctet === 192 && secondOctet === 168) return true;
-      return false;
-    }
-
-    // IPv6: check for link-local (fe80::/10), unique-local (fc00::/7), and loopback
-    // URL parser keeps brackets, so patterns like "[fe80::1]" or "[::1]"
-    if (
-      hostname.match(/^\[?fe80:/i) ||
-      hostname.match(/^\[?fc00:/i) ||
-      hostname.match(/^\[?fd00:/i)
-    ) {
-      return true;
-    }
-
-    return false;
+    return CLOUD_API_HOSTNAMES.some(
+      (h) => hostname === h || hostname.endsWith("." + h),
+    );
   } catch {
     return false;
   }
 }
+
+/**
+ * Validate that a URL is usable as a GenAI endpoint:
+ * - Must be a parseable URL with http:// or https:// scheme
+ * - Any host is allowed: localhost, LAN IP, .local, VPC hostname, public domain
+ *
+ * No host restriction is enforced — in-browser fetch is already subject to
+ * the browser's CORS policy. If the target server doesn't include the correct
+ * Access-Control-Allow-Origin header, the browser will block the response
+ * before any data is exposed.
+ */
+export function isValidLlmUrl(rawUrl: string): boolean {
+  try {
+    const { protocol } = new URL(rawUrl);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** @deprecated Use isValidLlmUrl — kept for backwards compatibility with imports. */
+export const isAllowedLocalUrl = isValidLlmUrl;
 
 // ─── Auth headers per dialect ─────────────────────────────────────────────────
 
@@ -164,11 +153,11 @@ async function testOllamaFallback(
 export async function testConnection(
   config: Omit<LocalLlmConfig, "modelId">,
 ): Promise<ConnectionTestResult> {
-  if (!isAllowedLocalUrl(config.baseUrl)) {
+  if (!isValidLlmUrl(config.baseUrl)) {
     return {
       ok: false,
       reason: "unreachable",
-      hint: "Base URL must point to localhost or a .local host.",
+      hint: "Base URL must be a valid http:// or https:// URL.",
     };
   }
 

--- a/src/services/local-llm/local-llm-client.ts
+++ b/src/services/local-llm/local-llm-client.ts
@@ -361,7 +361,7 @@ function mapRawToPreview(
     explanation: raw.explanation ?? "",
     choices,
     tags: [],
-    sourcePassage: raw.source_passage,
+    sourcePassage: raw.source_passage ?? undefined,
     qualityScore: score,
     qualityTier: scoreToTier(score),
   };

--- a/src/services/local-llm/local-llm-client.ts
+++ b/src/services/local-llm/local-llm-client.ts
@@ -15,16 +15,59 @@ import type {
 
 // ─── URL safety ──────────────────────────────────────────────────────────────
 
+/**
+ * Validate that a URL points to a safe local/private address:
+ * - localhost / 127.x / ::1
+ * - .local domain (mDNS)
+ * - Private RFC 1918 ranges: 10.x, 172.16-31.x, 192.168.x
+ * - Link-local IPv6: fe80::/10
+ *
+ * This allows self-hosted LLMs on any part of the local network,
+ * not just the same machine.
+ */
 export function isAllowedLocalUrl(rawUrl: string): boolean {
   try {
     const { hostname } = new URL(rawUrl);
-    return (
-      hostname === "localhost" ||
-      hostname === "127.0.0.1" ||
-      hostname === "::1" ||
-      hostname === "[::1]" ||
-      hostname.endsWith(".local")
-    );
+
+    // Localhost variants
+    if (hostname === "localhost" || hostname === "::1" || hostname === "[::1]") {
+      return true;
+    }
+
+    // .local mDNS domain
+    if (hostname.endsWith(".local")) {
+      return true;
+    }
+
+    // IPv4: check for private ranges (RFC 1918) and loopback
+    const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (ipv4Match) {
+      const [, a, b] = ipv4Match;
+      const firstOctet = parseInt(a, 10);
+      const secondOctet = parseInt(b, 10);
+
+      // 127.0.0.0 – 127.255.255.255 (loopback)
+      if (firstOctet === 127) return true;
+      // 10.0.0.0 – 10.255.255.255
+      if (firstOctet === 10) return true;
+      // 172.16.0.0 – 172.31.255.255
+      if (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31) return true;
+      // 192.168.0.0 – 192.168.255.255
+      if (firstOctet === 192 && secondOctet === 168) return true;
+      return false;
+    }
+
+    // IPv6: check for link-local (fe80::/10), unique-local (fc00::/7), and loopback
+    // URL parser keeps brackets, so patterns like "[fe80::1]" or "[::1]"
+    if (
+      hostname.match(/^\[?fe80:/i) ||
+      hostname.match(/^\[?fc00:/i) ||
+      hostname.match(/^\[?fd00:/i)
+    ) {
+      return true;
+    }
+
+    return false;
   } catch {
     return false;
   }

--- a/src/services/local-llm/schema.ts
+++ b/src/services/local-llm/schema.ts
@@ -7,7 +7,7 @@ export const RawQuestionSchema = z.object({
   options: z.array(z.string().min(1)).min(2).max(8),
   correct_answer: z.string().min(1),
   explanation: z.string().optional().default(""),
-  source_passage: z.string().optional(),
+  source_passage: z.string().nullish(), // local models often return null instead of omitting the field
   confidence_hint: z
     .enum(["high", "medium", "low"])
     .optional()


### PR DESCRIPTION
## Summary

- **Dynamic CORS setup guide**: thay hardcoded `your-app-domain.com` bằng `window.location.origin` thực tế của app, bao gồm hướng dẫn cho Ollama, LM Studio, llama.cpp, vLLM, và custom servers
- **Mở rộng URL whitelist → cho phép bất kỳ URL hợp lệ**: từ localhost/LAN-only sang bất kỳ `http://` hoặc `https://` endpoint (VPC, public domain, custom server). Browser CORS policy là guardrail thực sự thay vì application-level IP whitelist
- **Cloud provider soft-warning**: phát hiện nếu user nhập `api.openai.com`, `api.anthropic.com`, v.v. và cảnh báo dùng section Cloud Providers (BYOK) thay thế
- **Đổi tên hàm**: `isAllowedLocalUrl` → `isValidLlmUrl` (giữ alias backwards-compatible); thêm `isCloudProviderUrl`
- **Cập nhật UI description**: phản ánh rõ hỗ trợ mọi loại GenAI-compatible endpoint

## Test plan

- [ ] Mở CORS setup guide → xác nhận hiển thị đúng domain của app (không còn `your-app-domain.com`)
- [ ] Nhập URL localhost → Test Connection hoạt động bình thường
- [ ] Nhập URL private IP (e.g. `http://192.168.1.100:11434`) → Test Connection không bị block
- [ ] Nhập `https://api.openai.com/v1` → toast warning xuất hiện, không proceed test
- [ ] Nhập URL không hợp lệ (thiếu scheme, e.g. `localhost:11434`) → toast error
- [ ] Chạy unit tests: `npm run test -- --run src/services/local-llm/local-llm-client.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)