### PR TITLE
feat: Smart Exam Builder — blueprint mode (P1)

### DIFF
--- a/backend/src/exams/dto/blueprint.dto.ts
+++ b/backend/src/exams/dto/blueprint.dto.ts
@@ -1,0 +1,40 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsOptional,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class BlueprintDifficultyDto {
+  @ApiPropertyOptional({ example: 15, description: 'Number of EASY questions' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  EASY?: number;
+
+  @ApiPropertyOptional({ example: 25, description: 'Number of MEDIUM questions' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  MEDIUM?: number;
+
+  @ApiPropertyOptional({ example: 10, description: 'Number of HARD questions' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  HARD?: number;
+}
+
+export class BlueprintDto {
+  @ApiPropertyOptional({
+    type: () => BlueprintDifficultyDto,
+    description:
+      'Quota per difficulty level. Numbers are absolute question counts (not %).',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BlueprintDifficultyDto)
+  byDifficulty?: BlueprintDifficultyDto;
+}

--- a/backend/src/exams/dto/create-exam.dto.ts
+++ b/backend/src/exams/dto/create-exam.dto.ts
@@ -9,8 +9,11 @@ import {
   Min,
   IsUUID,
   MaxLength,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ExamVisibility, TimerMode, ExamType } from '@prisma/client';
+import { BlueprintDto } from './blueprint.dto';
 
 export class CreateExamDto {
   @ApiProperty({ example: 'AWS SAA Mock Test #1' })
@@ -73,4 +76,23 @@ export class CreateExamDto {
   @IsUUID('4', { each: true })
   @IsOptional()
   questionIds?: string[];
+
+  @ApiPropertyOptional({
+    enum: ['MANUAL', 'RANDOM', 'BLUEPRINT'],
+    description:
+      'How questions are selected. MANUAL=questionIds list, RANDOM=random pick, BLUEPRINT=quota-based.',
+  })
+  @IsEnum(['MANUAL', 'RANDOM', 'BLUEPRINT'])
+  @IsOptional()
+  selectionStrategy?: 'MANUAL' | 'RANDOM' | 'BLUEPRINT';
+
+  @ApiPropertyOptional({
+    type: () => BlueprintDto,
+    description:
+      'Blueprint quotas used when selectionStrategy=BLUEPRINT. Only byDifficulty is supported in P1.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BlueprintDto)
+  blueprint?: BlueprintDto;
 }

--- a/backend/src/exams/dto/update-exam.dto.ts
+++ b/backend/src/exams/dto/update-exam.dto.ts
@@ -8,8 +8,11 @@ import {
   IsArray,
   ArrayNotEmpty,
   ArrayUnique,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ExamVisibility, TimerMode } from '@prisma/client';
+import { BlueprintDto } from './blueprint.dto';
 
 export class UpdateExamDto {
   @ApiPropertyOptional({ example: 'AWS SAA Mock Test #1 (Updated)' })
@@ -50,4 +53,21 @@ export class UpdateExamDto {
   @IsString({ each: true })
   @IsOptional()
   questionIds?: string[];
+
+  @ApiPropertyOptional({
+    enum: ['MANUAL', 'RANDOM', 'BLUEPRINT'],
+    description: 'How questions are selected when updating the question set.',
+  })
+  @IsEnum(['MANUAL', 'RANDOM', 'BLUEPRINT'])
+  @IsOptional()
+  selectionStrategy?: 'MANUAL' | 'RANDOM' | 'BLUEPRINT';
+
+  @ApiPropertyOptional({
+    type: () => BlueprintDto,
+    description: 'Blueprint quotas used when selectionStrategy=BLUEPRINT.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BlueprintDto)
+  blueprint?: BlueprintDto;
 }

--- a/backend/src/exams/exams.service.ts
+++ b/backend/src/exams/exams.service.ts
@@ -25,7 +25,41 @@ export class ExamsService {
     certificationId: string,
     blueprint: BlueprintDto,
   ): Promise<string[]> {
-    const pickedIds: string[] = [];
+    // byDifficulty: each question has exactly one difficulty value, so buckets
+    // are mutually exclusive — no cross-bucket duplicates are possible.
+    // All bucket queries can therefore run in parallel.
+    if (!blueprint.byDifficulty) {
+      throw new BadRequestException(
+        'Blueprint không có bucket nào hợp lệ (tất cả count = 0)',
+      );
+    }
+
+    const entries = (
+      Object.entries(blueprint.byDifficulty) as [Difficulty, number | undefined][]
+    ).filter(([, count]) => count && count > 0);
+
+    if (entries.length === 0) {
+      throw new BadRequestException(
+        'Blueprint không có bucket nào hợp lệ (tất cả count = 0)',
+      );
+    }
+
+    // Fetch all buckets in parallel — safe because difficulty is mutually exclusive.
+    const bucketResults = await Promise.all(
+      entries.map(async ([difficulty, count]) => {
+        const candidates = await this.prisma.question.findMany({
+          where: {
+            certificationId,
+            status: QuestionStatus.APPROVED,
+            deletedAt: null,
+            difficulty,
+          },
+          select: { id: true },
+        });
+        return { difficulty, count: count!, candidates };
+      }),
+    );
+
     const shortages: {
       bucket: string;
       required: number;
@@ -33,42 +67,23 @@ export class ExamsService {
       missing: number;
     }[] = [];
 
-    if (blueprint.byDifficulty) {
-      const entries = Object.entries(blueprint.byDifficulty) as [
-        Difficulty,
-        number | undefined,
-      ][];
+    const pickedIds: string[] = [];
 
-      for (const [difficulty, count] of entries) {
-        if (!count || count <= 0) continue;
-
-        // Exclude already-picked IDs to avoid cross-bucket duplicates.
-        const candidates = await this.prisma.question.findMany({
-          where: {
-            certificationId,
-            status: QuestionStatus.APPROVED,
-            deletedAt: null,
-            difficulty,
-            id: pickedIds.length > 0 ? { notIn: pickedIds } : undefined,
-          },
-          select: { id: true },
+    for (const { difficulty, count, candidates } of bucketResults) {
+      if (candidates.length < count) {
+        shortages.push({
+          bucket: difficulty,
+          required: count,
+          available: candidates.length,
+          missing: count - candidates.length,
         });
-
-        if (candidates.length < count) {
-          shortages.push({
-            bucket: difficulty,
-            required: count,
-            available: candidates.length,
-            missing: count - candidates.length,
-          });
-        } else {
-          // Fisher-Yates shuffle then slice.
-          for (let i = candidates.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
-          }
-          pickedIds.push(...candidates.slice(0, count).map((q) => q.id));
+      } else {
+        // Fisher-Yates shuffle then slice.
+        for (let i = candidates.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
         }
+        pickedIds.push(...candidates.slice(0, count).map((q) => q.id));
       }
     }
 
@@ -81,13 +96,7 @@ export class ExamsService {
       });
     }
 
-    if (pickedIds.length === 0) {
-      throw new BadRequestException(
-        'Blueprint không có bucket nào hợp lệ (tất cả count = 0)',
-      );
-    }
-
-    // Final shuffle to mix buckets.
+    // Final shuffle to mix buckets together.
     for (let i = pickedIds.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [pickedIds[i], pickedIds[j]] = [pickedIds[j], pickedIds[i]];

--- a/backend/src/exams/exams.service.ts
+++ b/backend/src/exams/exams.service.ts
@@ -3,21 +3,113 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExamDto } from './dto/create-exam.dto';
 import { UpdateExamDto } from './dto/update-exam.dto';
-import { ExamVisibility, QuestionStatus, UserRole } from '@prisma/client';
+import { BlueprintDto } from './dto/blueprint.dto';
+import { ExamVisibility, QuestionStatus, UserRole, Difficulty } from '@prisma/client';
 import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class ExamsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(userId: string, dto: CreateExamDto) {
-    let questionIds = dto.questionIds;
+  /**
+   * Resolve a blueprint into a concrete list of question IDs.
+   * Throws UnprocessableEntityException (422) with `shortages` detail if any
+   * bucket cannot be filled from the approved question pool.
+   */
+  private async resolveBlueprint(
+    certificationId: string,
+    blueprint: BlueprintDto,
+  ): Promise<string[]> {
+    const pickedIds: string[] = [];
+    const shortages: {
+      bucket: string;
+      required: number;
+      available: number;
+      missing: number;
+    }[] = [];
 
-    if (!questionIds || questionIds.length === 0) {
+    if (blueprint.byDifficulty) {
+      const entries = Object.entries(blueprint.byDifficulty) as [
+        Difficulty,
+        number | undefined,
+      ][];
+
+      for (const [difficulty, count] of entries) {
+        if (!count || count <= 0) continue;
+
+        // Exclude already-picked IDs to avoid cross-bucket duplicates.
+        const candidates = await this.prisma.question.findMany({
+          where: {
+            certificationId,
+            status: QuestionStatus.APPROVED,
+            deletedAt: null,
+            difficulty,
+            id: pickedIds.length > 0 ? { notIn: pickedIds } : undefined,
+          },
+          select: { id: true },
+        });
+
+        if (candidates.length < count) {
+          shortages.push({
+            bucket: difficulty,
+            required: count,
+            available: candidates.length,
+            missing: count - candidates.length,
+          });
+        } else {
+          // Fisher-Yates shuffle then slice.
+          for (let i = candidates.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
+          }
+          pickedIds.push(...candidates.slice(0, count).map((q) => q.id));
+        }
+      }
+    }
+
+    if (shortages.length > 0) {
+      throw new UnprocessableEntityException({
+        error: 'BLUEPRINT_INSUFFICIENT_QUESTIONS',
+        message:
+          'Ngân hàng câu hỏi không đủ để tạo đề theo cấu trúc đã chọn',
+        shortages,
+      });
+    }
+
+    if (pickedIds.length === 0) {
+      throw new BadRequestException(
+        'Blueprint không có bucket nào hợp lệ (tất cả count = 0)',
+      );
+    }
+
+    // Final shuffle to mix buckets.
+    for (let i = pickedIds.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [pickedIds[i], pickedIds[j]] = [pickedIds[j], pickedIds[i]];
+    }
+
+    return pickedIds;
+  }
+
+  async create(userId: string, dto: CreateExamDto) {
+    let questionIds: string[];
+
+    if (dto.selectionStrategy === 'BLUEPRINT' && dto.blueprint) {
+      // Blueprint mode: resolve quota → concrete IDs.
+      questionIds = await this.resolveBlueprint(
+        dto.certificationId,
+        dto.blueprint,
+      );
+    } else if (dto.questionIds && dto.questionIds.length > 0) {
+      // Manual (pick) mode: use the provided list as-is.
+      questionIds = dto.questionIds;
+    } else {
+      // Random mode: shuffle all approved questions and slice.
       const questions = await this.prisma.question.findMany({
         where: {
           certificationId: dto.certificationId,
@@ -217,7 +309,14 @@ export class ExamsService {
     if (exam.createdBy !== userId)
       throw new ForbiddenException('You can only update your own exams');
 
-    const { questionIds, ...scalarData } = dto;
+    const { questionIds: rawQuestionIds, selectionStrategy, blueprint, ...scalarData } = dto;
+
+    let questionIds = rawQuestionIds;
+
+    // Blueprint mode on update: resolve quota into IDs for this exam's cert.
+    if (selectionStrategy === 'BLUEPRINT' && blueprint) {
+      questionIds = await this.resolveBlueprint(exam.certificationId, blueprint);
+    }
 
     // Metadata-only update: no question set change.
     if (!questionIds) {
@@ -230,14 +329,18 @@ export class ExamsService {
 
     // Every question must exist and belong to this exam's certification so the
     // exam cannot be stuffed with questions from an unrelated certification.
-    const validQuestions = await this.prisma.question.findMany({
-      where: { id: { in: questionIds }, certificationId: exam.certificationId },
-      select: { id: true },
-    });
-    if (validQuestions.length !== questionIds.length) {
-      throw new BadRequestException(
-        "One or more questions are invalid or do not belong to this exam's certification",
-      );
+    // (Blueprint-resolved IDs are already scoped to certificationId, but we
+    //  still validate MANUAL/PICK questionIds for safety.)
+    if (selectionStrategy !== 'BLUEPRINT') {
+      const validQuestions = await this.prisma.question.findMany({
+        where: { id: { in: questionIds }, certificationId: exam.certificationId },
+        select: { id: true },
+      });
+      if (validQuestions.length !== questionIds.length) {
+        throw new BadRequestException(
+          "One or more questions are invalid or do not belong to this exam's certification",
+        );
+      }
     }
 
     // Replace the full ordered question set and recompute questionCount.

--- a/backend/src/questions/questions.controller.ts
+++ b/backend/src/questions/questions.controller.ts
@@ -77,6 +77,21 @@ export class QuestionsController {
     );
   }
 
+  /**
+   * Must be declared before GET :id so the literal path "stats" is not
+   * mistakenly matched as a question ID.
+   */
+  @Get('stats')
+  @Public()
+  @ApiOperation({
+    summary:
+      'Get APPROVED question counts by difficulty and domain for a certification',
+  })
+  @ApiQuery({ name: 'certificationId', required: true, type: String })
+  getStats(@Query('certificationId') certificationId: string) {
+    return this.questionsService.getStats(certificationId);
+  }
+
   @Get(':id')
   @Public()
   @ApiOperation({ summary: 'Get a single question by ID' })

--- a/backend/src/questions/questions.controller.ts
+++ b/backend/src/questions/questions.controller.ts
@@ -11,6 +11,7 @@ import {
   Req,
   Request,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import {
   ApiTags,
   ApiOperation,
@@ -80,9 +81,13 @@ export class QuestionsController {
   /**
    * Must be declared before GET :id so the literal path "stats" is not
    * mistakenly matched as a question ID.
+   *
+   * Throttled at 30 req/min: called on every slider move in BlueprintEditor
+   * but results are cached client-side (staleTime 30 s), so 30 rpm is generous.
    */
   @Get('stats')
   @Public()
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({
     summary:
       'Get APPROVED question counts by difficulty and domain for a certification',

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -468,6 +468,61 @@ export class QuestionsService {
     this.recomputeDebounce.set(certId, timer);
   }
 
+  /**
+   * Return a statistical summary of the APPROVED question pool for a given
+   * certification. Used by the frontend BlueprintEditor to show real-time
+   * availability counts while the user sets quotas.
+   */
+  async getStats(certificationId: string) {
+    const where = {
+      certificationId,
+      status: QuestionStatus.APPROVED,
+      deletedAt: null,
+    };
+
+    const [total, byDifficultyRaw, byDomainRaw] = await Promise.all([
+      this.prisma.question.count({ where }),
+      this.prisma.question.groupBy({
+        by: ['difficulty'],
+        where,
+        _count: { id: true },
+      }),
+      this.prisma.question.groupBy({
+        by: ['domainId'],
+        where,
+        _count: { id: true },
+      }),
+    ]);
+
+    const byDifficulty: Record<string, number> = { EASY: 0, MEDIUM: 0, HARD: 0 };
+    for (const row of byDifficultyRaw) {
+      byDifficulty[row.difficulty] = row._count.id;
+    }
+
+    // Fetch domain names for non-null domainIds.
+    const domainIds = byDomainRaw
+      .map((r) => r.domainId)
+      .filter((id): id is string => !!id);
+
+    const domains =
+      domainIds.length > 0
+        ? await this.prisma.domain.findMany({
+            where: { id: { in: domainIds } },
+            select: { id: true, name: true },
+          })
+        : [];
+
+    const domainMap = new Map(domains.map((d) => [d.id, d.name]));
+
+    const byDomain = byDomainRaw.map((row) => ({
+      domainId: row.domainId,
+      name: row.domainId ? (domainMap.get(row.domainId) ?? 'Unknown') : null,
+      count: row._count.id,
+    }));
+
+    return { total, byDifficulty, byDomain };
+  }
+
   async adminDelete(questionId: string) {
     const question = await this.prisma.question.findUnique({
       where: { id: questionId },

--- a/docs/specs/smart-exam-builder-srs.md
+++ b/docs/specs/smart-exam-builder-srs.md
@@ -1,0 +1,222 @@
+# SRS — Smart Exam Builder (Tạo & sửa exam theo cấu trúc)
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | Smart Exam Builder — chế độ tạo đề "Theo cấu trúc" (Blueprint) |
+| **Phiên bản** | 0.1 (Draft — để review) |
+| **Ngày** | 2026-06-02 |
+| **Trạng thái** | Đề án, chưa triển khai code |
+| **Module liên quan** | `exams`, `questions` (backend) · `ExamBuilder.tsx` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+Tài liệu này đặc tả yêu cầu cho tính năng **Smart Exam Builder**, bổ sung chế độ tạo đề thi **theo cấu trúc (blueprint)** vào CertGym. Thay vì tick thủ công từng câu, người tạo đề chỉ khai báo **hạn ngạch (quota)** theo độ khó và/hoặc tỉ lệ phần trăm domain; hệ thống tự động bốc câu hỏi phù hợp từ ngân hàng câu hỏi đã duyệt.
+
+### 1.2. Phạm vi
+- **Trong phạm vi:** Chế độ tạo đề thứ 3 ("Theo cấu trúc"), API thống kê ngân hàng câu hỏi, logic bốc câu theo quota, cảnh báo/chặn khi thiếu câu, mở rộng luồng edit.
+- **Ngoài phạm vi:** Sinh câu hỏi mới bằng AI (đã có ở `AiQuestionGenerator.tsx`), kiểm duyệt câu hỏi, exam adaptive/scenario, đề của tổ chức (`/org`).
+
+### 1.3. Định nghĩa thuật ngữ
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **Blueprint** | Bảng khai báo cấu trúc đề: số câu theo từng độ khó / domain / ô matrix |
+| **Bucket (ô quota)** | Một nhóm tiêu chí cần bốc câu, vd "HARD × Security = 10 câu" |
+| **Quota** | Số câu mục tiêu của một bucket |
+| **Ngân hàng câu hỏi** | Tập câu hỏi `status = APPROVED` thuộc certification được chọn |
+| **Re-roll** | Bốc lại bộ câu mới giữ nguyên blueprint |
+| **Dry-run / Preview** | Bốc thử (không lưu) để xem trước bộ câu |
+
+### 1.4. Hiện trạng (baseline)
+Theo [ExamBuilder.tsx](../../src/pages/ExamBuilder.tsx) và [exams.service.ts](../../backend/src/exams/exams.service.ts):
+
+- Có 2 chế độ: **Random** (nhập 1 số, backend `shuffle().slice(count)` toàn bộ câu APPROVED) và **Pick** (tick checkbox từng câu, phân trang 20/lần).
+- Chế độ **Random** không kiểm soát được độ khó/domain → đề dễ bị lệch.
+- Chế độ **Pick** không khả thi với ngân hàng lớn (200–500 câu).
+- Luồng **edit** bị khoá cứng về mode "pick" → sửa đề lớn phải tick lại từ đầu.
+- Dữ liệu sẵn có nhưng chưa dùng: `Question.difficulty` (EASY/MEDIUM/HARD) và `Question.domainId` ([schema.prisma:344-349](../../backend/prisma/schema.prisma)).
+
+---
+
+## 2. Mô tả tổng quan
+
+### 2.1. Bối cảnh sản phẩm
+Smart Exam Builder là một chế độ bổ sung **không thay thế** Random/Pick. Người dùng chọn 1 trong 3 chế độ khi tạo đề. Tính năng tái sử dụng toàn bộ hạ tầng exam hiện có (model `Exam`, `ExamQuestion`, luồng làm bài).
+
+### 2.2. Các nhóm người dùng
+| Vai trò | Nhu cầu |
+|---|---|
+| **Người tạo đề (community)** | Tạo nhanh một đề cân bằng mà không tick từng câu |
+| **Power-user / instructor** | Mô phỏng đúng blueprint chính thức của hãng (AWS/Azure…) bằng tỉ lệ domain |
+| **Người sửa đề** | Điều chỉnh cấu trúc đề đã có (vd thêm câu khó) mà không dựng lại từ đầu |
+
+### 2.3. Giả định & ràng buộc
+- Câu hỏi phải có `status = APPROVED` mới được bốc.
+- `difficulty` luôn có giá trị (mặc định MEDIUM trong schema); `domainId` có thể NULL → cần xử lý nhóm "không có domain".
+- Giữ nguyên ràng buộc hiện tại: certification **không đổi được** sau khi tạo đề.
+- TypeScript loose (`strictNullChecks: false`) — tuân theo style sẵn có, không siết kiểu mới.
+
+### 2.4. Quyết định đã chốt
+1. **Đợt này chỉ làm tài liệu đề án/SRS, chưa code.**
+2. **Khi ngân hàng thiếu câu cho một bucket → CHẶN, không tạo đề**, báo lỗi rõ từng bucket thiếu. Không có chế độ "lấp tạm". Đề luôn đúng 100% blueprint hoặc không tạo.
+
+---
+
+## 3. Yêu cầu chức năng
+
+> Quy ước độ ưu tiên: **P1** = MVP (phải có) · **P2** = nên có · **P3** = nâng cao.
+
+### FR-1 — Chọn chế độ tạo đề `[P1]`
+- FR-1.1: Form tạo đề hiển thị 3 chế độ: **Random**, **Pick**, **Theo cấu trúc**.
+- FR-1.2: Mặc định giữ nguyên hành vi cũ; chọn "Theo cấu trúc" sẽ hiện trình soạn blueprint.
+- FR-1.3: Khi đổi certification, mọi quota/blueprint được reset.
+
+### FR-2 — Thống kê ngân hàng câu hỏi `[P1]`
+- FR-2.1: Hệ thống cung cấp số liệu phân bố câu APPROVED của certification: tổng, theo độ khó, theo domain, và (P3) theo ô matrix.
+- FR-2.2: UI dùng số liệu này để hiển thị "có sẵn bao nhiêu câu" cạnh mỗi bucket, **realtime** khi người dùng chỉnh quota.
+
+### FR-3 — Blueprint theo độ khó `[P1]`
+- FR-3.1: Người dùng nhập tổng số câu, rồi phân bổ theo EASY/MEDIUM/HARD bằng **%** hoặc **số câu tuyệt đối**.
+- FR-3.2: Khi nhập %, hệ thống tự quy đổi sang số câu (làm tròn), và **tự cân** để tổng các bucket khớp tổng số câu (chênh lệch do làm tròn dồn vào bucket lớn nhất).
+- FR-3.3: Tổng % phải bằng 100% (hoặc tổng số câu các bucket = tổng đề) thì mới cho lưu.
+
+### FR-4 — Blueprint theo tỉ lệ domain `[P2]`
+- FR-4.1: Liệt kê các domain của certification, mỗi domain một dòng quota (% hoặc số câu).
+- FR-4.2: Cùng cơ chế quy đổi/cân tổng như FR-3.
+- FR-4.3: Hỗ trợ nhóm "Không gán domain" nếu certification có câu `domainId = NULL`.
+
+### FR-5 — Blueprint matrix (domain × độ khó) `[P3]`
+- FR-5.1: Bảng 2 chiều domain × {EASY,MEDIUM,HARD}, mỗi ô một quota.
+- FR-5.2: Hiển thị tổng hàng/cột và tổng toàn bảng để người dùng đối chiếu.
+
+### FR-6 — Bốc câu theo blueprint `[P1]`
+- FR-6.1: Với mỗi bucket, hệ thống lấy ngẫu nhiên đủ số câu APPROVED khớp tiêu chí.
+- FR-6.2: **Không trùng** câu giữa các bucket.
+- FR-6.3: Thứ tự câu trong đề được trộn ngẫu nhiên (ghi vào `ExamQuestion.sortOrder`).
+- FR-6.4: Hành vi bốc câu dùng chung cho cả **tạo mới** và **sửa**.
+
+### FR-7 — Xử lý thiếu câu (CHẶN) `[P1]`
+- FR-7.1: Trước khi lưu, hệ thống kiểm tra mọi bucket có đủ câu không.
+- FR-7.2: Nếu bất kỳ bucket nào thiếu → **không tạo/không cập nhật đề**, trả lỗi `422` liệt kê từng bucket: `required`, `available`, `missing`.
+- FR-7.3: UI chặn ở client trước (disable nút lưu, đánh dấu đỏ dòng thiếu) dựa trên số liệu FR-2; backend vẫn validate lại lần cuối làm nguồn chân lý.
+
+### FR-8 — Xem trước (Preview / dry-run) `[P2]`
+- FR-8.1: Người dùng bấm "Xem trước" để bốc thử (không lưu) và xem danh sách câu sẽ vào đề, kèm nhãn độ khó/domain.
+- FR-8.2: Cho phép **đổi lẻ** một câu (swap) bằng câu khác cùng bucket trước khi lưu.
+- FR-8.3: Cho phép **re-roll** toàn bộ để bốc lại bộ câu mới cùng blueprint.
+
+### FR-9 — Lưu & re-roll blueprint `[P3]`
+- FR-9.1: Blueprint được lưu kèm `Exam` để về sau có thể edit lại cấu trúc hoặc re-roll.
+- FR-9.2: Chức năng "Nhân bản đề tương tự" tạo đề mới từ cùng blueprint với bộ câu mới.
+
+### FR-10 — Sửa đề (edit) `[P2]`
+- FR-10.1: Luồng edit cho phép cả 3 chế độ, không khoá cứng "pick".
+- FR-10.2: Nếu đề được tạo bằng blueprint (FR-9), edit hiển thị lại blueprint đã lưu để chỉnh.
+- FR-10.3: Lưu edit theo blueprint sẽ **thay toàn bộ** bộ câu (đồng nhất với hành vi update hiện tại) và cập nhật lại `questionCount`.
+
+---
+
+## 4. Yêu cầu phi chức năng
+
+| ID | Yêu cầu |
+|---|---|
+| NFR-1 (Hiệu năng) | API thống kê & bốc câu phản hồi < 500ms với ngân hàng ~1.000 câu. Truy vấn theo `certificationId`, `status`, `difficulty`, `domainId` cần có index phù hợp. |
+| NFR-2 (Tính nhất quán) | Backend là nguồn chân lý cuối cùng cho việc đủ/thiếu câu; tránh race khi câu đổi trạng thái giữa lúc người dùng đang soạn. |
+| NFR-3 (Khả dụng) | Slider/quota cập nhật realtime; cảnh báo thiếu câu hiển thị tức thì, không cần submit. |
+| NFR-4 (Tương thích) | Không phá vỡ Random/Pick hiện có; đề cũ vẫn chạy bình thường (blueprint là field tuỳ chọn). |
+| NFR-5 (A11y) | Trình soạn blueprint điều khiển được bằng bàn phím, có nhãn ARIA cho slider/ô nhập, tuân theo baseline tại `docs/a11y-baseline.md`. |
+| NFR-6 (i18n) | Chuỗi UI dùng cơ chế đa ngôn ngữ hiện hành của frontend. |
+
+---
+
+## 5. Thiết kế giao diện API (đề xuất)
+
+> Hợp đồng chi tiết sẽ được chốt ở bước thiết kế; phần này định hướng.
+
+### 5.1. `GET /questions/stats?certificationId=...` `[P1]`
+```jsonc
+{
+  "total": 320,
+  "byDifficulty": { "EASY": 90, "MEDIUM": 160, "HARD": 70 },
+  "byDomain": [
+    { "domainId": "d1", "name": "Design Secure Architectures", "count": 80 }
+  ],
+  "matrix": [                                  // P3
+    { "domainId": "d1", "difficulty": "HARD", "count": 12 }
+  ]
+}
+```
+
+### 5.2. Mở rộng `CreateExamDto` / `UpdateExamDto` `[P1+]`
+```ts
+selectionStrategy?: 'MANUAL' | 'RANDOM' | 'BLUEPRINT';
+
+blueprint?: {
+  byDifficulty?: { EASY?: number; MEDIUM?: number; HARD?: number };   // số câu
+  byDomain?: { domainId: string | null; count: number }[];           // P2
+  matrix?: { domainId: string | null; difficulty: Difficulty; count: number }[]; // P3
+};
+```
+- Hiện chỉ chấp nhận **một** trong `byDifficulty` / `byDomain` / `matrix` mỗi lần (không trộn) ở P1–P2; matrix là dạng tổng quát ở P3.
+
+### 5.3. `POST /exams/preview` (dry-run) `[P2]`
+- Nhận `certificationId` + `blueprint`, trả về danh sách câu được bốc **mà không lưu**, hoặc lỗi `422` nếu thiếu.
+
+### 5.4. Lỗi thiếu câu (chuẩn `[P1]`)
+```jsonc
+// 422 Unprocessable Entity
+{
+  "error": "BLUEPRINT_INSUFFICIENT_QUESTIONS",
+  "message": "Ngân hàng câu hỏi không đủ cho cấu trúc đã chọn",
+  "shortages": [
+    { "bucket": "HARD", "domainId": "d1", "required": 10, "available": 6, "missing": 4 }
+  ]
+}
+```
+
+---
+
+## 6. Ảnh hưởng dữ liệu
+
+- **P1–P2:** Không bắt buộc đổi schema — blueprint truyền qua DTO và chỉ dùng để bốc câu lúc tạo. Tận dụng `Question.difficulty`, `Question.domainId` sẵn có.
+- **P3:** Thêm cột JSON tuỳ chọn `blueprint` vào model `Exam` (1 migration nhỏ) để hỗ trợ lưu/re-roll/nhân bản. Cần migration + cập nhật `02-data_model.md`.
+- Rà soát index trên `Question(certificationId, status, difficulty, domainId)` phục vụ NFR-1.
+
+---
+
+## 7. Kế hoạch triển khai theo giai đoạn
+
+| Phase | Nội dung | FR bao phủ |
+|---|---|---|
+| **P1 (MVP)** | `GET /questions/stats` + Blueprint theo độ khó + bốc câu + chặn-báo-lỗi thiếu câu | FR-1, FR-2, FR-3, FR-6, FR-7 |
+| **P2** | Blueprint theo % domain + Preview/dry-run + swap lẻ + mở luồng edit | FR-4, FR-8, FR-10 |
+| **P3** | Matrix domain×difficulty + lưu blueprint + re-roll + nhân bản đề | FR-5, FR-9 |
+
+---
+
+## 8. Tiêu chí chấp nhận (Acceptance Criteria — P1)
+
+- **AC-1:** Tạo đề 50 câu với blueprint 30% EASY / 50% MEDIUM / 20% HARD → đề tạo ra có đúng 15/25/10 câu theo độ khó, không trùng câu.
+- **AC-2:** Tổng % ≠ 100% → nút "Tạo đề" bị disable, có thông báo lý do.
+- **AC-3:** Một bucket yêu cầu nhiều hơn số câu sẵn có → UI đánh dấu đỏ dòng đó, nút lưu disable; nếu gọi API trực tiếp vẫn trả `422` với `shortages` đúng.
+- **AC-4:** Bốc câu cùng blueprint hai lần cho ra bộ câu (có thể) khác nhau nhưng luôn đúng quota (tính ngẫu nhiên có kiểm soát).
+- **AC-5:** Random và Pick hoạt động y như trước, đề cũ mở/sửa/làm bài bình thường.
+
+---
+
+## 9. Rủi ro & vấn đề mở
+
+| # | Rủi ro / câu hỏi | Hướng xử lý đề xuất |
+|---|---|---|
+| R-1 | Câu `domainId = NULL` làm lệch quota theo domain | Tạo nhóm "Không gán domain" tường minh (FR-4.3) |
+| R-2 | Người dùng kỳ vọng trộn cả difficulty lẫn domain ở P2 | P2 chỉ chọn 1 chiều; trộn 2 chiều để dành matrix ở P3 |
+| R-3 | Câu đổi trạng thái giữa lúc soạn → preview đúng nhưng lưu lại thiếu | Backend validate lại lúc lưu (NFR-2), trả 422 nếu cần |
+| R-4 | Làm tròn % gây tổng lệch 1–2 câu | Quy tắc dồn phần dư vào bucket lớn nhất (FR-3.2) |
+| R-5 | Có nên lưu blueprint từ P1 để phân tích về sau? | Hiện hoãn tới P3; cân nhắc nếu cần dữ liệu sớm |
+
+---
+
+*Tài liệu này ở trạng thái Draft để review. Sau khi chốt phạm vi và các vấn đề mở (mục 9), sẽ chuyển sang thiết kế chi tiết (hợp đồng API đầy đủ, wireframe) và lập kế hoạch sprint.*

--- a/src/components/exam/BlueprintEditor.tsx
+++ b/src/components/exam/BlueprintEditor.tsx
@@ -1,0 +1,262 @@
+/**
+ * BlueprintEditor — P1 implementation.
+ *
+ * Lets users declare how many EASY / MEDIUM / HARD questions they want.
+ * The component works in "%" mode: user enters percentages that are
+ * converted to absolute counts based on the total question count.
+ * It shows real-time availability from the question bank and prevents
+ * submission when any bucket is under-filled.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { getQuestionStats } from "@/services/questions";
+import type { ExamBlueprint } from "@/types/api-types";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DifficultyRow {
+  key: "EASY" | "MEDIUM" | "HARD";
+  label: string;
+  colorClass: string;
+  badgeClass: string;
+}
+
+const ROWS: DifficultyRow[] = [
+  {
+    key: "EASY",
+    label: "Dễ",
+    colorClass: "text-emerald-500",
+    badgeClass: "bg-emerald-500/10 text-emerald-500",
+  },
+  {
+    key: "MEDIUM",
+    label: "Trung bình",
+    colorClass: "text-yellow-500",
+    badgeClass: "bg-yellow-500/10 text-yellow-500",
+  },
+  {
+    key: "HARD",
+    label: "Khó",
+    colorClass: "text-destructive",
+    badgeClass: "bg-destructive/10 text-destructive",
+  },
+];
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface BlueprintEditorProps {
+  certificationId: string;
+  totalCount: number;
+  /** Called with null when the blueprint is invalid */
+  onChange: (blueprint: ExamBlueprint | null) => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Round percentage → integer count, keeping total sum consistent. */
+function distributeByPercent(
+  pcts: [number, number, number],
+  total: number,
+): [number, number, number] {
+  const raw = pcts.map((p) => (p / 100) * total);
+  const floored = raw.map(Math.floor) as [number, number, number];
+  const remainder = total - floored.reduce((a, b) => a + b, 0);
+
+  // Distribute remainder to the bucket with the largest fractional part.
+  const fracs = raw.map((v, i) => ({ i, f: v - floored[i] }));
+  fracs.sort((a, b) => b.f - a.f);
+  for (let k = 0; k < remainder; k++) {
+    floored[fracs[k % 3].i]++;
+  }
+  return floored;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+const BlueprintEditor = ({
+  certificationId,
+  totalCount,
+  onChange,
+}: BlueprintEditorProps) => {
+  // Percentages for each difficulty (default: 30 / 50 / 20).
+  const [pcts, setPcts] = useState<[number, number, number]>([30, 50, 20]);
+
+  const { data: stats, isLoading: statsLoading } = useQuery({
+    queryKey: ["question-stats", certificationId],
+    queryFn: () => getQuestionStats(certificationId),
+    enabled: !!certificationId,
+    staleTime: 30_000,
+  });
+
+  // Absolute counts derived from percentages.
+  const counts = useMemo(
+    () => distributeByPercent(pcts, totalCount),
+    [pcts, totalCount],
+  );
+
+  const totalPct = pcts.reduce((a, b) => a + b, 0);
+  const pctValid = totalPct === 100;
+
+  // Shortage detection per row.
+  const shortages = useMemo(() => {
+    if (!stats) return [false, false, false];
+    return ROWS.map((row, i) => {
+      const available = stats.byDifficulty[row.key] ?? 0;
+      return counts[i] > available;
+    }) as [boolean, boolean, boolean];
+  }, [stats, counts]);
+
+  const hasShortage = shortages.some(Boolean);
+  const isValid = pctValid && !hasShortage && totalCount > 0;
+
+  // Propagate blueprint up.
+  useEffect(() => {
+    if (!isValid) {
+      onChange(null);
+      return;
+    }
+    onChange({
+      byDifficulty: {
+        EASY: counts[0],
+        MEDIUM: counts[1],
+        HARD: counts[2],
+      },
+    });
+  }, [isValid, counts, onChange]);
+
+  const updatePct = (idx: number, value: number) => {
+    const clamped = Math.max(0, Math.min(100, value));
+    setPcts((prev) => {
+      const next = [...prev] as [number, number, number];
+      next[idx] = clamped;
+      return next;
+    });
+  };
+
+  return (
+    <div className="glass-card p-4 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-mono text-muted-foreground">
+          Phân bổ cấu trúc đề
+        </span>
+        {statsLoading && (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        )}
+        {stats && !statsLoading && (
+          <span className="text-xs text-muted-foreground font-mono">
+            Ngân hàng: {stats.total} câu đã duyệt
+          </span>
+        )}
+      </div>
+
+      {/* Rows */}
+      <div className="space-y-3">
+        {ROWS.map((row, idx) => {
+          const available = stats?.byDifficulty[row.key] ?? null;
+          const shortage = shortages[idx];
+          const count = counts[idx];
+
+          return (
+            <div key={row.key} className="space-y-1.5">
+              <div className="flex items-center justify-between text-xs font-mono">
+                <span className={row.colorClass}>{row.label}</span>
+
+                <div className="flex items-center gap-2">
+                  {/* Availability badge */}
+                  {available !== null && (
+                    <span
+                      className={`px-1.5 py-0.5 rounded ${shortage ? "bg-destructive/10 text-destructive" : "bg-white/5 text-muted-foreground"}`}
+                    >
+                      {count} câu
+                      {shortage && (
+                        <span className="ml-1">
+                          (chỉ có {available})
+                        </span>
+                      )}
+                      {!shortage && available !== null && (
+                        <span className="ml-1 opacity-60">/ {available} có sẵn</span>
+                      )}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Slider + number input */}
+              <div className="flex items-center gap-2">
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={pcts[idx]}
+                  onChange={(e) => updatePct(idx, parseInt(e.target.value))}
+                  className="flex-1 accent-primary h-1.5 cursor-pointer"
+                />
+                <div className="flex items-center gap-1">
+                  <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={pcts[idx]}
+                    onChange={(e) =>
+                      updatePct(idx, parseInt(e.target.value) || 0)
+                    }
+                    className="w-14 text-right bg-white/5 border border-white/10 rounded px-2 py-0.5 text-xs font-mono focus:outline-none focus:border-primary/50"
+                  />
+                  <span className="text-xs text-muted-foreground font-mono">%</span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Total % indicator */}
+      <div
+        className={`flex items-center justify-between text-xs font-mono pt-1 border-t ${pctValid ? "border-white/10" : "border-destructive/30"}`}
+      >
+        <span className="text-muted-foreground">Tổng</span>
+        <span
+          className={`font-semibold ${pctValid ? "text-primary" : "text-destructive"}`}
+        >
+          {totalPct}%{" "}
+          {!pctValid && (
+            <span className="font-normal opacity-80">
+              (cần đúng 100%)
+            </span>
+          )}
+        </span>
+      </div>
+
+      {/* Shortage warning */}
+      {hasShortage && (
+        <div className="flex items-start gap-2 text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+          <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span>
+            Một hoặc nhiều độ khó yêu cầu nhiều câu hơn số câu hiện có
+            trong ngân hàng. Giảm tỉ lệ hoặc chọn tổng số câu ít hơn.
+          </span>
+        </div>
+      )}
+
+      {/* Summary counts */}
+      <div className="flex gap-2 flex-wrap">
+        {ROWS.map((row, idx) => (
+          <span
+            key={row.key}
+            className={`text-xs px-2 py-0.5 rounded font-mono ${row.badgeClass}`}
+          >
+            {row.key}: {counts[idx]} câu
+          </span>
+        ))}
+        <span className="text-xs px-2 py-0.5 rounded font-mono bg-white/5 text-muted-foreground">
+          Tổng: {counts.reduce((a, b) => a + b, 0)} câu
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default BlueprintEditor;

--- a/src/pages/ExamBuilder.tsx
+++ b/src/pages/ExamBuilder.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { getCertifications } from "@/services/certifications";
@@ -23,17 +23,18 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   ChevronLeft,
-  Loader2,
-  Plus,
-  Search,
   Clock,
   Coffee,
+  LayoutGrid,
+  Loader2,
+  Plus,
   Zap,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import { toast } from "sonner";
 import Navbar from "@/components/Navbar";
-import type { TimerMode } from "@/types/api-types";
+import BlueprintEditor from "@/components/exam/BlueprintEditor";
+import type { TimerMode, ExamBlueprint } from "@/types/api-types";
 
 const ExamBuilder = () => {
   const navigate = useNavigate();
@@ -49,10 +50,15 @@ const ExamBuilder = () => {
     "PUBLIC",
   );
   const [timerMode, setTimerMode] = useState<TimerMode>("STRICT");
-  const [mode, setMode] = useState<"random" | "pick">("random");
+  const [mode, setMode] = useState<"random" | "pick" | "blueprint">("random");
   const [selectedQuestionIds, setSelectedQuestionIds] = useState<string[]>([]);
+  const [blueprint, setBlueprint] = useState<ExamBlueprint | null>(null);
   const [questionPage, setQuestionPage] = useState(1);
   const [searchCert, setSearchCert] = useState("");
+  const handleBlueprintChange = useCallback(
+    (bp: ExamBlueprint | null) => setBlueprint(bp),
+    [],
+  );
 
   const { data: certifications } = useQuery({
     queryKey: ["certifications"],
@@ -92,6 +98,11 @@ const ExamBuilder = () => {
     enabled: mode === "pick" && !!certId,
   });
 
+  // Reset blueprint state when mode changes away from blueprint.
+  useEffect(() => {
+    if (mode !== "blueprint") setBlueprint(null);
+  }, [mode]);
+
   const mutation = useMutation({
     mutationFn: (data: CreateExamPayload | UpdateExamPayload) =>
       isEditMode
@@ -118,31 +129,62 @@ const ExamBuilder = () => {
     if (!certId) return toast.error("Please select a certification");
     if (mode === "pick" && selectedQuestionIds.length === 0)
       return toast.error("Please select at least one question");
+    if (mode === "blueprint" && !blueprint)
+      return toast.error(
+        "Cấu trúc đề chưa hợp lệ — kiểm tra tổng % và số câu sẵn có",
+      );
 
     if (isEditMode) {
-      const payload: UpdateExamPayload = {
-        title: title.trim(),
-        description: description.trim() || undefined,
-        timeLimit,
-        visibility,
-        timerMode,
-        questionIds: selectedQuestionIds,
-      };
+      const payload: UpdateExamPayload =
+        mode === "blueprint"
+          ? {
+              title: title.trim(),
+              description: description.trim() || undefined,
+              timeLimit,
+              visibility,
+              timerMode,
+              selectionStrategy: "BLUEPRINT",
+              blueprint: blueprint!,
+            }
+          : {
+              title: title.trim(),
+              description: description.trim() || undefined,
+              timeLimit,
+              visibility,
+              timerMode,
+              questionIds: selectedQuestionIds,
+            };
       mutation.mutate(payload);
       return;
     }
 
-    const payload: CreateExamPayload = {
-      title: title.trim(),
-      description: description.trim() || undefined,
-      certificationId: certId,
-      questionCount:
-        mode === "pick" ? selectedQuestionIds.length : questionCount,
-      timeLimit,
-      visibility,
-      timerMode,
-      questionIds: mode === "pick" ? selectedQuestionIds : undefined,
-    };
+    const payload: CreateExamPayload =
+      mode === "blueprint"
+        ? {
+            title: title.trim(),
+            description: description.trim() || undefined,
+            certificationId: certId,
+            questionCount: Object.values(blueprint!.byDifficulty ?? {}).reduce(
+              (s: number, v) => s + (v ?? 0),
+              0,
+            ),
+            timeLimit,
+            visibility,
+            timerMode,
+            selectionStrategy: "BLUEPRINT",
+            blueprint: blueprint!,
+          }
+        : {
+            title: title.trim(),
+            description: description.trim() || undefined,
+            certificationId: certId,
+            questionCount:
+              mode === "pick" ? selectedQuestionIds.length : questionCount,
+            timeLimit,
+            visibility,
+            timerMode,
+            questionIds: mode === "pick" ? selectedQuestionIds : undefined,
+          };
 
     mutation.mutate(payload);
   };
@@ -323,34 +365,44 @@ const ExamBuilder = () => {
                 </div>
               </div>
 
-              {/* Question Selection Mode (creation only — editing always picks) */}
-              {!isEditMode && (
-                <div>
-                  <label className="text-sm font-mono text-muted-foreground mb-2 block">
-                    Question Selection
-                  </label>
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => setMode("random")}
-                      className={`flex-1 p-3 rounded-lg border text-sm font-mono transition-all ${mode === "random" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
-                    >
-                      Random Selection
-                      <div className="text-xs mt-1 opacity-70">
-                        Auto-pick from approved questions
-                      </div>
-                    </button>
-                    <button
-                      onClick={() => setMode("pick")}
-                      className={`flex-1 p-3 rounded-lg border text-sm font-mono transition-all ${mode === "pick" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
-                    >
-                      Pick Questions
-                      <div className="text-xs mt-1 opacity-70">
-                        Choose specific questions
-                      </div>
-                    </button>
-                  </div>
+              {/* Question Selection Mode */}
+              <div>
+                <label className="text-sm font-mono text-muted-foreground mb-2 block">
+                  Question Selection
+                </label>
+                <div className="grid grid-cols-3 gap-2">
+                  <button
+                    onClick={() => setMode("random")}
+                    className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "random" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
+                  >
+                    <div className="font-semibold mb-0.5">Ngẫu nhiên</div>
+                    <div className="text-xs opacity-70">
+                      Tự bốc từ ngân hàng câu đã duyệt
+                    </div>
+                  </button>
+                  <button
+                    onClick={() => setMode("blueprint")}
+                    className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "blueprint" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
+                  >
+                    <div className="flex items-center gap-1.5 font-semibold mb-0.5">
+                      <LayoutGrid className="h-3.5 w-3.5" />
+                      Theo cấu trúc
+                    </div>
+                    <div className="text-xs opacity-70">
+                      Khai báo tỉ lệ độ khó
+                    </div>
+                  </button>
+                  <button
+                    onClick={() => setMode("pick")}
+                    className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "pick" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
+                  >
+                    <div className="font-semibold mb-0.5">Chọn tay</div>
+                    <div className="text-xs opacity-70">
+                      Tick từng câu hỏi cụ thể
+                    </div>
+                  </button>
                 </div>
-              )}
+              </div>
 
               {/* Random mode: question count */}
               {mode === "random" && (
@@ -369,6 +421,38 @@ const ExamBuilder = () => {
                     className="bg-white/5 border-white/10 w-32"
                   />
                 </div>
+              )}
+
+              {/* Blueprint mode */}
+              {mode === "blueprint" && certId && (
+                <div className="space-y-3">
+                  <div>
+                    <label className="text-sm font-mono text-muted-foreground mb-1.5 block">
+                      Tổng số câu hỏi
+                    </label>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={200}
+                      value={questionCount}
+                      onChange={(e) =>
+                        setQuestionCount(parseInt(e.target.value) || 1)
+                      }
+                      className="bg-white/5 border-white/10 w-32"
+                    />
+                  </div>
+                  <BlueprintEditor
+                    certificationId={certId}
+                    totalCount={questionCount}
+                    onChange={handleBlueprintChange}
+                  />
+                </div>
+              )}
+
+              {mode === "blueprint" && !certId && (
+                <p className="text-xs text-muted-foreground font-mono">
+                  Chọn chứng chỉ trước để cấu hình cấu trúc đề.
+                </p>
               )}
 
               {/* Pick mode: question browser */}
@@ -457,7 +541,10 @@ const ExamBuilder = () => {
                 className="w-full glow-cyan font-mono"
                 size="lg"
                 onClick={handleSubmit}
-                disabled={mutation.isPending}
+                disabled={
+                  mutation.isPending ||
+                  (mode === "blueprint" && !blueprint)
+                }
               >
                 {mutation.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin mr-2" />

--- a/src/pages/ExamBuilder.tsx
+++ b/src/pages/ExamBuilder.tsx
@@ -135,24 +135,23 @@ const ExamBuilder = () => {
       );
 
     if (isEditMode) {
+      const base = {
+        title: title.trim(),
+        description: description.trim() || undefined,
+        timeLimit,
+        visibility,
+        timerMode,
+      };
       const payload: UpdateExamPayload =
         mode === "blueprint"
-          ? {
-              title: title.trim(),
-              description: description.trim() || undefined,
-              timeLimit,
-              visibility,
-              timerMode,
-              selectionStrategy: "BLUEPRINT",
-              blueprint: blueprint!,
-            }
+          ? { ...base, selectionStrategy: "BLUEPRINT", blueprint: blueprint! }
           : {
-              title: title.trim(),
-              description: description.trim() || undefined,
-              timeLimit,
-              visibility,
-              timerMode,
-              questionIds: selectedQuestionIds,
+              ...base,
+              // Only send questionIds when pick mode has an actual selection;
+              // sending an empty array fails the backend @ArrayNotEmpty guard.
+              ...(selectedQuestionIds.length > 0
+                ? { questionIds: selectedQuestionIds }
+                : {}),
             };
       mutation.mutate(payload);
       return;
@@ -164,10 +163,9 @@ const ExamBuilder = () => {
             title: title.trim(),
             description: description.trim() || undefined,
             certificationId: certId,
-            questionCount: Object.values(blueprint!.byDifficulty ?? {}).reduce(
-              (s: number, v) => s + (v ?? 0),
-              0,
-            ),
+            // BlueprintEditor.distributeByPercent guarantees sum(counts) === questionCount,
+            // so the state value is the source of truth — no need to re-derive.
+            questionCount,
             timeLimit,
             visibility,
             timerMode,
@@ -365,21 +363,26 @@ const ExamBuilder = () => {
                 </div>
               </div>
 
-              {/* Question Selection Mode */}
+              {/* Question Selection Mode
+                  Edit mode hides "Ngẫu nhiên": random on update would be a
+                  no-op (no questionIds → metadata-only path in backend).
+                  Users can re-roll via "Theo cấu trúc" or adjust via "Chọn tay". */}
               <div>
                 <label className="text-sm font-mono text-muted-foreground mb-2 block">
                   Question Selection
                 </label>
-                <div className="grid grid-cols-3 gap-2">
-                  <button
-                    onClick={() => setMode("random")}
-                    className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "random" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
-                  >
-                    <div className="font-semibold mb-0.5">Ngẫu nhiên</div>
-                    <div className="text-xs opacity-70">
-                      Tự bốc từ ngân hàng câu đã duyệt
-                    </div>
-                  </button>
+                <div className={`grid gap-2 ${isEditMode ? "grid-cols-2" : "grid-cols-3"}`}>
+                  {!isEditMode && (
+                    <button
+                      onClick={() => setMode("random")}
+                      className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "random" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
+                    >
+                      <div className="font-semibold mb-0.5">Ngẫu nhiên</div>
+                      <div className="text-xs opacity-70">
+                        Tự bốc từ ngân hàng câu đã duyệt
+                      </div>
+                    </button>
+                  )}
                   <button
                     onClick={() => setMode("blueprint")}
                     className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "blueprint" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}

--- a/src/services/exams.ts
+++ b/src/services/exams.ts
@@ -3,6 +3,8 @@ import {
   ExamSummary,
   CreateExamPayload,
   PaginatedResponse,
+  ExamBlueprint,
+  ExamSelectionStrategy,
 } from "@/types/api-types";
 
 export type { ExamSummary, CreateExamPayload };
@@ -56,6 +58,8 @@ export interface UpdateExamPayload {
   visibility?: string;
   timerMode?: string;
   questionIds?: string[];
+  selectionStrategy?: ExamSelectionStrategy;
+  blueprint?: ExamBlueprint;
 }
 
 export const updateExam = async (id: string, data: UpdateExamPayload) => {

--- a/src/services/questions.ts
+++ b/src/services/questions.ts
@@ -3,6 +3,17 @@ import { Question, PaginatedResponse } from '@/types/api-types';
 
 export type PaginatedQuestions = PaginatedResponse<Question>;
 
+export interface QuestionStats {
+  total: number;
+  byDifficulty: { EASY: number; MEDIUM: number; HARD: number };
+  byDomain: { domainId: string | null; name: string | null; count: number }[];
+}
+
+export const getQuestionStats = async (certificationId: string): Promise<QuestionStats> => {
+  const response = await api.get<QuestionStats>(`/questions/stats?certificationId=${certificationId}`);
+  return response.data;
+};
+
 export const getQuestions = async (certificationId?: string, page = 1, limit = 10, isTrapQuestion?: boolean, status?: string): Promise<PaginatedQuestions> => {
     const params = new URLSearchParams();
     if (certificationId) params.append('certificationId', certificationId);

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -279,6 +279,16 @@ export interface ExamSummary {
   };
 }
 
+export interface ExamBlueprint {
+  byDifficulty?: {
+    EASY?: number;
+    MEDIUM?: number;
+    HARD?: number;
+  };
+}
+
+export type ExamSelectionStrategy = "MANUAL" | "RANDOM" | "BLUEPRINT";
+
 export interface CreateExamPayload {
   title: string;
   description?: string;
@@ -289,6 +299,8 @@ export interface CreateExamPayload {
   timerMode?: TimerMode;
   examType?: ExamMode;
   questionIds?: string[];
+  selectionStrategy?: ExamSelectionStrategy;
+  blueprint?: ExamBlueprint;
 }
 
 // ─── AI Question Bank ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Thêm chế độ tạo đề thứ 3 **\"Theo cấu trúc\" (Blueprint)** vào Exam Builder — người dùng khai báo tỉ lệ % theo độ khó (EASY / MEDIUM / HARD), hệ thống tự bốc câu phù hợp từ ngân hàng câu hỏi đã duyệt
- Bổ sung `GET /questions/stats` endpoint trả về phân bố ngân hàng câu hỏi theo độ khó và domain, dùng để hiển thị cảnh báo thiếu câu realtime trên UI
- Chặn tạo/sửa đề với lỗi `422 BLUEPRINT_INSUFFICIENT_QUESTIONS` kèm chi tiết từng bucket thiếu khi ngân hàng không đủ câu — đề luôn đúng 100% blueprint hoặc không tạo

## Thay đổi

### Backend
- `backend/src/exams/dto/blueprint.dto.ts` *(mới)*: `BlueprintDto` + `BlueprintDifficultyDto` validated bởi class-validator
- `CreateExamDto` / `UpdateExamDto`: thêm `selectionStrategy` và `blueprint` (optional, backward-compatible)
- `ExamsService.resolveBlueprint()`: fetch tất cả bucket song song (`Promise.all`), Fisher-Yates shuffle per bucket, throw `422` với `shortages` detail khi thiếu câu
- `ExamsService.create()` / `update()`: ba nhánh rõ ràng — blueprint / manual / random
- `GET /questions/stats` *(mới, `@Public`, throttle 30 req/min)*: groupBy difficulty + domain

### Frontend
- `src/components/exam/BlueprintEditor.tsx` *(mới)*: slider UI với quy đổi %→câu realtime, badge "X câu / Y có sẵn", cảnh báo đỏ khi thiếu, validate tổng = 100%
- `ExamBuilder.tsx`: 3-mode selector (Ngẫu nhiên / Theo cấu trúc / Chọn tay); submit button disabled khi blueprint invalid; edit mode ẩn "Ngẫu nhiên" (tránh silent no-op)
- Types và services mở rộng: `ExamBlueprint`, `ExamSelectionStrategy`, `QuestionStats`, `getQuestionStats()`

## Không có breaking change

Random và Pick mode giữ nguyên hoàn toàn. Tất cả field mới đều `@IsOptional()`. Đề cũ mở/sửa/làm bài bình thường.

## Tài liệu

SRS đầy đủ tại [`docs/specs/smart-exam-builder-srs.md`](docs/specs/smart-exam-builder-srs.md).

## Test plan

- [ ] Tạo đề blueprint 30% EASY / 50% MEDIUM / 20% HARD với tổng 50 câu → đề có 15/25/10 câu đúng độ khó
- [ ] Kéo slider vượt số câu có sẵn → nút "Tạo đề" bị disable, badge đỏ hiển thị
- [ ] Tổng % ≠ 100% → nút disable, indicator đỏ
- [ ] Gọi API trực tiếp với blueprint thiếu câu → `422` với `shortages` đúng
- [ ] Tạo/làm bài đề Random và Pick → không bị ảnh hưởng
- [ ] Edit đề hiện có bằng blueprint → câu thay thế hoàn toàn, `questionCount` cập nhật đúng

🤖 Generated with [Claude Code](https://claude.com/claude-code)