### PR TITLE
feat: Smart Exam Builder — blueprint by domain percentage

### DIFF
--- a/backend/src/exams/dto/blueprint.dto.ts
+++ b/backend/src/exams/dto/blueprint.dto.ts
@@ -2,6 +2,7 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsInt,
+  IsObject,
   IsOptional,
   Min,
   ValidateNested,
@@ -37,4 +38,17 @@ export class BlueprintDto {
   @ValidateNested()
   @Type(() => BlueprintDifficultyDto)
   byDifficulty?: BlueprintDifficultyDto;
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: { type: 'integer' },
+    example: { 'domain-uuid-a': 20, 'domain-uuid-b': 15 },
+    description:
+      'Quota per domain. Keys are domainId, values are absolute question counts (not %). ' +
+      'Questions within each domain are picked at random across all difficulties. ' +
+      'Mutually exclusive with byDifficulty — supply only one axis.',
+  })
+  @IsOptional()
+  @IsObject()
+  byDomain?: Record<string, number>;
 }

--- a/backend/src/exams/exams.service.spec.ts
+++ b/backend/src/exams/exams.service.spec.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { ExamsService } from './exams.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -226,6 +227,115 @@ describe('ExamsService', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
 
       expect(mockPrismaService.examQuestion.deleteMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveBlueprint', () => {
+    // resolveBlueprint is private; cast to reach it directly so each axis can
+    // be exercised in isolation without the surrounding create/update plumbing.
+    const resolve = (blueprint: any) =>
+      (service as any).resolveBlueprint('cert-1', blueprint) as Promise<
+        string[]
+      >;
+
+    it('fills difficulty buckets from the approved pool (existing behaviour)', async () => {
+      mockPrismaService.question.findMany.mockImplementation(
+        ({ where }: any) => {
+          if (where.difficulty === 'EASY')
+            return Promise.resolve([{ id: 'e-1' }, { id: 'e-2' }, { id: 'e-3' }]);
+          if (where.difficulty === 'HARD')
+            return Promise.resolve([{ id: 'h-1' }, { id: 'h-2' }]);
+          return Promise.resolve([]);
+        },
+      );
+
+      const ids = await resolve({ byDifficulty: { EASY: 2, HARD: 1 } });
+
+      expect(ids).toHaveLength(3);
+      // Two EASY picks and one HARD pick, scoped to the requested buckets.
+      expect(ids.filter((id) => id.startsWith('e-'))).toHaveLength(2);
+      expect(ids.filter((id) => id.startsWith('h-'))).toHaveLength(1);
+    });
+
+    it('fills domain buckets, querying by domainId and APPROVED status', async () => {
+      mockPrismaService.question.findMany.mockImplementation(
+        ({ where }: any) => {
+          if (where.domainId === 'dom-a')
+            return Promise.resolve([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+          if (where.domainId === 'dom-b')
+            return Promise.resolve([{ id: 'b-1' }, { id: 'b-2' }]);
+          return Promise.resolve([]);
+        },
+      );
+
+      const ids = await resolve({ byDomain: { 'dom-a': 2, 'dom-b': 1 } });
+
+      expect(ids).toHaveLength(3);
+      expect(ids.filter((id) => id.startsWith('a-'))).toHaveLength(2);
+      expect(ids.filter((id) => id.startsWith('b-'))).toHaveLength(1);
+
+      // Each domain bucket is scoped to certification + APPROVED + non-deleted.
+      const calls = mockPrismaService.question.findMany.mock.calls.map(
+        (c: any[]) => c[0].where,
+      );
+      expect(calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            certificationId: 'cert-1',
+            status: 'APPROVED',
+            deletedAt: null,
+            domainId: 'dom-a',
+          }),
+        ]),
+      );
+    });
+
+    it('throws 422 with shortage detail when a domain bucket is under-filled', async () => {
+      mockPrismaService.question.findMany.mockImplementation(
+        ({ where }: any) => {
+          if (where.domainId === 'dom-a') return Promise.resolve([{ id: 'a-1' }]);
+          return Promise.resolve([]);
+        },
+      );
+
+      await expect(
+        resolve({ byDomain: { 'dom-a': 5 } }),
+      ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    });
+
+    it('rejects mixing difficulty and domain quotas in one blueprint', async () => {
+      await expect(
+        resolve({ byDifficulty: { EASY: 1 }, byDomain: { 'dom-a': 1 } }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects an empty blueprint (all counts zero / absent)', async () => {
+      await expect(
+        resolve({ byDifficulty: { EASY: 0 }, byDomain: {} }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects more domain buckets than the allowed maximum', async () => {
+      const byDomain: Record<string, number> = {};
+      for (let i = 0; i < 51; i++) byDomain[`dom-${i}`] = 1;
+
+      await expect(resolve({ byDomain })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      // Rejected before any query fan-out.
+      expect(mockPrismaService.question.findMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-integer domain quota', async () => {
+      await expect(
+        resolve({ byDomain: { 'dom-a': 2.5 } }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects a domain quota above the per-bucket maximum', async () => {
+      await expect(
+        resolve({ byDomain: { 'dom-a': 201 } }),
+      ).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 });

--- a/backend/src/exams/exams.service.ts
+++ b/backend/src/exams/exams.service.ts
@@ -9,11 +9,22 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreateExamDto } from './dto/create-exam.dto';
 import { UpdateExamDto } from './dto/update-exam.dto';
 import { BlueprintDto } from './dto/blueprint.dto';
-import { ExamVisibility, QuestionStatus, UserRole, Difficulty } from '@prisma/client';
+import {
+  ExamVisibility,
+  QuestionStatus,
+  UserRole,
+  Difficulty,
+  Prisma,
+} from '@prisma/client';
 import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class ExamsService {
+  /** Upper bound on distinct domain buckets in a single blueprint (limits query fan-out). */
+  private static readonly MAX_BLUEPRINT_BUCKETS = 50;
+  /** Upper bound on questions requested per bucket (matches the 200-question exam cap). */
+  private static readonly MAX_BLUEPRINT_BUCKET_COUNT = 200;
+
   constructor(private readonly prisma: PrismaService) {}
 
   /**
@@ -25,38 +36,102 @@ export class ExamsService {
     certificationId: string,
     blueprint: BlueprintDto,
   ): Promise<string[]> {
-    // byDifficulty: each question has exactly one difficulty value, so buckets
-    // are mutually exclusive — no cross-bucket duplicates are possible.
-    // All bucket queries can therefore run in parallel.
-    if (!blueprint.byDifficulty) {
-      throw new BadRequestException(
-        'Blueprint không có bucket nào hợp lệ (tất cả count = 0)',
-      );
-    }
-
-    const entries = (
-      Object.entries(blueprint.byDifficulty) as [Difficulty, number | undefined][]
+    // A blueprint declares quotas along exactly one axis:
+    //   - byDifficulty: each question has exactly one difficulty value.
+    //   - byDomain:     each question belongs to at most one domain.
+    // Either axis yields mutually-exclusive buckets, so bucket queries can run
+    // in parallel with no risk of cross-bucket duplicates.
+    const difficultyEntries = (
+      Object.entries(blueprint.byDifficulty ?? {}) as [
+        Difficulty,
+        number | undefined,
+      ][]
     ).filter(([, count]) => count && count > 0);
 
-    if (entries.length === 0) {
+    const domainEntries = Object.entries(blueprint.byDomain ?? {}).filter(
+      ([, count]) => typeof count === 'number' && count > 0,
+    );
+
+    const hasDifficulty = difficultyEntries.length > 0;
+    const hasDomain = domainEntries.length > 0;
+
+    if (hasDifficulty && hasDomain) {
       throw new BadRequestException(
-        'Blueprint không có bucket nào hợp lệ (tất cả count = 0)',
+        'Blueprint cannot mix difficulty and domain quotas — choose a single axis',
+      );
+    }
+    if (!hasDifficulty && !hasDomain) {
+      throw new BadRequestException(
+        'Blueprint has no valid buckets (all counts are 0)',
       );
     }
 
-    // Fetch all buckets in parallel — safe because difficulty is mutually exclusive.
+    let buckets: { label: string; count: number; where: Prisma.QuestionWhereInput }[];
+
+    if (hasDomain) {
+      // byDomain is a free-form Record, so it needs explicit bounds the typed
+      // byDifficulty axis gets for free. Cap the number of buckets to avoid
+      // firing an unbounded fan-out of parallel queries, and bound each count
+      // so a single quota can't request an absurd slice.
+      if (domainEntries.length > ExamsService.MAX_BLUEPRINT_BUCKETS) {
+        throw new BadRequestException(
+          `Blueprint cannot declare more than ${ExamsService.MAX_BLUEPRINT_BUCKETS} domains`,
+        );
+      }
+      for (const [, count] of domainEntries) {
+        if (!Number.isInteger(count) || count < 0) {
+          throw new BadRequestException(
+            'Blueprint domain quotas must be non-negative integers',
+          );
+        }
+        if (count > ExamsService.MAX_BLUEPRINT_BUCKET_COUNT) {
+          throw new BadRequestException(
+            `Blueprint domain quota cannot exceed ${ExamsService.MAX_BLUEPRINT_BUCKET_COUNT} questions`,
+          );
+        }
+      }
+      buckets = domainEntries.map(([domainId, count]) => ({
+        label: `domain:${domainId}`,
+        count,
+        where: {
+          certificationId,
+          status: QuestionStatus.APPROVED,
+          deletedAt: null,
+          domainId,
+        },
+      }));
+    } else {
+      buckets = difficultyEntries.map(([difficulty, count]) => ({
+        label: difficulty,
+        count: count!,
+        where: {
+          certificationId,
+          status: QuestionStatus.APPROVED,
+          deletedAt: null,
+          difficulty,
+        },
+      }));
+    }
+
+    return this.resolveBuckets(buckets);
+  }
+
+  /**
+   * Fill a set of mutually-exclusive buckets from the approved question pool.
+   * Each bucket is shuffled (Fisher-Yates) and sliced to its quota; picks are
+   * then re-shuffled together. Throws 422 with per-bucket `shortages` detail if
+   * any bucket cannot be filled.
+   */
+  private async resolveBuckets(
+    buckets: { label: string; count: number; where: Prisma.QuestionWhereInput }[],
+  ): Promise<string[]> {
     const bucketResults = await Promise.all(
-      entries.map(async ([difficulty, count]) => {
+      buckets.map(async (bucket) => {
         const candidates = await this.prisma.question.findMany({
-          where: {
-            certificationId,
-            status: QuestionStatus.APPROVED,
-            deletedAt: null,
-            difficulty,
-          },
+          where: bucket.where,
           select: { id: true },
         });
-        return { difficulty, count: count!, candidates };
+        return { ...bucket, candidates };
       }),
     );
 
@@ -69,10 +144,10 @@ export class ExamsService {
 
     const pickedIds: string[] = [];
 
-    for (const { difficulty, count, candidates } of bucketResults) {
+    for (const { label, count, candidates } of bucketResults) {
       if (candidates.length < count) {
         shortages.push({
-          bucket: difficulty,
+          bucket: label,
           required: count,
           available: candidates.length,
           missing: count - candidates.length,
@@ -91,7 +166,7 @@ export class ExamsService {
       throw new UnprocessableEntityException({
         error: 'BLUEPRINT_INSUFFICIENT_QUESTIONS',
         message:
-          'Ngân hàng câu hỏi không đủ để tạo đề theo cấu trúc đã chọn',
+          'The question bank does not have enough questions to build an exam with the selected blueprint',
         shortages,
       });
     }

--- a/src/components/exam/BlueprintEditor.tsx
+++ b/src/components/exam/BlueprintEditor.tsx
@@ -1,11 +1,15 @@
 /**
- * BlueprintEditor — P1 implementation.
+ * BlueprintEditor — P2 implementation.
  *
- * Lets users declare how many EASY / MEDIUM / HARD questions they want.
- * The component works in "%" mode: user enters percentages that are
- * converted to absolute counts based on the total question count.
- * It shows real-time availability from the question bank and prevents
- * submission when any bucket is under-filled.
+ * Lets users declare an exam structure along ONE axis:
+ *   - "By difficulty": how many EASY / MEDIUM / HARD questions.
+ *   - "By domain":     how many questions per certification domain (picked at
+ *                      random across all difficulties within that domain).
+ *
+ * The component works in "%" mode: the user enters percentages that are
+ * converted to absolute counts based on the total question count. It shows
+ * real-time availability from the question bank and prevents submission when
+ * any bucket is under-filled or the percentages don't add up to 100.
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -16,29 +20,35 @@ import type { ExamBlueprint } from "@/types/api-types";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface DifficultyRow {
-  key: "EASY" | "MEDIUM" | "HARD";
+type Axis = "difficulty" | "domain";
+
+/** A single allocatable bucket rendered as one slider row. */
+interface BucketRow {
+  /** Stable identity: difficulty enum value or domainId. */
+  key: string;
   label: string;
+  /** Approved questions available for this bucket, or null while loading. */
+  available: number | null;
   colorClass: string;
   badgeClass: string;
 }
 
-const ROWS: DifficultyRow[] = [
+const DIFFICULTY_ROWS: Omit<BucketRow, "available">[] = [
   {
     key: "EASY",
-    label: "Dễ",
+    label: "Easy",
     colorClass: "text-emerald-500",
     badgeClass: "bg-emerald-500/10 text-emerald-500",
   },
   {
     key: "MEDIUM",
-    label: "Trung bình",
+    label: "Medium",
     colorClass: "text-yellow-500",
     badgeClass: "bg-yellow-500/10 text-yellow-500",
   },
   {
     key: "HARD",
-    label: "Khó",
+    label: "Hard",
     colorClass: "text-destructive",
     badgeClass: "bg-destructive/10 text-destructive",
   },
@@ -55,22 +65,28 @@ interface BlueprintEditorProps {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Round percentage → integer count, keeping total sum consistent. */
-function distributeByPercent(
-  pcts: [number, number, number],
-  total: number,
-): [number, number, number] {
+/** Round percentages → integer counts, keeping the total sum consistent. */
+function distributeByPercent(pcts: number[], total: number): number[] {
+  if (pcts.length === 0) return [];
   const raw = pcts.map((p) => (p / 100) * total);
-  const floored = raw.map(Math.floor) as [number, number, number];
+  const floored = raw.map(Math.floor);
   const remainder = total - floored.reduce((a, b) => a + b, 0);
 
-  // Distribute remainder to the bucket with the largest fractional part.
+  // Distribute remainder to the buckets with the largest fractional parts.
   const fracs = raw.map((v, i) => ({ i, f: v - floored[i] }));
   fracs.sort((a, b) => b.f - a.f);
   for (let k = 0; k < remainder; k++) {
-    floored[fracs[k % 3].i]++;
+    floored[fracs[k % fracs.length].i]++;
   }
   return floored;
+}
+
+/** Even-as-possible split of 100% across n buckets (sums to exactly 100). */
+function evenSplit(n: number): number[] {
+  if (n <= 0) return [];
+  const base = Math.floor(100 / n);
+  const rem = 100 - base * n;
+  return Array.from({ length: n }, (_, i) => base + (i < rem ? 1 : 0));
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -80,8 +96,11 @@ const BlueprintEditor = ({
   totalCount,
   onChange,
 }: BlueprintEditorProps) => {
-  // Percentages for each difficulty (default: 30 / 50 / 20).
-  const [pcts, setPcts] = useState<[number, number, number]>([30, 50, 20]);
+  const [axis, setAxis] = useState<Axis>("difficulty");
+
+  // Percentages are tracked per-axis so toggling preserves each axis' state.
+  const [diffPcts, setDiffPcts] = useState<number[]>([30, 50, 20]);
+  const [domainPcts, setDomainPcts] = useState<number[]>([]);
 
   const { data: stats, isLoading: statsLoading } = useQuery({
     queryKey: ["question-stats", certificationId],
@@ -90,6 +109,50 @@ const BlueprintEditor = ({
     staleTime: 30_000,
   });
 
+  // Domain buckets, excluding uncategorized (null domainId) questions.
+  const domainBuckets = useMemo(
+    () =>
+      (stats?.byDomain ?? [])
+        .filter((d) => d.domainId)
+        .map((d) => ({
+          key: d.domainId as string,
+          label: d.name ?? "Unknown",
+          available: d.count,
+        })),
+    [stats],
+  );
+
+  // Initialise / resize domain percentages once the domain list is known.
+  useEffect(() => {
+    setDomainPcts((prev) =>
+      prev.length === domainBuckets.length
+        ? prev
+        : evenSplit(domainBuckets.length),
+    );
+  }, [domainBuckets.length]);
+
+  // Active rows + percentage state for the selected axis.
+  const rows: BucketRow[] = useMemo(
+    () =>
+      axis === "difficulty"
+        ? DIFFICULTY_ROWS.map((r) => ({
+            ...r,
+            available:
+              stats?.byDifficulty[r.key as "EASY" | "MEDIUM" | "HARD"] ?? null,
+          }))
+        : domainBuckets.map((d) => ({
+            key: d.key,
+            label: d.label,
+            available: d.available,
+            colorClass: "text-primary",
+            badgeClass: "bg-primary/10 text-primary",
+          })),
+    [axis, stats, domainBuckets],
+  );
+
+  const pcts = axis === "difficulty" ? diffPcts : domainPcts;
+  const setPcts = axis === "difficulty" ? setDiffPcts : setDomainPcts;
+
   // Absolute counts derived from percentages.
   const counts = useMemo(
     () => distributeByPercent(pcts, totalCount),
@@ -97,87 +160,143 @@ const BlueprintEditor = ({
   );
 
   const totalPct = pcts.reduce((a, b) => a + b, 0);
-  const pctValid = totalPct === 100;
+  const pctValid = totalPct === 100 && pcts.length > 0;
+
+  // pcts and rows can be momentarily out of sync on the render right after the
+  // axis or domain list changes (the resize effect runs afterwards). Treat that
+  // transient state as not-yet-aligned so we never emit a half-built blueprint.
+  const aligned = pcts.length === rows.length;
 
   // Shortage detection per row.
-  const shortages = useMemo(() => {
-    if (!stats) return [false, false, false];
-    return ROWS.map((row, i) => {
-      const available = stats.byDifficulty[row.key] ?? 0;
-      return counts[i] > available;
-    }) as [boolean, boolean, boolean];
-  }, [stats, counts]);
+  const shortages = useMemo(
+    () =>
+      rows.map(
+        (row, i) => row.available != null && counts[i] > row.available,
+      ),
+    [rows, counts],
+  );
 
   const hasShortage = shortages.some(Boolean);
-  const isValid = pctValid && !hasShortage && totalCount > 0;
+  const noDomains = axis === "domain" && domainBuckets.length === 0;
+  const isValid =
+    aligned && pctValid && !hasShortage && totalCount > 0 && !noDomains;
 
-  // Propagate blueprint up.
+  // Propagate blueprint up. Depend on memoised values only (counts, axis,
+  // domainBuckets) so this doesn't re-fire on every render.
   useEffect(() => {
     if (!isValid) {
       onChange(null);
       return;
     }
-    onChange({
-      byDifficulty: {
-        EASY: counts[0],
-        MEDIUM: counts[1],
-        HARD: counts[2],
-      },
-    });
-  }, [isValid, counts, onChange]);
+    if (axis === "difficulty") {
+      onChange({
+        byDifficulty: {
+          EASY: counts[0],
+          MEDIUM: counts[1],
+          HARD: counts[2],
+        },
+      });
+    } else {
+      const byDomain: Record<string, number> = {};
+      domainBuckets.forEach((b, i) => {
+        byDomain[b.key] = counts[i];
+      });
+      onChange({ byDomain });
+    }
+  }, [isValid, counts, axis, domainBuckets, onChange]);
 
   const updatePct = (idx: number, value: number) => {
     const clamped = Math.max(0, Math.min(100, value));
     setPcts((prev) => {
-      const next = [...prev] as [number, number, number];
+      const next = [...prev];
       next[idx] = clamped;
       return next;
     });
   };
 
+  const axisTabClass = (active: boolean) =>
+    `flex-1 px-3 py-1.5 rounded-md text-xs font-mono transition-all ${
+      active
+        ? "bg-primary/15 text-primary border border-primary/40"
+        : "text-muted-foreground border border-transparent hover:text-foreground"
+    }`;
+
   return (
     <div className="glass-card p-4 space-y-4">
+      {/* Axis toggle */}
+      <div className="flex items-center gap-1 bg-white/5 rounded-lg p-1">
+        <button
+          type="button"
+          onClick={() => setAxis("difficulty")}
+          className={axisTabClass(axis === "difficulty")}
+        >
+          By difficulty
+        </button>
+        <button
+          type="button"
+          onClick={() => setAxis("domain")}
+          className={axisTabClass(axis === "domain")}
+        >
+          By domain
+        </button>
+      </div>
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <span className="text-sm font-mono text-muted-foreground">
-          Phân bổ cấu trúc đề
+          {axis === "difficulty"
+            ? "Difficulty distribution"
+            : "Domain distribution"}
         </span>
         {statsLoading && (
           <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
         )}
         {stats && !statsLoading && (
           <span className="text-xs text-muted-foreground font-mono">
-            Ngân hàng: {stats.total} câu đã duyệt
+            Bank: {stats.total} approved questions
           </span>
         )}
       </div>
 
+      {/* No-domains hint */}
+      {noDomains && !statsLoading && (
+        <div className="flex items-start gap-2 text-xs text-muted-foreground bg-white/5 rounded-lg px-3 py-2">
+          <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span>
+            This certification has no domains with approved questions. Use the
+            "By difficulty" axis instead.
+          </span>
+        </div>
+      )}
+
       {/* Rows */}
       <div className="space-y-3">
-        {ROWS.map((row, idx) => {
-          const available = stats?.byDifficulty[row.key] ?? null;
+        {rows.map((row, idx) => {
+          const available = row.available;
           const shortage = shortages[idx];
           const count = counts[idx];
 
           return (
             <div key={row.key} className="space-y-1.5">
               <div className="flex items-center justify-between text-xs font-mono">
-                <span className={row.colorClass}>{row.label}</span>
+                <span className={`${row.colorClass} truncate pr-2`}>
+                  {row.label}
+                </span>
 
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 shrink-0">
                   {/* Availability badge */}
                   {available !== null && (
                     <span
                       className={`px-1.5 py-0.5 rounded ${shortage ? "bg-destructive/10 text-destructive" : "bg-white/5 text-muted-foreground"}`}
                     >
-                      {count} câu
+                      {count} Q
                       {shortage && (
                         <span className="ml-1">
-                          (chỉ có {available})
+                          (only {available})
                         </span>
                       )}
-                      {!shortage && available !== null && (
-                        <span className="ml-1 opacity-60">/ {available} có sẵn</span>
+                      {!shortage && (
+                        <span className="ml-1 opacity-60">/ {available} available</span>
                       )}
                     </span>
                   )}
@@ -190,7 +309,7 @@ const BlueprintEditor = ({
                   type="range"
                   min={0}
                   max={100}
-                  value={pcts[idx]}
+                  value={pcts[idx] ?? 0}
                   onChange={(e) => updatePct(idx, parseInt(e.target.value))}
                   className="flex-1 accent-primary h-1.5 cursor-pointer"
                 />
@@ -199,7 +318,7 @@ const BlueprintEditor = ({
                     type="number"
                     min={0}
                     max={100}
-                    value={pcts[idx]}
+                    value={pcts[idx] ?? 0}
                     onChange={(e) =>
                       updatePct(idx, parseInt(e.target.value) || 0)
                     }
@@ -214,47 +333,52 @@ const BlueprintEditor = ({
       </div>
 
       {/* Total % indicator */}
-      <div
-        className={`flex items-center justify-between text-xs font-mono pt-1 border-t ${pctValid ? "border-white/10" : "border-destructive/30"}`}
-      >
-        <span className="text-muted-foreground">Tổng</span>
-        <span
-          className={`font-semibold ${pctValid ? "text-primary" : "text-destructive"}`}
+      {rows.length > 0 && (
+        <div
+          className={`flex items-center justify-between text-xs font-mono pt-1 border-t ${pctValid ? "border-white/10" : "border-destructive/30"}`}
         >
-          {totalPct}%{" "}
-          {!pctValid && (
-            <span className="font-normal opacity-80">
-              (cần đúng 100%)
-            </span>
-          )}
-        </span>
-      </div>
+          <span className="text-muted-foreground">Total</span>
+          <span
+            className={`font-semibold ${pctValid ? "text-primary" : "text-destructive"}`}
+          >
+            {totalPct}%{" "}
+            {!pctValid && (
+              <span className="font-normal opacity-80">
+                (must equal 100%)
+              </span>
+            )}
+          </span>
+        </div>
+      )}
 
       {/* Shortage warning */}
       {hasShortage && (
         <div className="flex items-start gap-2 text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
           <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
           <span>
-            Một hoặc nhiều độ khó yêu cầu nhiều câu hơn số câu hiện có
-            trong ngân hàng. Giảm tỉ lệ hoặc chọn tổng số câu ít hơn.
+            {axis === "difficulty"
+              ? "One or more difficulty levels require more questions than are available in the bank. Lower the percentage or choose a smaller total question count."
+              : "One or more domains require more questions than are available in the bank. Lower the percentage or choose a smaller total question count."}
           </span>
         </div>
       )}
 
       {/* Summary counts */}
-      <div className="flex gap-2 flex-wrap">
-        {ROWS.map((row, idx) => (
-          <span
-            key={row.key}
-            className={`text-xs px-2 py-0.5 rounded font-mono ${row.badgeClass}`}
-          >
-            {row.key}: {counts[idx]} câu
+      {rows.length > 0 && (
+        <div className="flex gap-2 flex-wrap">
+          {rows.map((row, idx) => (
+            <span
+              key={row.key}
+              className={`text-xs px-2 py-0.5 rounded font-mono ${row.badgeClass}`}
+            >
+              {row.label}: {counts[idx]} Q
+            </span>
+          ))}
+          <span className="text-xs px-2 py-0.5 rounded font-mono bg-white/5 text-muted-foreground">
+            Total: {counts.reduce((a, b) => a + b, 0)} Q
           </span>
-        ))}
-        <span className="text-xs px-2 py-0.5 rounded font-mono bg-white/5 text-muted-foreground">
-          Tổng: {counts.reduce((a, b) => a + b, 0)} câu
-        </span>
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/ExamBuilder.tsx
+++ b/src/pages/ExamBuilder.tsx
@@ -131,7 +131,7 @@ const ExamBuilder = () => {
       return toast.error("Please select at least one question");
     if (mode === "blueprint" && !blueprint)
       return toast.error(
-        "Cấu trúc đề chưa hợp lệ — kiểm tra tổng % và số câu sẵn có",
+        "Blueprint is not valid — check the total % and available question counts",
       );
 
     if (isEditMode) {
@@ -364,9 +364,9 @@ const ExamBuilder = () => {
               </div>
 
               {/* Question Selection Mode
-                  Edit mode hides "Ngẫu nhiên": random on update would be a
+                  Edit mode hides "Random": random on update would be a
                   no-op (no questionIds → metadata-only path in backend).
-                  Users can re-roll via "Theo cấu trúc" or adjust via "Chọn tay". */}
+                  Users can re-roll via "Blueprint" or adjust via "Manual pick". */}
               <div>
                 <label className="text-sm font-mono text-muted-foreground mb-2 block">
                   Question Selection
@@ -377,9 +377,9 @@ const ExamBuilder = () => {
                       onClick={() => setMode("random")}
                       className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "random" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
                     >
-                      <div className="font-semibold mb-0.5">Ngẫu nhiên</div>
+                      <div className="font-semibold mb-0.5">Random</div>
                       <div className="text-xs opacity-70">
-                        Tự bốc từ ngân hàng câu đã duyệt
+                        Auto-pick from the approved question bank
                       </div>
                     </button>
                   )}
@@ -389,19 +389,19 @@ const ExamBuilder = () => {
                   >
                     <div className="flex items-center gap-1.5 font-semibold mb-0.5">
                       <LayoutGrid className="h-3.5 w-3.5" />
-                      Theo cấu trúc
+                      Blueprint
                     </div>
                     <div className="text-xs opacity-70">
-                      Khai báo tỉ lệ độ khó
+                      Declare difficulty or domain percentages
                     </div>
                   </button>
                   <button
                     onClick={() => setMode("pick")}
                     className={`p-3 rounded-lg border text-sm font-mono transition-all text-left ${mode === "pick" ? "border-primary bg-primary/10 text-primary" : "border-white/10 bg-white/5 text-muted-foreground hover:border-white/20"}`}
                   >
-                    <div className="font-semibold mb-0.5">Chọn tay</div>
+                    <div className="font-semibold mb-0.5">Manual pick</div>
                     <div className="text-xs opacity-70">
-                      Tick từng câu hỏi cụ thể
+                      Select individual questions
                     </div>
                   </button>
                 </div>
@@ -431,7 +431,7 @@ const ExamBuilder = () => {
                 <div className="space-y-3">
                   <div>
                     <label className="text-sm font-mono text-muted-foreground mb-1.5 block">
-                      Tổng số câu hỏi
+                      Total Questions
                     </label>
                     <Input
                       type="number"
@@ -454,7 +454,7 @@ const ExamBuilder = () => {
 
               {mode === "blueprint" && !certId && (
                 <p className="text-xs text-muted-foreground font-mono">
-                  Chọn chứng chỉ trước để cấu hình cấu trúc đề.
+                  Select a certification first to configure the blueprint.
                 </p>
               )}
 

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -285,6 +285,9 @@ export interface ExamBlueprint {
     MEDIUM?: number;
     HARD?: number;
   };
+  /** Quota per domain — keys are domainId, values are absolute question counts.
+   *  Mutually exclusive with byDifficulty. */
+  byDomain?: Record<string, number>;
 }
 
 export type ExamSelectionStrategy = "MANUAL" | "RANDOM" | "BLUEPRINT";


### PR DESCRIPTION
## Summary
- **New axis**: Authors can now declare exam blueprints by domain percentage in addition to the existing difficulty split (Option A)
- **Domain auto-pick**: Questions are randomly selected from each domain across all difficulties
- **Security hardening**: Domain buckets are capped at 50 (prevents query fan-out), per-bucket count at 200
- **No downgrade**: Random, Manual, and difficulty-blueprint paths remain unchanged; `byDomain` is purely optional
- **Localization**: Translated all remaining Vietnamese strings to English (UI + backend errors)

## Changes
### Backend
- `BlueprintDto`: Added optional `byDomain: Record<string, number>` (mutually exclusive with `byDifficulty`)
- `ExamsService`:
  - `resolveBlueprint()` now dispatches on axis with mutual-exclusion guard (400 if both supplied)
  - Extracted shared `resolveBuckets()` helper for both axes
  - Domain queries correctly scoped to `certificationId + APPROVED + non-deleted`
  - Validates domain counts: non-negative integer, ≤50 buckets, ≤200 per bucket
- 20/20 tests passing (difficulty regression + new domain coverage)

### Frontend
- `ExamBlueprint` type: Added `byDomain` field
- `BlueprintEditor.tsx`:
  - "By difficulty / By domain" toggle (preserved axis state on toggle)
  - Dynamic domain rows from question-bank stats (excludes uncategorized)
  - Generalized %→count distribution to N buckets with even-split initialization
  - Emits null while pcts/rows are transiently misaligned (guards edge case)
  - Live availability badges, shortage detection, 100%-total validation
- `ExamBuilder.tsx`: Updated card description
- All Vietnamese text translated to English

## Test Plan
- [x] Backend: 20/20 exams.service.spec tests pass
  - Difficulty regression (existing behavior preserved)
  - Domain happy path with `where` scoping verified
  - 422 shortage, 400 on mixed-axis/empty/over-cap/non-integer
- [x] Frontend: tsc clean, ESLint clean (BlueprintEditor)
- [x] No new TS errors or pre-existing test breakage

🤖 Generated with [Claude Code](https://claude.ai/code)