### PR TITLE
fix: correct Dashboard analytics calculations (per-cert passing score + readiness)

### DIFF
--- a/backend/prisma/migrations/20260710000001_add_certification_passing_score/migration.sql
+++ b/backend/prisma/migrations/20260710000001_add_certification_passing_score/migration.sql
@@ -1,0 +1,3 @@
+-- Add per-certification passing score (percentage 0-100).
+-- Nullable: existing rows default to NULL and analytics falls back to 70.
+ALTER TABLE "certifications" ADD COLUMN "passing_score" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -297,6 +297,7 @@ model Certification {
   code        String   @unique
   description String?
   examFormat  Json?    @map("exam_format")
+  passingScore Int?    @map("passing_score")
   isActive    Boolean  @default(true) @map("is_active")
   createdAt   DateTime @default(now()) @map("created_at")
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,4 +1,10 @@
-import { PrismaClient, UserRole, QuestionType, Difficulty, QuestionStatus } from '@prisma/client';
+import {
+  PrismaClient,
+  UserRole,
+  QuestionType,
+  Difficulty,
+  QuestionStatus,
+} from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
@@ -35,11 +41,36 @@ async function main() {
 
   // 2. Create Providers
   const providersData = [
-    { name: 'AWS', slug: 'aws', website: 'https://aws.amazon.com', description: 'Amazon Web Services cloud platform' },
-    { name: 'Azure', slug: 'azure', website: 'https://azure.microsoft.com', description: 'Microsoft Azure cloud platform' },
-    { name: 'Google Cloud', slug: 'google-cloud', website: 'https://cloud.google.com', description: 'Google Cloud Platform' },
-    { name: 'CNCF', slug: 'cncf', website: 'https://www.cncf.io', description: 'Cloud Native Computing Foundation' },
-    { name: 'PMI', slug: 'pmi', website: 'https://www.pmi.org', description: 'Project Management Institute' },
+    {
+      name: 'AWS',
+      slug: 'aws',
+      website: 'https://aws.amazon.com',
+      description: 'Amazon Web Services cloud platform',
+    },
+    {
+      name: 'Azure',
+      slug: 'azure',
+      website: 'https://azure.microsoft.com',
+      description: 'Microsoft Azure cloud platform',
+    },
+    {
+      name: 'Google Cloud',
+      slug: 'google-cloud',
+      website: 'https://cloud.google.com',
+      description: 'Google Cloud Platform',
+    },
+    {
+      name: 'CNCF',
+      slug: 'cncf',
+      website: 'https://www.cncf.io',
+      description: 'Cloud Native Computing Foundation',
+    },
+    {
+      name: 'PMI',
+      slug: 'pmi',
+      website: 'https://www.pmi.org',
+      description: 'Project Management Institute',
+    },
   ];
 
   const providerMap = new Map<string, string>();
@@ -62,32 +93,61 @@ async function main() {
       providerName: 'AWS',
       name: 'Solutions Architect Associate',
       code: 'SAA-C03',
-      description: 'Design distributed systems on AWS with high availability and fault tolerance.',
-      domains: ['Design Resilient Architectures', 'Design High-Performing Architectures', 'Design Secure Applications', 'Design Cost-Optimized Architectures'],
+      description:
+        'Design distributed systems on AWS with high availability and fault tolerance.',
+      passingScore: 72, // AWS SAA-C03: 720/1000
+      domains: [
+        'Design Resilient Architectures',
+        'Design High-Performing Architectures',
+        'Design Secure Applications',
+        'Design Cost-Optimized Architectures',
+      ],
     },
     {
       id: 'az-900',
       providerName: 'Azure',
       name: 'Azure Fundamentals',
       code: 'AZ-900',
-      description: 'Foundational knowledge of cloud concepts and Azure services.',
-      domains: ['Cloud Concepts', 'Azure Architecture', 'Azure Services', 'Security & Compliance'],
+      description:
+        'Foundational knowledge of cloud concepts and Azure services.',
+      passingScore: 70, // AZ-900: 700/1000
+      domains: [
+        'Cloud Concepts',
+        'Azure Architecture',
+        'Azure Services',
+        'Security & Compliance',
+      ],
     },
     {
       id: 'gcp-pca',
       providerName: 'Google Cloud',
       name: 'Professional Cloud Architect',
       code: 'PCA',
-      description: 'Design and manage solutions using Google Cloud technologies.',
-      domains: ['Design & Plan', 'Manage & Provision', 'Security & Compliance', 'Analyzing Processes'],
+      description:
+        'Design and manage solutions using Google Cloud technologies.',
+      passingScore: 70, // GCP PCA: no official public cutoff; default 70
+      domains: [
+        'Design & Plan',
+        'Manage & Provision',
+        'Security & Compliance',
+        'Analyzing Processes',
+      ],
     },
     {
       id: 'cka',
       providerName: 'CNCF',
       name: 'Certified Kubernetes Administrator',
       code: 'CKA',
-      description: 'Demonstrate competence in Kubernetes cluster administration.',
-      domains: ['Cluster Architecture', 'Workloads & Scheduling', 'Services & Networking', 'Storage', 'Troubleshooting'],
+      description:
+        'Demonstrate competence in Kubernetes cluster administration.',
+      passingScore: 66, // CKA: 66%
+      domains: [
+        'Cluster Architecture',
+        'Workloads & Scheduling',
+        'Services & Networking',
+        'Storage',
+        'Troubleshooting',
+      ],
     },
     {
       id: 'pmp',
@@ -95,6 +155,7 @@ async function main() {
       name: 'Project Management Professional',
       code: 'PMP',
       description: 'Globally recognized project management certification.',
+      passingScore: 70, // PMP: proficiency-band scoring; default 70
       domains: ['People', 'Process', 'Business Environment'],
     },
   ];
@@ -106,13 +167,14 @@ async function main() {
 
     const createdCert = await prisma.certification.upsert({
       where: { code: cert.code },
-      update: { providerId },
+      update: { providerId, passingScore: cert.passingScore },
       create: {
         id: cert.id,
         providerId,
         name: cert.name,
         code: cert.code,
         description: cert.description,
+        passingScore: cert.passingScore,
       },
     });
 
@@ -140,7 +202,8 @@ async function main() {
   const questionsData = [
     {
       title: 'Which AWS service provides a managed relational database?',
-      explanation: 'Amazon RDS (Relational Database Service) is a managed service that makes it easy to set up, operate, and scale a relational database in the cloud.',
+      explanation:
+        'Amazon RDS (Relational Database Service) is a managed service that makes it easy to set up, operate, and scale a relational database in the cloud.',
       difficulty: Difficulty.EASY,
       domain: 'Design High-Performing Architectures',
       certificationId: 'aws-saa',
@@ -149,12 +212,15 @@ async function main() {
         { label: 'b', text: 'Amazon RDS', isCorrect: true },
         { label: 'c', text: 'Amazon SQS', isCorrect: false },
         { label: 'd', text: 'Amazon CloudFront', isCorrect: false },
-      ]
+      ],
     },
     {
-      title: 'A company needs to store infrequently accessed data with rapid retrieval. Which S3 storage class should they use?',
-      description: 'The company has regulatory requirements to retain data for 5 years but only accesses it once a quarter for audit purposes.',
-      explanation: 'S3 Standard-IA is designed for data that is accessed less frequently but requires rapid access when needed. It offers lower storage costs than S3 Standard while maintaining the same low latency.',
+      title:
+        'A company needs to store infrequently accessed data with rapid retrieval. Which S3 storage class should they use?',
+      description:
+        'The company has regulatory requirements to retain data for 5 years but only accesses it once a quarter for audit purposes.',
+      explanation:
+        'S3 Standard-IA is designed for data that is accessed less frequently but requires rapid access when needed. It offers lower storage costs than S3 Standard while maintaining the same low latency.',
       difficulty: Difficulty.MEDIUM,
       domain: 'Design Cost-Optimized Architectures',
       certificationId: 'aws-saa',
@@ -163,11 +229,13 @@ async function main() {
         { label: 'b', text: 'S3 Glacier Deep Archive', isCorrect: false },
         { label: 'c', text: 'S3 Standard-Infrequent Access', isCorrect: true },
         { label: 'd', text: 'S3 One Zone-IA', isCorrect: false },
-      ]
+      ],
     },
     {
-      title: 'Which service enables you to create a logically isolated section of the AWS Cloud?',
-      explanation: 'Amazon VPC (Virtual Private Cloud) lets you provision a logically isolated section of the AWS Cloud where you can launch AWS resources in a virtual network that you define.',
+      title:
+        'Which service enables you to create a logically isolated section of the AWS Cloud?',
+      explanation:
+        'Amazon VPC (Virtual Private Cloud) lets you provision a logically isolated section of the AWS Cloud where you can launch AWS resources in a virtual network that you define.',
       difficulty: Difficulty.EASY,
       domain: 'Design Secure Applications',
       certificationId: 'aws-saa',
@@ -176,8 +244,8 @@ async function main() {
         { label: 'b', text: 'Amazon VPC', isCorrect: true },
         { label: 'c', text: 'AWS CloudTrail', isCorrect: false },
         { label: 'd', text: 'Amazon Route 53', isCorrect: false },
-      ]
-    }
+      ],
+    },
   ];
 
   for (const q of questionsData) {
@@ -185,7 +253,7 @@ async function main() {
 
     // Check if question already exists by title
     const existingQ = await prisma.question.findFirst({
-      where: { title: q.title }
+      where: { title: q.title },
     });
 
     if (!existingQ) {
@@ -205,9 +273,9 @@ async function main() {
               content: c.text,
               isCorrect: c.isCorrect,
               sortOrder: index,
-            }))
-          }
-        }
+            })),
+          },
+        },
       });
     }
   }

--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -61,6 +61,50 @@ describe('AnalyticsService', () => {
       expect(result.totalExams).toBe(0);
       expect(result.avgScore).toBe(0);
     });
+
+    it("honors each certification's own passing score", async () => {
+      // Cert requires 75% to pass: a 72% attempt should NOT count as passed,
+      // even though it clears the default 70% fallback.
+      const attempts = [
+        {
+          score: 80,
+          totalCorrect: 8,
+          totalQuestions: 10,
+          timeSpent: 600,
+          exam: { certification: { passingScore: 75 } },
+        },
+        {
+          score: 72,
+          totalCorrect: 7,
+          totalQuestions: 10,
+          timeSpent: 500,
+          exam: { certification: { passingScore: 75 } },
+        },
+      ];
+      mockPrismaService.examAttempt.findMany.mockResolvedValue(attempts);
+
+      const result = await service.getSummary('user-1');
+
+      expect(result.totalPassed).toBe(1);
+      expect(result.passRate).toBe(50);
+    });
+
+    it('falls back to 70 when a certification has no passing score', async () => {
+      const attempts = [
+        {
+          score: 70,
+          totalCorrect: 7,
+          totalQuestions: 10,
+          timeSpent: 600,
+          exam: { certification: { passingScore: null } },
+        },
+      ];
+      mockPrismaService.examAttempt.findMany.mockResolvedValue(attempts);
+
+      const result = await service.getSummary('user-1');
+
+      expect(result.totalPassed).toBe(1);
+    });
   });
 
   describe('getReadiness', () => {

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -21,6 +21,12 @@ import {
   HistoryItemResponse,
 } from './dto/analytics-response.dto';
 
+/**
+ * Fallback pass threshold (percent) used when a certification has no
+ * explicit `passingScore` configured. Most certs sit around 70%.
+ */
+export const DEFAULT_PASSING_SCORE = 70;
+
 @Injectable()
 export class AnalyticsService {
   constructor(private readonly prisma: PrismaService) {}
@@ -45,6 +51,11 @@ export class AnalyticsService {
         totalQuestions: true,
         timeSpent: true,
         domainScores: true,
+        exam: {
+          select: {
+            certification: { select: { passingScore: true } },
+          },
+        },
       },
     });
 
@@ -61,7 +72,13 @@ export class AnalyticsService {
     }
 
     const scores = attempts.map((a) => Number(a.score ?? 0));
-    const totalPassed = scores.filter((s) => s >= 70).length;
+    // Each attempt is judged against its own certification's passing score,
+    // so an "All certifications" summary stays correct across mixed cutoffs.
+    const totalPassed = attempts.filter(
+      (a) =>
+        Number(a.score ?? 0) >=
+        (a.exam?.certification?.passingScore ?? DEFAULT_PASSING_SCORE),
+    ).length;
 
     return {
       totalExams: attempts.length,

--- a/backend/src/analytics/benchmark/benchmark.service.ts
+++ b/backend/src/analytics/benchmark/benchmark.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AttemptStatus } from '@prisma/client';
+import { DEFAULT_PASSING_SCORE } from '../analytics.service';
 
 export interface DomainBreakdownEntry {
   domainId: string;
@@ -43,7 +44,11 @@ export class BenchmarkService {
     userId: string,
     certificationId: string,
   ): Promise<BenchmarkDto> {
-    const passingScore = 70;
+    const cert = await this.prisma.certification.findUnique({
+      where: { id: certificationId },
+      select: { passingScore: true },
+    });
+    const passingScore = cert?.passingScore ?? DEFAULT_PASSING_SCORE;
 
     // Passers-only cohort: submitted + score >= passingScore, joined through Exam
     const attempts = await this.prisma.examAttempt.findMany({
@@ -74,8 +79,12 @@ export class BenchmarkService {
     ];
     if (!certIds.length) return [];
 
+    const certs = await this.prisma.certification.findMany({
+      where: { id: { in: certIds } },
+      select: { id: true, passingScore: true },
+    });
     const passingScoreMap = new Map(
-      certIds.map((id) => [id, 70]),
+      certs.map((c) => [c.id, c.passingScore ?? DEFAULT_PASSING_SCORE]),
     );
 
     // Single batch query for all attempts across relevant certs
@@ -105,7 +114,8 @@ export class BenchmarkService {
 
     return certIds.map((certificationId) => {
       const attempts = byCert.get(certificationId) ?? [];
-      const passingScore = passingScoreMap.get(certificationId) ?? 70;
+      const passingScore =
+        passingScoreMap.get(certificationId) ?? DEFAULT_PASSING_SCORE;
 
       const passers = attempts.filter(
         (a) => Number(a.score ?? 0) >= passingScore,

--- a/backend/src/certifications/dto/create-certification.dto.ts
+++ b/backend/src/certifications/dto/create-certification.dto.ts
@@ -1,5 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, IsArray } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsArray,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateCertificationDto {
   @ApiProperty({ example: 'Solutions Architect Associate' })
@@ -27,4 +36,16 @@ export class CreateCertificationDto {
   @IsString({ each: true })
   @IsOptional()
   domains?: string[];
+
+  @ApiPropertyOptional({
+    example: 72,
+    description:
+      'Passing score as a percentage (0-100). Falls back to 70 when unset.',
+  })
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  @IsOptional()
+  @Type(() => Number)
+  passingScore?: number;
 }

--- a/src/components/dashboard/ReadinessScore.tsx
+++ b/src/components/dashboard/ReadinessScore.tsx
@@ -1,49 +1,43 @@
-import { motion } from 'framer-motion';
-import { Shield, TrendingUp, AlertTriangle } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { AnalyticsSummary, DomainPerformance, ReadinessScore as ReadinessData } from '@/services/analytics';
+import { motion } from "framer-motion";
+import {
+  Shield,
+  TrendingUp,
+  AlertTriangle,
+  Loader2,
+  AlertCircle,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DomainPerformance,
+  ReadinessScore as ReadinessData,
+} from "@/services/analytics";
 
 interface Props {
-  summary: AnalyticsSummary | undefined;
-  domains: DomainPerformance[] | undefined;
   weakTopics: DomainPerformance[] | undefined;
   readiness?: ReadinessData;
+  isLoading?: boolean;
+  isError?: boolean;
   isCertSelected?: boolean;
 }
 
-function computeReadiness(summary?: AnalyticsSummary, domains?: DomainPerformance[]) {
-  if (!summary || !summary.totalExams) return { score: 0, probability: 0, level: 'low' as const };
+type ReadinessLevel = "high" | "medium" | "low";
 
-  const avgWeight = 0.4;
-  const passRateWeight = 0.3;
-  const consistencyWeight = 0.3;
-
-  const avgNorm = Math.min(summary.avgScore / 100, 1);
-  const passNorm = Math.min(summary.passRate / 100, 1);
-
-  // Consistency: how uniform are domain scores
-  let consistencyNorm = 0.5;
-  if (domains && domains.length > 1) {
-    const mean = domains.reduce((s, d) => s + d.percentage, 0) / domains.length;
-    const variance = domains.reduce((s, d) => s + (d.percentage - mean) ** 2, 0) / domains.length;
-    const stdDev = Math.sqrt(variance);
-    consistencyNorm = Math.max(0, 1 - stdDev / 50);
-  }
-
-  const score = Math.round((avgNorm * avgWeight + passNorm * passRateWeight + consistencyNorm * consistencyWeight) * 100);
-  const probability = Math.round(Math.min(100, score * 0.95 + (summary.bestScore > 80 ? 5 : 0)));
-
-  const level = score >= 75 ? 'high' : score >= 50 ? 'medium' : 'low';
-  return { score, probability, level };
+function levelFromScore(score: number): ReadinessLevel {
+  if (score >= 75) return "high";
+  if (score >= 50) return "medium";
+  return "low";
 }
 
-export default function ReadinessScore({ summary, domains, weakTopics, readiness, isCertSelected }: Props) {
-  const clientCalc = computeReadiness(summary, domains);
-  
-  const score = readiness ? readiness.readinessScore : clientCalc.score;
-  const probability = readiness ? Math.round(readiness.readinessScore * 0.95 + (summary?.bestScore && summary.bestScore > 80 ? 5 : 0)) : clientCalc.probability;
-  const level = score >= 75 ? ('high' as const) : score >= 50 ? ('medium' as const) : ('low' as const);
-
+export default function ReadinessScore({
+  weakTopics,
+  readiness,
+  isLoading,
+  isError,
+  isCertSelected,
+}: Props) {
+  // Readiness is a single backend-owned metric. The component never recomputes
+  // it client-side, so the number shown here always matches the server formula
+  // (recency-weighted score + weakest-domain confidence + exam-count factor).
   if (!isCertSelected) {
     return (
       <Card className="glass-card">
@@ -59,17 +53,67 @@ export default function ReadinessScore({ summary, domains, weakTopics, readiness
     );
   }
 
+  // Readiness query failed — surface an error instead of a perpetual spinner.
+  if (isError && !readiness) {
+    return (
+      <Card className="glass-card">
+        <CardHeader>
+          <CardTitle className="text-base font-mono flex items-center gap-2">
+            <Shield className="h-4 w-4 text-primary" /> Exam Readiness
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="h-32 flex items-center justify-center gap-2 text-sm text-destructive font-mono">
+          <AlertCircle className="h-4 w-4" /> Couldn’t load readiness
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Certification selected but the readiness query has not resolved yet.
+  if (isLoading || !readiness) {
+    return (
+      <Card className="glass-card">
+        <CardHeader>
+          <CardTitle className="text-base font-mono flex items-center gap-2">
+            <Shield className="h-4 w-4 text-primary" /> Exam Readiness
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="h-32 flex items-center justify-center gap-2 text-sm text-muted-foreground font-mono">
+          <Loader2 className="h-4 w-4 animate-spin" /> Calculating readiness…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const score = Math.min(
+    100,
+    Math.max(0, Math.round(readiness.readinessScore)),
+  );
+  const weightedAvg = Math.round(readiness.weightedAvgScore);
+  const examCount = readiness.totalExams;
+  const level = levelFromScore(score);
+
   const colorMap = {
-    high: { ring: 'hsl(var(--accent))', text: 'text-accent', label: 'Ready' },
-    medium: { ring: 'hsl(var(--warning))', text: 'text-warning', label: 'Almost There' },
-    low: { ring: 'hsl(var(--destructive))', text: 'text-destructive', label: 'Keep Practicing' },
+    high: { ring: "hsl(var(--accent))", text: "text-accent", label: "Ready" },
+    medium: {
+      ring: "hsl(var(--warning))",
+      text: "text-warning",
+      label: "Almost There",
+    },
+    low: {
+      ring: "hsl(var(--destructive))",
+      text: "text-destructive",
+      label: "Keep Practicing",
+    },
   };
   const c = colorMap[level];
 
   const circumference = 2 * Math.PI * 54;
   const strokeOffset = circumference - (score / 100) * circumference;
 
-  const recommendedDomains = (weakTopics ?? []).filter(d => d.percentage < 70).slice(0, 3);
+  const recommendedDomains = (weakTopics ?? [])
+    .filter((d) => d.percentage < 70)
+    .slice(0, 3);
 
   return (
     <Card className="glass-card">
@@ -82,41 +126,62 @@ export default function ReadinessScore({ summary, domains, weakTopics, readiness
         {/* Circular gauge */}
         <div className="relative w-32 h-32 shrink-0">
           <svg viewBox="0 0 120 120" className="w-full h-full -rotate-90">
-            <circle cx="60" cy="60" r="54" fill="none" stroke="hsl(var(--secondary))" strokeWidth="8" />
+            <circle
+              cx="60"
+              cy="60"
+              r="54"
+              fill="none"
+              stroke="hsl(var(--secondary))"
+              strokeWidth="8"
+            />
             <motion.circle
-              cx="60" cy="60" r="54" fill="none"
+              cx="60"
+              cy="60"
+              r="54"
+              fill="none"
               stroke={c.ring}
               strokeWidth="8"
               strokeLinecap="round"
               strokeDasharray={circumference}
               initial={{ strokeDashoffset: circumference }}
               animate={{ strokeDashoffset: strokeOffset }}
-              transition={{ duration: 1.2, ease: 'easeOut' }}
+              transition={{ duration: 1.2, ease: "easeOut" }}
             />
           </svg>
           <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <span className={`text-2xl font-bold font-mono ${c.text}`}>{score}%</span>
+            <span className={`text-2xl font-bold font-mono ${c.text}`}>
+              {score}%
+            </span>
             <span className="text-[10px] text-muted-foreground">{c.label}</span>
           </div>
         </div>
 
         <div className="flex-1 space-y-4 min-w-0">
-          {/* Pass probability */}
+          {/* Recency-weighted average score — a real, server-computed metric */}
           <div className="flex items-center gap-3">
             <TrendingUp className="h-4 w-4 text-primary shrink-0" />
             <div className="flex-1">
-              <div className="text-xs text-muted-foreground mb-1">Pass Probability</div>
+              <div className="text-xs text-muted-foreground mb-1">
+                Recent weighted avg score
+                <span className="ml-1 text-muted-foreground/60">
+                  ({examCount} {examCount === 1 ? "exam" : "exams"})
+                </span>
+              </div>
               <div className="flex items-center gap-2">
                 <div className="flex-1 h-2 rounded-full bg-secondary overflow-hidden">
                   <motion.div
                     className="h-full rounded-full"
                     style={{ backgroundColor: c.ring }}
                     initial={{ width: 0 }}
-                    animate={{ width: `${probability}%` }}
-                    transition={{ duration: 1, ease: 'easeOut', delay: 0.3 }}
+                    animate={{
+                      width: `${Math.min(100, Math.max(0, weightedAvg))}%`,
+                    }}
+                    transition={{ duration: 1, ease: "easeOut", delay: 0.3 }}
                   />
                 </div>
-                <span className={`text-sm font-mono font-bold ${c.text}`}>{probability}%</span>
+                <span className={`text-sm font-mono font-bold ${c.text}`}>
+                  {weightedAvg}%
+                </span>
               </div>
             </div>
           </div>
@@ -126,10 +191,12 @@ export default function ReadinessScore({ summary, domains, weakTopics, readiness
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <AlertTriangle className="h-3.5 w-3.5 text-warning" />
-                <span className="text-xs text-muted-foreground">Focus Areas</span>
+                <span className="text-xs text-muted-foreground">
+                  Focus Areas
+                </span>
               </div>
               <div className="flex flex-wrap gap-1.5">
-                {recommendedDomains.map(d => (
+                {recommendedDomains.map((d) => (
                   <span
                     key={d.domain}
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-warning/10 text-warning text-[11px] font-mono"

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -74,7 +74,11 @@ const Dashboard = () => {
     enabled: isAuthenticated,
   });
 
-  const { data: readinessData } = useQuery({
+  const {
+    data: readinessData,
+    isLoading: readinessLoading,
+    isError: readinessError,
+  } = useQuery({
     queryKey: ["readiness", certFilter],
     queryFn: () => getReadiness(certFilter),
     enabled: isAuthenticated && !!certFilter,
@@ -355,10 +359,10 @@ const Dashboard = () => {
         {/* Readiness + Mistake Patterns */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <ReadinessScore
-            summary={summary}
-            domains={domains ?? undefined}
             weakTopics={weakTopics ?? undefined}
             readiness={readinessData}
+            isLoading={readinessLoading}
+            isError={readinessError}
             isCertSelected={!!certFilter}
           />
           <MistakePatternChart history={history} patterns={mistakePatterns} />


### PR DESCRIPTION
## What changed

Fixes incorrect metric calculations on the Dashboard, found while auditing the analytics pipeline.

### 1. Per-certification passing score (was hardcoded 70%)
- **Schema + migration**: new nullable `Certification.passingScore` column (`20260710000001_add_certification_passing_score`). Falls back to `70` when unset, so existing rows keep working.
- **`getSummary`**: `totalPassed` / `passRate` now judge **each attempt against its own certification's cutoff**, so the "All certifications" summary stays correct across mixed thresholds (previously every cert was scored at 70%).
- **`benchmark.service`**: `getBenchmark` and `getAllBenchmarks` fetch real passing scores instead of the placeholder `70`.
- **DTO + seed**: `passingScore` is settable via create/update certification; seeded with public values — SAA-C03=72, AZ-900=70, PCA=70, CKA=66, PMP=70.

### 2. Readiness metric
- Removed the **divergent client-side readiness formula** — the component now trusts the single backend score and shows explicit **loading / error** states (no more perpetual spinner on query failure).
- Replaced the **fabricated "Pass Probability"** (`readinessScore * 0.95 + …`) with the real **recency-weighted average score** returned by the backend.

## Why
- "Passed" / "Pass Rate" were wrong for any certification whose real cutoff ≠ 70%.
- Two different readiness formulas (frontend fallback vs backend) produced inconsistent numbers; the "Pass Probability" bar had no statistical basis.

## Reviewer notes
- `DEFAULT_PASSING_SCORE = 70` is exported from `analytics.service.ts` and reused by `benchmark.service.ts` (no import cycle).
- Migration is **additive + nullable** — safe to deploy before backfilling values.

## Operational follow-up (requires DB)
Dev DB has diverged migrations, so this was **not** auto-applied. When ready:
```bash
cd backend
npx prisma migrate deploy   # apply passing_score column
npm run seed                # populate passingScore for existing certs
```

## Test plan
- [x] Backend build (`nest build`) — pass
- [x] `analytics` + `certifications` unit tests — 28/28 pass (incl. 2 new cases locking per-cert threshold + null fallback)
- [x] Frontend `tsc --noEmit` — 0 errors
- [x] Lint (changed files) — clean
- [ ] Apply migration + seed on a real DB and verify Dashboard "Passed"/readiness reflect per-cert cutoffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)