### PR TITLE
fix: stop history.replaceState() rate-limit crash on auth redirects

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuthStore } from "../stores/auth.store";
 
@@ -9,11 +10,20 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
     const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
     const location = useLocation();
 
+    // Keep the `state` object identity stable. `<Navigate>` re-runs its internal
+    // effect (which calls history.replaceState) every time the `state` prop
+    // changes identity. An inline `{{ from: location }}` is a brand-new object on
+    // each render, so while AnimatePresence (mode="wait") keeps this redirecting
+    // subtree mounted during the page exit animation, every animation frame
+    // re-fired replaceState — tripping WebKit's "more than 100 times per 10
+    // seconds" SecurityError and crashing into the ErrorBoundary.
+    const redirectState = useMemo(() => ({ from: location }), [location]);
+
     if (!isAuthenticated) {
         // Redirect them to the /auth page, but save the current location they were
         // trying to go to when they were redirected. This allows us to send them
         // along to that page after they login, which is a nicer user experience.
-        return <Navigate to="/auth" state={{ from: location }} replace />;
+        return <Navigate to="/auth" state={redirectState} replace />;
     }
 
     return <>{children}</>;

--- a/src/pages/TrainingHub.tsx
+++ b/src/pages/TrainingHub.tsx
@@ -8,13 +8,19 @@ import { WeaknessMode } from '@/components/training/WeaknessMode';
 import { DailyReviewMode } from '@/components/training/DailyReviewMode';
 import { FlashcardReviewMode } from '@/components/training/FlashcardReviewMode';
 
+// Module-level constant so the `state` object identity stays stable across
+// renders. A new inline object would make `<Navigate>` re-fire its effect (and
+// history.replaceState) on every render — under AnimatePresence's exit
+// animation that bursts past WebKit's replaceState rate limit and crashes.
+const AUTH_REDIRECT_STATE = { from: '/training' };
+
 export default function TrainingHub() {
   const { isAuthenticated } = useAuthStore();
   const [certFilter, setCertFilter] = useState<string>('');
   const [activeMode, setActiveMode] = useState<'hub' | 'weakness' | 'daily' | 'flashcard'>('hub');
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" state={{ from: '/training' }} replace />;
+    return <Navigate to="/auth" state={AUTH_REDIRECT_STATE} replace />;
   }
 
   const goBackItems = () => setActiveMode('hub');


### PR DESCRIPTION
## Summary

Fixes a `SecurityError` crash in WebKit/in-app browsers ("Attempt to use history.replaceState() more than 100 times per 10 seconds") that manifests as "Something went wrong" in the ErrorBoundary.

## Root Cause

React-router's `<Navigate>` component stores `state` in the dependency array of an effect that calls `history.replaceState()`. An inline object passed to `state` gets a fresh identity on every render, causing the effect to re-run repeatedly.

Under `<AnimatePresence mode="wait">` (in App.tsx), when a redirect occurs, the leaving route's subtree stays mounted during the ~250ms exit animation and re-renders ~60fps. This causes `<Navigate>` to fire `history.replaceState()` 60+ times per second, exceeding WebKit's ~10 calls/second rate limit and crashing.

Affected routes:
- Logged-out users accessing protected routes via `<ProtectedRoute>`
- Logged-out users accessing `/training` directly

## Fix

Stabilize `state` object identity:

1. **ProtectedRoute.tsx**: Use `useMemo` to keep `{ from: location }` stable across renders (only recreated when `location` changes)
2. **TrainingHub.tsx**: Move `state` object to module-level constant

This ensures `<Navigate>`'s effect runs exactly once, calling `history.replaceState()` a single time instead of every render.

## Testing

- ✅ ESLint: pass on both modified files
- ✅ TypeScript: no new type errors introduced
- ✅ No UX changes — redirects behave identically