### PR TITLE
feat: Enterprise Entrance Exam — P1 Recruiting Workflow (ATS-lite)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -16,9 +16,7 @@ module.exports = {
   testRegex: '.*\\.spec\\.ts$',
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
-  moduleNameMapper: {
-    '^uuid$': 'uuid',
-  },
+  moduleNameMapper: {},
   setupFiles: ['<rootDir>/../jest-setup.js'],
   transform: {
     '^.+\\.tsx?$': [
@@ -46,6 +44,7 @@ module.exports = {
     ],
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(@nestjs|@prisma|class-transformer|class-validator)/)',
+    // Transform uuid (ESM-only in v9+) and other packages that ship as ESM
+    'node_modules/(?!(@nestjs|@prisma|class-transformer|class-validator|uuid)/)',
   ],
 };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4162,6 +4162,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
       "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -11800,6 +11801,7 @@
       "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "devOptional": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"

--- a/backend/prisma/migrations/20260712000001_p1_recruiting_workflow/migration.sql
+++ b/backend/prisma/migrations/20260712000001_p1_recruiting_workflow/migration.sql
@@ -1,0 +1,42 @@
+-- P1: Recruiting Workflow (ATS-lite)
+
+-- AlterEnum: OrgRole — add RECRUITER
+ALTER TYPE "OrgRole" ADD VALUE 'RECRUITER';
+
+-- CreateEnum: CandidateStage
+CREATE TYPE "CandidateStage" AS ENUM ('APPLIED', 'SCREENING', 'SHORTLISTED', 'REJECTED', 'HIRED');
+
+-- CreateTable: JobRole
+CREATE TABLE "job_roles" (
+    "id" TEXT NOT NULL,
+    "org_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "department" TEXT,
+    "description" TEXT,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "job_roles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "job_roles_org_id_idx" ON "job_roles"("org_id");
+
+-- AddForeignKey
+ALTER TABLE "job_roles" ADD CONSTRAINT "job_roles_org_id_fkey" FOREIGN KEY ("org_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable: Assessment — add job_role_id
+ALTER TABLE "assessments"
+    ADD COLUMN "job_role_id" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "assessments" ADD CONSTRAINT "assessments_job_role_id_fkey" FOREIGN KEY ("job_role_id") REFERENCES "job_roles"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AlterTable: CandidateInvite — add ATS fields
+ALTER TABLE "candidate_invites"
+    ADD COLUMN "stage" "CandidateStage" NOT NULL DEFAULT 'APPLIED',
+    ADD COLUMN "rating" INTEGER,
+    ADD COLUMN "recruiter_note" TEXT,
+    ADD COLUMN "decided_by" TEXT,
+    ADD COLUMN "decided_at" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -158,7 +158,16 @@ enum OrgRole {
   OWNER
   ADMIN
   MANAGER
+  RECRUITER
   MEMBER
+}
+
+enum CandidateStage {
+  APPLIED
+  SCREENING
+  SHORTLISTED
+  REJECTED
+  HIRED
 }
 
 /// RFC-011 / Decision D5: squads are Organization rows with kind = SQUAD.
@@ -816,6 +825,7 @@ model Organization {
   privateQuestions OrgQuestion[]
   catalogItems     ExamCatalogItem[]
   assessments      Assessment[]
+  jobRoles         JobRole[]
   joinLinks        OrgJoinLink[]
   learningTracks   LearningTrack[]
   generationJobs   QuestionGenerationJob[] // RFC-012: Track org-level LLM costs
@@ -1011,6 +1021,25 @@ model OrgExamAssignment {
   @@map("org_exam_assignments")
 }
 
+// ─── JOB ROLES (P1 Recruiting Workflow) ───
+
+model JobRole {
+  id          String   @id @default(uuid())
+  orgId       String   @map("org_id")
+  title       String
+  department  String?
+  description String?
+  isActive    Boolean  @default(true) @map("is_active")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  organization Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  assessments  Assessment[]
+
+  @@index([orgId])
+  @@map("job_roles")
+}
+
 // ─── CANDIDATE ASSESSMENT (External Invitations) ───
 
 model Assessment {
@@ -1031,11 +1060,13 @@ model Assessment {
   detectTabSwitch    Boolean                  @default(false) @map("detect_tab_switch")
   blockCopyPaste     Boolean                  @default(false) @map("block_copy_paste")
   linkExpiryHours    Int                      @default(72) @map("link_expiry_hours")
+  jobRoleId          String?                  @map("job_role_id")
   createdBy          String                   @map("created_by")
   createdAt          DateTime                 @default(now()) @map("created_at")
   updatedAt          DateTime                 @updatedAt @map("updated_at")
 
   organization     Organization          @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  jobRole          JobRole?              @relation(fields: [jobRoleId], references: [id])
   candidateInvites CandidateInvite[]
   questions        AssessmentQuestion[]
 
@@ -1075,6 +1106,15 @@ model CandidateInvite {
   expiresAt        DateTime               @map("expires_at")
   /// POOL mode: snapshot of drawn OrgQuestion IDs for this invite (idempotent re-load)
   drawnQuestionIds String[]               @default([]) @map("drawn_question_ids")
+  /// P1: Recruiting pipeline stage
+  stage            CandidateStage         @default(APPLIED) @map("stage")
+  /// P1: 1-5 star rating by recruiter
+  rating           Int?
+  /// P1: Internal recruiter note
+  recruiterNote    String?                @map("recruiter_note")
+  /// P1: Who made the final hire/reject decision
+  decidedBy        String?                @map("decided_by")
+  decidedAt        DateTime?              @map("decided_at")
   createdAt        DateTime               @default(now()) @map("created_at")
 
   assessment Assessment        @relation(fields: [assessmentId], references: [id], onDelete: Cascade)

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { OrganizationsModule } from './organizations/organizations.module';
 import { OrgQuestionsModule } from './org-questions/org-questions.module';
 import { ExamCatalogModule } from './exam-catalog/exam-catalog.module';
 import { AssessmentsModule } from './assessments/assessments.module';
+import { JobRolesModule } from './job-roles/job-roles.module';
 import { OrgAnalyticsModule } from './org-analytics/org-analytics.module';
 import { QueuesModule } from './queues/queues.module';
 import { MasteryModule } from './mastery/mastery.module';
@@ -72,6 +73,7 @@ import { KnowledgeGraphModule } from './knowledge-graph/knowledge-graph.module';
     OrgQuestionsModule,
     ExamCatalogModule,
     AssessmentsModule,
+    JobRolesModule,
     OrgAnalyticsModule,
     QueuesModule,
     MasteryModule,

--- a/backend/src/assessments/assessments-p1.service.spec.ts
+++ b/backend/src/assessments/assessments-p1.service.spec.ts
@@ -4,12 +4,6 @@
  *   - getResults with percentile calculation
  */
 
-// Mock OrganizationsService before any imports to prevent its transitive
-// dependency on uuid (ESM-only) from breaking Jest's CJS transform.
-jest.mock('../organizations/organizations.service');
-// Same for MailService — avoids any ESM deps it may pull in.
-jest.mock('../mail/mail.service');
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { AssessmentsService } from './assessments.service';

--- a/backend/src/assessments/assessments-p1.service.spec.ts
+++ b/backend/src/assessments/assessments-p1.service.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * P1 Recruiting Workflow — unit tests for new service methods:
+ *   - updateCandidateDecision (stage, rating, recruiterNote)
+ *   - getResults with percentile calculation
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { AssessmentsService } from './assessments.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { OrganizationsService } from '../organizations/organizations.service';
+import { MailService } from '../mail/mail.service';
+
+// ── Minimal prisma mock ──────────────────────────────────────────────────────
+
+const mockAssessment = {
+  id: 'a1',
+  orgId: 'org-1',
+  title: 'Test Assessment',
+  passingScore: 70,
+  status: 'ACTIVE',
+  selectionMode: 'MANUAL',
+  selectionConfig: null,
+  questionCount: 10,
+  timeLimit: 60,
+  jobRoleId: null,
+  jobRole: null,
+};
+
+const mockInvite = {
+  id: 'inv-1',
+  assessmentId: 'a1',
+  candidateEmail: 'test@example.com',
+  status: 'SUBMITTED',
+  score: 80,
+  stage: 'APPLIED',
+  rating: null,
+  recruiterNote: null,
+  decidedBy: null,
+  decidedAt: null,
+};
+
+const mockPrisma: any = {
+  assessment: {
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  candidateInvite: {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    aggregate: jest.fn(),
+    create: jest.fn(),
+    createMany: jest.fn(),
+  },
+  orgQuestion: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  $transaction: jest.fn((fn: any) => fn(mockPrisma)),
+};
+
+const mockOrgsService = {
+  resolveOrgId: jest.fn().mockResolvedValue('org-1'),
+};
+
+const mockMailService = { sendAssessmentInvite: jest.fn() };
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AssessmentsService — P1 Recruiting', () => {
+  let service: AssessmentsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AssessmentsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: OrganizationsService, useValue: mockOrgsService },
+        { provide: MailService, useValue: mockMailService },
+      ],
+    }).compile();
+    service = module.get<AssessmentsService>(AssessmentsService);
+  });
+
+  // ── updateCandidateDecision ─────────────────────────────────────────────
+
+  describe('updateCandidateDecision', () => {
+    beforeEach(() => {
+      mockPrisma.assessment.findFirst.mockResolvedValue(mockAssessment);
+      mockPrisma.candidateInvite.findFirst.mockResolvedValue(mockInvite);
+      mockPrisma.candidateInvite.update.mockResolvedValue({
+        ...mockInvite,
+        stage: 'SHORTLISTED',
+      });
+    });
+
+    it('throws NotFoundException if assessment not found', async () => {
+      mockPrisma.assessment.findFirst.mockResolvedValue(null);
+      await expect(
+        service.updateCandidateDecision('org-1', 'a1', 'inv-1', { stage: 'SCREENING' }, 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException if invite not found', async () => {
+      mockPrisma.candidateInvite.findFirst.mockResolvedValue(null);
+      await expect(
+        service.updateCandidateDecision('org-1', 'a1', 'inv-1', { stage: 'SCREENING' }, 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('updates stage to SHORTLISTED and sets decidedBy/decidedAt', async () => {
+      await service.updateCandidateDecision(
+        'org-1', 'a1', 'inv-1', { stage: 'SHORTLISTED' }, 'recruiter-1',
+      );
+      expect(mockPrisma.candidateInvite.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            stage: 'SHORTLISTED',
+            decidedBy: 'recruiter-1',
+            decidedAt: expect.any(Date),
+          }),
+        }),
+      );
+    });
+
+    it('updates stage to SCREENING without setting decidedBy', async () => {
+      await service.updateCandidateDecision(
+        'org-1', 'a1', 'inv-1', { stage: 'SCREENING' }, 'user-1',
+      );
+      const call = mockPrisma.candidateInvite.update.mock.calls[0][0];
+      expect(call.data.stage).toBe('SCREENING');
+      expect(call.data.decidedBy).toBeUndefined();
+    });
+
+    it('updates rating without changing stage', async () => {
+      await service.updateCandidateDecision(
+        'org-1', 'a1', 'inv-1', { rating: 4 }, 'user-1',
+      );
+      const call = mockPrisma.candidateInvite.update.mock.calls[0][0];
+      expect(call.data.rating).toBe(4);
+      expect(call.data.stage).toBeUndefined();
+    });
+
+    it('updates recruiterNote', async () => {
+      await service.updateCandidateDecision(
+        'org-1', 'a1', 'inv-1', { recruiterNote: 'Great candidate' }, 'user-1',
+      );
+      const call = mockPrisma.candidateInvite.update.mock.calls[0][0];
+      expect(call.data.recruiterNote).toBe('Great candidate');
+    });
+  });
+
+  // ── getResults with percentile ──────────────────────────────────────────
+
+  describe('getResults — percentile', () => {
+    it('calculates correct percentile for 3 submitted candidates', async () => {
+      const invites = [
+        { ...mockInvite, id: 'inv-1', status: 'SUBMITTED', score: 90, stage: 'APPLIED' },
+        { ...mockInvite, id: 'inv-2', status: 'SUBMITTED', score: 70, stage: 'APPLIED' },
+        { ...mockInvite, id: 'inv-3', status: 'SUBMITTED', score: 50, stage: 'APPLIED' },
+      ];
+      mockPrisma.assessment.findFirst.mockResolvedValue({
+        ...mockAssessment, jobRole: null,
+      });
+      mockPrisma.candidateInvite.findMany.mockResolvedValue(invites);
+
+      const result = await service.getResults('my-org', 'a1');
+
+      // score=90: 2 below → percentile = round(2/2*100) = 100
+      expect(result.candidates.find((c) => c.id === 'inv-1')?.percentile).toBe(100);
+      // score=70: 1 below → percentile = round(1/2*100) = 50
+      expect(result.candidates.find((c) => c.id === 'inv-2')?.percentile).toBe(50);
+      // score=50: 0 below → percentile = round(0/2*100) = 0
+      expect(result.candidates.find((c) => c.id === 'inv-3')?.percentile).toBe(0);
+    });
+
+    it('returns percentile 100 for single submitted candidate', async () => {
+      const invites = [
+        { ...mockInvite, id: 'inv-1', status: 'SUBMITTED', score: 75, stage: 'APPLIED' },
+      ];
+      mockPrisma.assessment.findFirst.mockResolvedValue({
+        ...mockAssessment, jobRole: null,
+      });
+      mockPrisma.candidateInvite.findMany.mockResolvedValue(invites);
+
+      const result = await service.getResults('my-org', 'a1');
+      expect(result.candidates[0].percentile).toBe(100);
+    });
+
+    it('returns null percentile for non-submitted candidates', async () => {
+      const invites = [
+        { ...mockInvite, id: 'inv-1', status: 'INVITED', score: null, stage: 'APPLIED' },
+      ];
+      mockPrisma.assessment.findFirst.mockResolvedValue({
+        ...mockAssessment, jobRole: null,
+      });
+      mockPrisma.candidateInvite.findMany.mockResolvedValue(invites);
+
+      const result = await service.getResults('my-org', 'a1');
+      expect(result.candidates[0].percentile).toBeNull();
+    });
+
+    it('includes jobRole in assessment response', async () => {
+      const jobRole = { id: 'jr-1', title: 'Engineer', department: 'Engineering' };
+      mockPrisma.assessment.findFirst.mockResolvedValue({
+        ...mockAssessment, jobRole,
+      });
+      mockPrisma.candidateInvite.findMany.mockResolvedValue([]);
+
+      const result = await service.getResults('my-org', 'a1');
+      expect(result.assessment.jobRole).toEqual(jobRole);
+    });
+  });
+});

--- a/backend/src/assessments/assessments-p1.service.spec.ts
+++ b/backend/src/assessments/assessments-p1.service.spec.ts
@@ -3,6 +3,13 @@
  *   - updateCandidateDecision (stage, rating, recruiterNote)
  *   - getResults with percentile calculation
  */
+
+// Mock OrganizationsService before any imports to prevent its transitive
+// dependency on uuid (ESM-only) from breaking Jest's CJS transform.
+jest.mock('../organizations/organizations.service');
+// Same for MailService — avoids any ESM deps it may pull in.
+jest.mock('../mail/mail.service');
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { AssessmentsService } from './assessments.service';

--- a/backend/src/assessments/assessments.controller.ts
+++ b/backend/src/assessments/assessments.controller.ts
@@ -16,6 +16,7 @@ import { AssessmentsService } from './assessments.service';
 import { CreateAssessmentDto } from './dto/create-assessment.dto';
 import { UpdateAssessmentDto } from './dto/update-assessment.dto';
 import { InviteCandidateDto } from './dto/invite-candidate.dto';
+import { UpdateCandidateDecisionDto } from './dto/update-candidate-decision.dto';
 import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
 import { OrgRoles } from '../common/decorators/org-roles.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -24,7 +25,7 @@ import { AssessmentStatus } from '@prisma/client';
 
 @Controller('organizations/:orgId/assessments')
 @UseGuards(JwtAuthGuard, OrgRoleGuard)
-@OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+@OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'RECRUITER')
 export class AssessmentsController {
   constructor(private readonly service: AssessmentsService) {}
 
@@ -115,6 +116,17 @@ export class AssessmentsController {
       'attachment; filename="assessment-results.csv"',
     );
     res.send(csv);
+  }
+
+  @Patch(':aid/candidates/:inviteId')
+  updateCandidateDecision(
+    @Param('orgId') orgId: string,
+    @Param('aid') aid: string,
+    @Param('inviteId') inviteId: string,
+    @Body() dto: UpdateCandidateDecisionDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.service.updateCandidateDecision(orgId, aid, inviteId, dto, user.id);
   }
 
   @Delete(':aid')

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -6,10 +6,11 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { OrganizationsService } from '../organizations/organizations.service';
 import { MailService } from '../mail/mail.service';
-import { AssessmentSelectionMode, AssessmentStatus, Prisma } from '@prisma/client';
+import { AssessmentSelectionMode, AssessmentStatus, CandidateStage, Prisma } from '@prisma/client';
 import { CreateAssessmentDto } from './dto/create-assessment.dto';
 import { UpdateAssessmentDto } from './dto/update-assessment.dto';
 import { InviteCandidateDto } from './dto/invite-candidate.dto';
+import { UpdateCandidateDecisionDto } from './dto/update-candidate-decision.dto';
 import { randomUUID } from 'crypto';
 
 // ─── Blueprint / Pool config shapes ─────────────────────────────────────────
@@ -202,6 +203,7 @@ export class AssessmentsService {
         orderBy: { createdAt: 'desc' },
         include: {
           _count: { select: { candidateInvites: true, questions: true } },
+          jobRole: { select: { id: true, title: true, department: true } },
         },
       }),
       this.prisma.assessment.count({ where: { orgId } }),
@@ -248,6 +250,7 @@ export class AssessmentsService {
             orgId,
             title: dto.title,
             description: dto.description,
+            jobRoleId: dto.jobRoleId ?? null,
             selectionMode: AssessmentSelectionMode.BLUEPRINT,
             selectionConfig: dto.selectionConfig,
             questionCount: questionRows.length,
@@ -297,6 +300,7 @@ export class AssessmentsService {
             orgId,
             title: dto.title,
             description: dto.description,
+            jobRoleId: dto.jobRoleId ?? null,
             selectionMode: AssessmentSelectionMode.POOL,
             selectionConfig: dto.selectionConfig,
             questionCount: config.drawCount,
@@ -323,6 +327,7 @@ export class AssessmentsService {
           orgId,
           title: dto.title,
           description: dto.description,
+          jobRoleId: dto.jobRoleId ?? null,
           selectionMode: AssessmentSelectionMode.MANUAL,
           questionCount: questions.length,
           timeLimit: dto.timeLimit,
@@ -598,6 +603,7 @@ export class AssessmentsService {
     const orgId = await this.orgsService.resolveOrgId(slugOrId);
     const assessment = await this.prisma.assessment.findFirst({
       where: { id: assessmentId, orgId },
+      include: { jobRole: true },
     });
     if (!assessment) throw new NotFoundException('Assessment not found');
 
@@ -606,12 +612,29 @@ export class AssessmentsService {
       orderBy: [{ score: 'desc' }, { createdAt: 'asc' }],
     });
 
+    // Compute percentile rank for each submitted candidate
+    const submitted = invites.filter((i) => i.status === 'SUBMITTED');
+    const submittedCount = submitted.length;
+    const candidates = invites.map((invite) => {
+      if (invite.status !== 'SUBMITTED' || invite.score == null) {
+        return { ...invite, percentile: null };
+      }
+      const score = Number(invite.score);
+      const below = submitted.filter(
+        (s) => s.score != null && Number(s.score) < score,
+      ).length;
+      const percentile =
+        submittedCount > 1
+          ? Math.round((below / (submittedCount - 1)) * 100)
+          : 100;
+      return { ...invite, percentile };
+    });
+
     const total = invites.length;
     const started = invites.filter((i) => i.status !== 'INVITED').length;
-    const submitted = invites.filter((i) => i.status === 'SUBMITTED').length;
     const passed =
       assessment.passingScore != null
-        ? invites.filter(
+        ? submitted.filter(
             (i) =>
               i.score != null && Number(i.score) >= assessment.passingScore!,
           ).length
@@ -619,9 +642,48 @@ export class AssessmentsService {
 
     return {
       assessment,
-      funnel: { total, started, submitted, passed },
-      candidates: invites,
+      funnel: { total, started, submitted: submittedCount, passed },
+      candidates,
     };
+  }
+
+  async updateCandidateDecision(
+    slugOrId: string,
+    assessmentId: string,
+    inviteId: string,
+    dto: UpdateCandidateDecisionDto,
+    decidedByUserId: string,
+  ) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    const assessment = await this.prisma.assessment.findFirst({
+      where: { id: assessmentId, orgId },
+    });
+    if (!assessment) throw new NotFoundException('Assessment not found');
+
+    const invite = await this.prisma.candidateInvite.findFirst({
+      where: { id: inviteId, assessmentId },
+    });
+    if (!invite) throw new NotFoundException('Candidate invite not found');
+
+    const isStageDecision =
+      dto.stage === CandidateStage.HIRED ||
+      dto.stage === CandidateStage.REJECTED ||
+      dto.stage === CandidateStage.SHORTLISTED;
+
+    return this.prisma.candidateInvite.update({
+      where: { id: inviteId },
+      data: {
+        ...(dto.stage !== undefined && { stage: dto.stage }),
+        ...(dto.rating !== undefined && { rating: dto.rating }),
+        ...(dto.recruiterNote !== undefined && {
+          recruiterNote: dto.recruiterNote,
+        }),
+        ...(isStageDecision && {
+          decidedBy: decidedByUserId,
+          decidedAt: new Date(),
+        }),
+      },
+    });
   }
 
   async exportCsv(slugOrId: string, assessmentId: string): Promise<string> {

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -670,38 +670,43 @@ export class AssessmentsService {
       dto.stage === CandidateStage.REJECTED ||
       dto.stage === CandidateStage.SHORTLISTED;
 
+    const data = {
+      ...(dto.stage !== undefined && { stage: dto.stage }),
+      ...(dto.rating !== undefined && { rating: dto.rating }),
+      ...(dto.recruiterNote !== undefined && { recruiterNote: dto.recruiterNote }),
+      ...(isStageDecision && { decidedBy: decidedByUserId, decidedAt: new Date() }),
+    };
+
+    // No-op guard — avoid hitting the DB if nothing changed
+    if (Object.keys(data).length === 0) return invite;
+
     return this.prisma.candidateInvite.update({
       where: { id: inviteId },
-      data: {
-        ...(dto.stage !== undefined && { stage: dto.stage }),
-        ...(dto.rating !== undefined && { rating: dto.rating }),
-        ...(dto.recruiterNote !== undefined && {
-          recruiterNote: dto.recruiterNote,
-        }),
-        ...(isStageDecision && {
-          decidedBy: decidedByUserId,
-          decidedAt: new Date(),
-        }),
-      },
+      data,
     });
   }
 
   async exportCsv(slugOrId: string, assessmentId: string): Promise<string> {
     const results = await this.getResults(slugOrId, assessmentId);
     const header =
-      'Name,Email,Status,Score (%),Total Correct,Total Questions,Time Spent (s),Tab Switches,Started At,Submitted At';
+      'Name,Email,Attempt Status,Stage,Score (%),Percentile,Total Correct,Total Questions,Rating,Time Spent (s),Tab Switches,Started At,Submitted At,Recruiter Note';
+    const esc = (v: string) => `"${v.replace(/"/g, '""')}"`;
     const rows = results.candidates.map((c) =>
       [
-        c.candidateName ?? '',
-        c.candidateEmail,
+        esc(c.candidateName ?? ''),
+        esc(c.candidateEmail),
         c.status,
+        c.stage ?? 'APPLIED',
         c.score != null ? Number(c.score).toFixed(2) : '',
+        c.percentile != null ? c.percentile : '',
         c.totalCorrect ?? '',
         c.totalQuestions ?? '',
+        c.rating ?? '',
         c.timeSpent ?? '',
         c.tabSwitchCount ?? 0,
         c.startedAt?.toISOString() ?? '',
         c.submittedAt?.toISOString() ?? '',
+        esc(c.recruiterNote ?? ''),
       ].join(','),
     );
     return [header, ...rows].join('\n');

--- a/backend/src/assessments/dto/create-assessment.dto.ts
+++ b/backend/src/assessments/dto/create-assessment.dto.ts
@@ -73,6 +73,10 @@ export class CreateAssessmentDto {
   linkExpiryHours?: number;
 
   @IsOptional()
+  @IsString()
+  jobRoleId?: string;
+
+  @IsOptional()
   @IsEnum(AssessmentSelectionMode)
   selectionMode?: AssessmentSelectionMode;
 

--- a/backend/src/assessments/dto/update-candidate-decision.dto.ts
+++ b/backend/src/assessments/dto/update-candidate-decision.dto.ts
@@ -1,0 +1,25 @@
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { CandidateStage } from '@prisma/client';
+
+export class UpdateCandidateDecisionDto {
+  @IsOptional()
+  @IsEnum(CandidateStage)
+  stage?: CandidateStage;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating?: number;
+
+  @IsOptional()
+  @IsString()
+  recruiterNote?: string;
+}

--- a/backend/src/job-roles/dto/create-job-role.dto.ts
+++ b/backend/src/job-roles/dto/create-job-role.dto.ts
@@ -1,0 +1,16 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateJobRoleDto {
+  @IsString()
+  @MaxLength(200)
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  department?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/backend/src/job-roles/dto/update-job-role.dto.ts
+++ b/backend/src/job-roles/dto/update-job-role.dto.ts
@@ -1,0 +1,21 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateJobRoleDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  department?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/backend/src/job-roles/job-roles.controller.ts
+++ b/backend/src/job-roles/job-roles.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
+import { JobRolesService } from './job-roles.service';
+import { CreateJobRoleDto } from './dto/create-job-role.dto';
+import { UpdateJobRoleDto } from './dto/update-job-role.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
+import { OrgRoles } from '../common/decorators/org-roles.decorator';
+
+@Controller('organizations/:orgId/job-roles')
+@UseGuards(JwtAuthGuard, OrgRoleGuard)
+export class JobRolesController {
+  constructor(private readonly service: JobRolesService) {}
+
+  @Get()
+  // All org members can view job roles (used in AssessmentBuilder selectors)
+  list(@Param('orgId') orgId: string) {
+    return this.service.list(orgId);
+  }
+
+  @Post()
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'RECRUITER')
+  create(@Param('orgId') orgId: string, @Body() dto: CreateJobRoleDto) {
+    return this.service.create(orgId, dto);
+  }
+
+  @Patch(':roleId')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'RECRUITER')
+  update(
+    @Param('orgId') orgId: string,
+    @Param('roleId') roleId: string,
+    @Body() dto: UpdateJobRoleDto,
+  ) {
+    return this.service.update(orgId, roleId, dto);
+  }
+
+  @Delete(':roleId')
+  @OrgRoles('OWNER', 'ADMIN')
+  remove(@Param('orgId') orgId: string, @Param('roleId') roleId: string) {
+    return this.service.remove(orgId, roleId);
+  }
+}

--- a/backend/src/job-roles/job-roles.module.ts
+++ b/backend/src/job-roles/job-roles.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { JobRolesController } from './job-roles.controller';
+import { JobRolesService } from './job-roles.service';
+import { OrganizationsModule } from '../organizations/organizations.module';
+
+@Module({
+  imports: [OrganizationsModule],
+  controllers: [JobRolesController],
+  providers: [JobRolesService],
+  exports: [JobRolesService],
+})
+export class JobRolesModule {}

--- a/backend/src/job-roles/job-roles.service.spec.ts
+++ b/backend/src/job-roles/job-roles.service.spec.ts
@@ -1,3 +1,7 @@
+// Mock OrganizationsService before any imports to prevent its transitive
+// dependency on uuid (ESM-only) from breaking Jest's CJS transform.
+jest.mock('../organizations/organizations.service');
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { JobRolesService } from './job-roles.service';

--- a/backend/src/job-roles/job-roles.service.spec.ts
+++ b/backend/src/job-roles/job-roles.service.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { JobRolesService } from './job-roles.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { OrganizationsService } from '../organizations/organizations.service';
+
+const mockPrisma = {
+  jobRole: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
+const mockOrgsService = {
+  resolveOrgId: jest.fn().mockResolvedValue('org-1'),
+};
+
+describe('JobRolesService', () => {
+  let service: JobRolesService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobRolesService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: OrganizationsService, useValue: mockOrgsService },
+      ],
+    }).compile();
+    service = module.get<JobRolesService>(JobRolesService);
+  });
+
+  describe('list', () => {
+    it('returns job roles for the org', async () => {
+      const roles = [{ id: 'r1', title: 'Engineer', isActive: true }];
+      mockPrisma.jobRole.findMany.mockResolvedValue(roles);
+      const result = await service.list('my-org');
+      expect(result).toEqual(roles);
+      expect(mockPrisma.jobRole.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { orgId: 'org-1' } }),
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('creates a job role with required fields', async () => {
+      const created = { id: 'r1', title: 'Designer', department: null, isActive: true };
+      mockPrisma.jobRole.create.mockResolvedValue(created);
+      const result = await service.create('my-org', { title: 'Designer' });
+      expect(result).toEqual(created);
+      expect(mockPrisma.jobRole.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ orgId: 'org-1', title: 'Designer' }),
+        }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFoundException when role not found', async () => {
+      mockPrisma.jobRole.findFirst.mockResolvedValue(null);
+      await expect(service.update('my-org', 'bad-id', { title: 'X' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('updates job role when found', async () => {
+      mockPrisma.jobRole.findFirst.mockResolvedValue({ id: 'r1' });
+      mockPrisma.jobRole.update.mockResolvedValue({ id: 'r1', title: 'Updated' });
+      const result = await service.update('my-org', 'r1', { title: 'Updated' });
+      expect(result).toEqual({ id: 'r1', title: 'Updated' });
+    });
+
+    it('can toggle isActive', async () => {
+      mockPrisma.jobRole.findFirst.mockResolvedValue({ id: 'r1' });
+      mockPrisma.jobRole.update.mockResolvedValue({ id: 'r1', isActive: false });
+      const result = await service.update('my-org', 'r1', { isActive: false });
+      expect(mockPrisma.jobRole.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isActive: false }),
+        }),
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('throws NotFoundException when role not found', async () => {
+      mockPrisma.jobRole.findFirst.mockResolvedValue(null);
+      await expect(service.remove('my-org', 'bad-id')).rejects.toThrow(NotFoundException);
+    });
+
+    it('deletes the role when found', async () => {
+      mockPrisma.jobRole.findFirst.mockResolvedValue({ id: 'r1' });
+      mockPrisma.jobRole.delete.mockResolvedValue({ id: 'r1' });
+      await service.remove('my-org', 'r1');
+      expect(mockPrisma.jobRole.delete).toHaveBeenCalledWith({ where: { id: 'r1' } });
+    });
+  });
+});

--- a/backend/src/job-roles/job-roles.service.spec.ts
+++ b/backend/src/job-roles/job-roles.service.spec.ts
@@ -1,7 +1,3 @@
-// Mock OrganizationsService before any imports to prevent its transitive
-// dependency on uuid (ESM-only) from breaking Jest's CJS transform.
-jest.mock('../organizations/organizations.service');
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { JobRolesService } from './job-roles.service';

--- a/backend/src/job-roles/job-roles.service.ts
+++ b/backend/src/job-roles/job-roles.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { OrganizationsService } from '../organizations/organizations.service';
+import { CreateJobRoleDto } from './dto/create-job-role.dto';
+import { UpdateJobRoleDto } from './dto/update-job-role.dto';
+
+@Injectable()
+export class JobRolesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly orgsService: OrganizationsService,
+  ) {}
+
+  async list(slugOrId: string) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    return this.prisma.jobRole.findMany({
+      where: { orgId },
+      orderBy: [{ isActive: 'desc' }, { title: 'asc' }],
+      include: {
+        _count: { select: { assessments: true } },
+      },
+    });
+  }
+
+  async create(slugOrId: string, dto: CreateJobRoleDto) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    return this.prisma.jobRole.create({
+      data: {
+        orgId,
+        title: dto.title,
+        department: dto.department,
+        description: dto.description,
+      },
+    });
+  }
+
+  async update(slugOrId: string, roleId: string, dto: UpdateJobRoleDto) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    const existing = await this.prisma.jobRole.findFirst({
+      where: { id: roleId, orgId },
+    });
+    if (!existing) throw new NotFoundException('Job role not found');
+
+    return this.prisma.jobRole.update({
+      where: { id: roleId },
+      data: {
+        ...(dto.title !== undefined && { title: dto.title }),
+        ...(dto.department !== undefined && { department: dto.department }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.isActive !== undefined && { isActive: dto.isActive }),
+      },
+    });
+  }
+
+  async remove(slugOrId: string, roleId: string) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    const existing = await this.prisma.jobRole.findFirst({
+      where: { id: roleId, orgId },
+    });
+    if (!existing) throw new NotFoundException('Job role not found');
+    return this.prisma.jobRole.delete({ where: { id: roleId } });
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ const OrgLearningTracks = lazy(() => import("./pages/org/OrgLearningTracks"));
 const OrgAssessments = lazy(() => import("./pages/org/OrgAssessments"));
 const AssessmentBuilder = lazy(() => import("./pages/org/AssessmentBuilder"));
 const AssessmentResults = lazy(() => import("./pages/org/AssessmentResults"));
+const OrgJobRoles = lazy(() => import("./pages/org/OrgJobRoles"));
 const OrgAnalytics = lazy(() => import("./pages/org/OrgAnalytics"));
 const OrgAuditLog = lazy(() => import("./pages/org/OrgAuditLog"));
 const CandidateExam = lazy(() => import("./pages/CandidateExam"));
@@ -389,6 +390,7 @@ const AnimatedRoutes = () => {
           <Route path="assessments/create" element={<AssessmentBuilder />} />
           <Route path="assessments/:aid" element={<AssessmentResults />} />
           <Route path="assessments/:aid/edit" element={<AssessmentBuilder />} />
+          <Route path="job-roles" element={<OrgJobRoles />} />
           <Route path="analytics" element={<OrgAnalytics />} />
           <Route path="settings" element={<OrgSettings />} />
           <Route path="settings/audit" element={<OrgAuditLog />} />

--- a/src/components/org/CandidateRanking.tsx
+++ b/src/components/org/CandidateRanking.tsx
@@ -1,17 +1,59 @@
 import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
-  CheckCircle2, XCircle, AlertTriangle, ChevronDown, ChevronRight, RefreshCw,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  RefreshCw,
+  MoreVertical,
+  Star,
+  UserCheck,
+  UserX,
+  Eye,
+  Search,
+  ThumbsUp,
 } from 'lucide-react';
-import type { CandidateInvite } from '@/types/assessment-types';
+import { toast } from 'sonner';
+import { updateCandidateDecision } from '@/services/assessments';
+import type { CandidateInvite, CandidateStage } from '@/types/assessment-types';
 
-const statusConfig: Record<string, { color: string; label: string }> = {
-  INVITED: { color: 'bg-blue-500/15 text-blue-400', label: 'Invited' },
-  STARTED: { color: 'bg-amber-500/15 text-amber-400', label: 'In Progress' },
+// ─── Stage config ─────────────────────────────────────────────────────────────
+
+const stageConfig: Record<
+  CandidateStage,
+  { color: string; label: string; icon: React.ElementType }
+> = {
+  APPLIED:     { color: 'bg-blue-500/15 text-blue-400',    label: 'Applied',     icon: Eye },
+  SCREENING:   { color: 'bg-amber-500/15 text-amber-400',  label: 'Screening',   icon: Search },
+  SHORTLISTED: { color: 'bg-violet-500/15 text-violet-400',label: 'Shortlisted', icon: ThumbsUp },
+  REJECTED:    { color: 'bg-red-500/15 text-red-400',      label: 'Rejected',    icon: UserX },
+  HIRED:       { color: 'bg-emerald-500/15 text-emerald-400', label: 'Hired',    icon: UserCheck },
+};
+
+const attemptStatusConfig: Record<string, { color: string; label: string }> = {
+  INVITED:   { color: 'bg-slate-500/15 text-slate-400',   label: 'Invited' },
+  STARTED:   { color: 'bg-amber-500/15 text-amber-400',   label: 'In Progress' },
   SUBMITTED: { color: 'bg-emerald-500/15 text-emerald-400', label: 'Submitted' },
-  EXPIRED: { color: 'bg-zinc-500/15 text-zinc-400', label: 'Expired' },
+  EXPIRED:   { color: 'bg-zinc-500/15 text-zinc-400',     label: 'Expired' },
 };
 
 const formatDuration = (seconds: number | null): string => {
@@ -21,163 +63,464 @@ const formatDuration = (seconds: number | null): string => {
   return `${m}m ${s}s`;
 };
 
+// ─── StarRating ───────────────────────────────────────────────────────────────
+
+const StarRating = ({
+  value,
+  onChange,
+  readonly,
+}: {
+  value: number | null;
+  onChange?: (n: number) => void;
+  readonly?: boolean;
+}) => (
+  <div className="flex gap-0.5">
+    {[1, 2, 3, 4, 5].map((n) => (
+      <Star
+        key={n}
+        className={`h-3.5 w-3.5 transition-colors ${
+          (value ?? 0) >= n ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground/30'
+        } ${!readonly ? 'cursor-pointer hover:text-amber-400' : ''}`}
+        onClick={!readonly ? () => onChange?.(n) : undefined}
+      />
+    ))}
+  </div>
+);
+
+// ─── CandidateDetailDrawer ────────────────────────────────────────────────────
+
+interface DrawerProps {
+  candidate: CandidateInvite | null;
+  passingScore: number | null;
+  slug: string;
+  aid: string;
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+const CandidateDetailDrawer = ({
+  candidate,
+  passingScore,
+  slug,
+  aid,
+  onClose,
+  onUpdated,
+}: DrawerProps) => {
+  const [note, setNote] = useState(candidate?.recruiterNote ?? '');
+  const [rating, setRating] = useState<number | null>(candidate?.rating ?? null);
+
+  const mutation = useMutation({
+    mutationFn: (data: Parameters<typeof updateCandidateDecision>[3]) =>
+      updateCandidateDecision(slug, aid, candidate!.id, data),
+    onSuccess: () => {
+      toast.success('Updated');
+      onUpdated();
+    },
+    onError: (e: any) => toast.error(e?.response?.data?.message || 'Update failed'),
+  });
+
+  if (!candidate) return null;
+
+  const passed =
+    passingScore != null && candidate.score != null
+      ? Number(candidate.score) >= passingScore
+      : null;
+
+  const handleSaveNote = () => {
+    mutation.mutate({ recruiterNote: note });
+  };
+
+  const handleRating = (n: number) => {
+    setRating(n);
+    mutation.mutate({ rating: n });
+  };
+
+  return (
+    <Sheet open={!!candidate} onOpenChange={onClose}>
+      <SheetContent className="w-[420px] sm:w-[520px] overflow-y-auto bg-card border-border">
+        <SheetHeader className="mb-4">
+          <SheetTitle className="font-mono text-base">
+            {candidate.candidateName || candidate.candidateEmail}
+          </SheetTitle>
+          {candidate.candidateName && (
+            <p className="text-xs text-muted-foreground">{candidate.candidateEmail}</p>
+          )}
+        </SheetHeader>
+
+        <div className="space-y-5">
+          {/* Score summary */}
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                label: 'Score',
+                value: candidate.score != null ? `${Number(candidate.score).toFixed(1)}%` : '-',
+                accent: passed === true ? 'text-emerald-400' : passed === false ? 'text-red-400' : '',
+              },
+              {
+                label: 'Correct',
+                value: candidate.totalCorrect != null
+                  ? `${candidate.totalCorrect}/${candidate.totalQuestions}`
+                  : '-',
+                accent: '',
+              },
+              {
+                label: 'Percentile',
+                value: candidate.percentile != null ? `${candidate.percentile}th` : '-',
+                accent: 'text-violet-400',
+              },
+            ].map(({ label, value, accent }) => (
+              <div key={label} className="rounded-lg border border-border bg-muted/30 p-3 text-center">
+                <p className="text-[10px] text-muted-foreground font-mono uppercase tracking-wider">{label}</p>
+                <p className={`text-lg font-mono font-bold mt-0.5 ${accent}`}>{value}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* Meta */}
+          <div className="space-y-1.5 text-[11px] font-mono">
+            {[
+              { label: 'Status', value: attemptStatusConfig[candidate.status]?.label ?? candidate.status },
+              { label: 'Time spent', value: formatDuration(candidate.timeSpent) },
+              { label: 'Tab switches', value: String(candidate.tabSwitchCount ?? 0) },
+              { label: 'Submitted', value: candidate.submittedAt ? new Date(candidate.submittedAt).toLocaleString() : '-' },
+              { label: 'Expires', value: new Date(candidate.expiresAt).toLocaleString() },
+            ].map(({ label, value }) => (
+              <div key={label} className="flex justify-between">
+                <span className="text-muted-foreground">{label}</span>
+                <span>{value}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Domain scores */}
+          {candidate.domainScores && Object.keys(candidate.domainScores).length > 0 && (
+            <div>
+              <p className="text-[10px] text-muted-foreground font-mono uppercase tracking-wider mb-2">
+                Domain Breakdown
+              </p>
+              <div className="space-y-2">
+                {Object.entries(candidate.domainScores).map(([domain, stats]) => {
+                  const pct = stats.total > 0 ? Math.round((stats.correct / stats.total) * 100) : 0;
+                  const isWeak = pct < (passingScore ?? 70);
+                  return (
+                    <div key={domain} className="flex items-center gap-3">
+                      <span className="w-32 truncate text-[10px] font-mono text-muted-foreground shrink-0">
+                        {domain}
+                      </span>
+                      <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${isWeak ? 'bg-red-500' : 'bg-emerald-500'}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <span className={`text-[10px] font-mono w-16 text-right shrink-0 ${isWeak ? 'text-red-400' : 'text-emerald-400'}`}>
+                        {stats.correct}/{stats.total} ({pct}%)
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Rating */}
+          <div>
+            <p className="text-[10px] text-muted-foreground font-mono uppercase tracking-wider mb-2">
+              Rating
+            </p>
+            <StarRating value={rating} onChange={handleRating} />
+          </div>
+
+          {/* Recruiter note */}
+          <div>
+            <p className="text-[10px] text-muted-foreground font-mono uppercase tracking-wider mb-2">
+              Internal Note
+            </p>
+            <Textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Add internal notes about this candidate…"
+              className="text-xs font-mono bg-muted/30 border-border resize-none min-h-[80px]"
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              className="mt-2 text-xs font-mono"
+              onClick={handleSaveNote}
+              disabled={mutation.isPending}
+            >
+              Save note
+            </Button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
 interface Props {
   candidates: CandidateInvite[];
   passingScore: number | null;
+  slug: string;
+  aid: string;
   onReinvite?: (email: string) => void;
   isReinviting?: boolean;
 }
 
-const CandidateRanking = ({ candidates, passingScore, onReinvite, isReinviting }: Props) => {
+const CandidateRanking = ({
+  candidates,
+  passingScore,
+  slug,
+  aid,
+  onReinvite,
+  isReinviting,
+}: Props) => {
+  const queryClient = useQueryClient();
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [drawerCandidate, setDrawerCandidate] = useState<CandidateInvite | null>(null);
+
+  const stageMutation = useMutation({
+    mutationFn: ({
+      inviteId,
+      stage,
+    }: {
+      inviteId: string;
+      stage: CandidateStage;
+    }) => updateCandidateDecision(slug, aid, inviteId, { stage }),
+    onSuccess: () => {
+      toast.success('Stage updated');
+      queryClient.invalidateQueries({ queryKey: ['assessment-results', slug, aid] });
+    },
+    onError: (e: any) => toast.error(e?.response?.data?.message || 'Update failed'),
+  });
+
+  const handleUpdated = () => {
+    queryClient.invalidateQueries({ queryKey: ['assessment-results', slug, aid] });
+  };
 
   return (
-    <Card className="bg-card border-border">
-      <CardContent className="p-0">
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs font-mono">
-            <thead>
-              <tr className="border-b border-border text-muted-foreground">
-                <th className="text-left p-3 font-medium w-6"></th>
-                <th className="text-left p-3 font-medium">#</th>
-                <th className="text-left p-3 font-medium">Candidate</th>
-                <th className="text-left p-3 font-medium">Status</th>
-                <th className="text-right p-3 font-medium">Score</th>
-                <th className="text-right p-3 font-medium">Correct</th>
-                <th className="text-right p-3 font-medium">Time</th>
-                <th className="text-right p-3 font-medium">Switches</th>
-                <th className="text-left p-3 font-medium">Result</th>
-                <th className="text-right p-3 font-medium"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {candidates.map((c, i) => {
-                const passed = passingScore != null && c.score != null
-                  ? Number(c.score) >= passingScore
-                  : null;
-                const hasDomainScores = c.domainScores && Object.keys(c.domainScores).length > 0;
-                const isExpanded = expandedId === c.id;
-                const canReinvite = (c.status === 'INVITED' || c.status === 'EXPIRED') && !!onReinvite;
+    <>
+      <Card className="bg-card border-border">
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs font-mono">
+              <thead>
+                <tr className="border-b border-border text-muted-foreground">
+                  <th className="text-left p-3 font-medium w-6"></th>
+                  <th className="text-left p-3 font-medium">#</th>
+                  <th className="text-left p-3 font-medium">Candidate</th>
+                  <th className="text-left p-3 font-medium">Attempt</th>
+                  <th className="text-left p-3 font-medium">Stage</th>
+                  <th className="text-right p-3 font-medium">Score</th>
+                  <th className="text-right p-3 font-medium">%tile</th>
+                  <th className="text-right p-3 font-medium">Time</th>
+                  <th className="text-right p-3 font-medium">Switches</th>
+                  <th className="text-left p-3 font-medium">Result</th>
+                  <th className="text-right p-3 font-medium">Rating</th>
+                  <th className="text-right p-3 font-medium"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {candidates.map((c, i) => {
+                  const passed =
+                    passingScore != null && c.score != null
+                      ? Number(c.score) >= passingScore
+                      : null;
+                  const hasDomainScores =
+                    c.domainScores && Object.keys(c.domainScores).length > 0;
+                  const isExpanded = expandedId === c.id;
+                  const canReinvite =
+                    (c.status === 'INVITED' || c.status === 'EXPIRED') && !!onReinvite;
+                  const stage = c.stage ?? 'APPLIED';
+                  const StageCfg = stageConfig[stage];
 
-                return (
-                  <>
-                    <tr
-                      key={c.id}
-                      className={`border-b border-border/50 ${hasDomainScores ? 'cursor-pointer hover:bg-muted/30' : ''}`}
-                      onClick={() => hasDomainScores && setExpandedId(isExpanded ? null : c.id)}
-                    >
-                      <td className="p-3 text-muted-foreground">
-                        {hasDomainScores && (
-                          isExpanded
-                            ? <ChevronDown className="h-3.5 w-3.5" />
-                            : <ChevronRight className="h-3.5 w-3.5" />
-                        )}
-                      </td>
-                      <td className="p-3 text-muted-foreground">{i + 1}</td>
-                      <td className="p-3">
-                        <div>
-                          {c.candidateName && (
-                            <span className="font-medium">{c.candidateName}</span>
-                          )}
-                          <span className={`${c.candidateName ? 'text-muted-foreground ml-1' : ''}`}>
-                            {c.candidateEmail}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="p-3">
-                        <Badge className={`text-[10px] ${statusConfig[c.status]?.color ?? ''}`}>
-                          {statusConfig[c.status]?.label ?? c.status}
-                        </Badge>
-                      </td>
-                      <td className="p-3 text-right">
-                        {c.score != null ? `${Number(c.score).toFixed(1)}%` : '-'}
-                      </td>
-                      <td className="p-3 text-right">
-                        {c.totalCorrect != null ? `${c.totalCorrect}/${c.totalQuestions}` : '-'}
-                      </td>
-                      <td className="p-3 text-right">
-                        {formatDuration(c.timeSpent)}
-                      </td>
-                      <td className="p-3 text-right">
-                        {c.tabSwitchCount != null && c.tabSwitchCount > 0 ? (
-                          <span className="flex items-center justify-end gap-1 text-amber-400">
-                            <AlertTriangle className="h-3 w-3" /> {c.tabSwitchCount}
-                          </span>
-                        ) : (
-                          <span className="text-muted-foreground">0</span>
-                        )}
-                      </td>
-                      <td className="p-3">
-                        {passed === true && (
-                          <span className="flex items-center gap-1 text-emerald-400">
-                            <CheckCircle2 className="h-3.5 w-3.5" /> Pass
-                          </span>
-                        )}
-                        {passed === false && (
-                          <span className="flex items-center gap-1 text-red-400">
-                            <XCircle className="h-3.5 w-3.5" /> Fail
-                          </span>
-                        )}
-                      </td>
-                      <td className="p-3 text-right" onClick={(e) => e.stopPropagation()}>
-                        {canReinvite && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-[10px] font-mono text-muted-foreground hover:text-foreground"
-                            disabled={isReinviting}
-                            onClick={() => onReinvite!(c.candidateEmail)}
-                          >
-                            <RefreshCw className="h-3 w-3 mr-1" /> Re-send
-                          </Button>
-                        )}
-                      </td>
-                    </tr>
-
-                    {/* Domain Score Expansion */}
-                    {isExpanded && hasDomainScores && (
-                      <tr key={`${c.id}-domain`} className="border-b border-border/50 bg-muted/20">
-                        <td colSpan={10} className="px-5 py-3">
-                          <div className="space-y-2">
-                            <p className="text-[10px] text-muted-foreground font-mono uppercase tracking-wider mb-2">
-                              Domain Breakdown
-                            </p>
-                            {Object.entries(c.domainScores!).map(([domain, stats]) => {
-                              const pct = stats.total > 0 ? Math.round((stats.correct / stats.total) * 100) : 0;
-                              const isWeak = pct < (passingScore ?? 70);
-                              return (
-                                <div key={domain} className="flex items-center gap-3">
-                                  <span className="w-40 truncate text-[10px] font-mono text-muted-foreground shrink-0">
-                                    {domain}
-                                  </span>
-                                  <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
-                                    <div
-                                      className={`h-full rounded-full transition-all ${
-                                        isWeak ? 'bg-red-500' : 'bg-emerald-500'
-                                      }`}
-                                      style={{ width: `${pct}%` }}
-                                    />
-                                  </div>
-                                  <span className={`text-[10px] font-mono w-14 text-right shrink-0 ${
-                                    isWeak ? 'text-red-400' : 'text-emerald-400'
-                                  }`}>
-                                    {stats.correct}/{stats.total} ({pct}%)
-                                  </span>
-                                </div>
-                              );
-                            })}
+                  return (
+                    <>
+                      <tr
+                        key={c.id}
+                        className="border-b border-border/50 hover:bg-muted/20 transition-colors"
+                      >
+                        {/* expand toggle */}
+                        <td
+                          className="p-3 text-muted-foreground cursor-pointer"
+                          onClick={() =>
+                            hasDomainScores && setExpandedId(isExpanded ? null : c.id)
+                          }
+                        >
+                          {hasDomainScores &&
+                            (isExpanded ? (
+                              <ChevronDown className="h-3.5 w-3.5" />
+                            ) : (
+                              <ChevronRight className="h-3.5 w-3.5" />
+                            ))}
+                        </td>
+                        <td className="p-3 text-muted-foreground">{i + 1}</td>
+                        <td className="p-3">
+                          <div>
+                            {c.candidateName && (
+                              <span className="font-medium block">{c.candidateName}</span>
+                            )}
+                            <span className="text-muted-foreground">{c.candidateEmail}</span>
                           </div>
                         </td>
+                        <td className="p-3">
+                          <Badge
+                            className={`text-[10px] ${attemptStatusConfig[c.status]?.color ?? ''}`}
+                          >
+                            {attemptStatusConfig[c.status]?.label ?? c.status}
+                          </Badge>
+                        </td>
+                        {/* Stage badge */}
+                        <td className="p-3">
+                          <Badge className={`text-[10px] ${StageCfg.color}`}>
+                            {StageCfg.label}
+                          </Badge>
+                        </td>
+                        <td className="p-3 text-right">
+                          {c.score != null ? `${Number(c.score).toFixed(1)}%` : '-'}
+                        </td>
+                        <td className="p-3 text-right text-violet-400">
+                          {c.percentile != null ? `${c.percentile}th` : '-'}
+                        </td>
+                        <td className="p-3 text-right">{formatDuration(c.timeSpent)}</td>
+                        <td className="p-3 text-right">
+                          {c.tabSwitchCount != null && c.tabSwitchCount > 0 ? (
+                            <span className="flex items-center justify-end gap-1 text-amber-400">
+                              <AlertTriangle className="h-3 w-3" /> {c.tabSwitchCount}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">0</span>
+                          )}
+                        </td>
+                        <td className="p-3">
+                          {passed === true && (
+                            <span className="flex items-center gap-1 text-emerald-400">
+                              <CheckCircle2 className="h-3.5 w-3.5" /> Pass
+                            </span>
+                          )}
+                          {passed === false && (
+                            <span className="flex items-center gap-1 text-red-400">
+                              <XCircle className="h-3.5 w-3.5" /> Fail
+                            </span>
+                          )}
+                        </td>
+                        <td className="p-3 text-right">
+                          <StarRating value={c.rating} readonly />
+                        </td>
+                        {/* Actions */}
+                        <td className="p-3 text-right" onClick={(e) => e.stopPropagation()}>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                              >
+                                <MoreVertical className="h-3.5 w-3.5" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="text-xs font-mono w-44">
+                              <DropdownMenuItem onClick={() => setDrawerCandidate(c)}>
+                                <Eye className="h-3.5 w-3.5 mr-2" /> View details
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              {(
+                                ['APPLIED', 'SCREENING', 'SHORTLISTED', 'REJECTED', 'HIRED'] as CandidateStage[]
+                              )
+                                .filter((s) => s !== stage)
+                                .map((s) => {
+                                  const cfg = stageConfig[s];
+                                  const Icon = cfg.icon;
+                                  return (
+                                    <DropdownMenuItem
+                                      key={s}
+                                      onClick={() =>
+                                        stageMutation.mutate({ inviteId: c.id, stage: s })
+                                      }
+                                      disabled={stageMutation.isPending}
+                                    >
+                                      <Icon className="h-3.5 w-3.5 mr-2" />
+                                      Move to {cfg.label}
+                                    </DropdownMenuItem>
+                                  );
+                                })}
+                              {canReinvite && (
+                                <>
+                                  <DropdownMenuSeparator />
+                                  <DropdownMenuItem
+                                    onClick={() => onReinvite!(c.candidateEmail)}
+                                    disabled={isReinviting}
+                                  >
+                                    <RefreshCw className="h-3.5 w-3.5 mr-2" /> Re-send invite
+                                  </DropdownMenuItem>
+                                </>
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </td>
                       </tr>
-                    )}
-                  </>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </CardContent>
-    </Card>
+
+                      {/* Domain score expansion */}
+                      {isExpanded && hasDomainScores && (
+                        <tr key={`${c.id}-domain`} className="border-b border-border/50 bg-muted/20">
+                          <td colSpan={12} className="px-5 py-3">
+                            <div className="space-y-2">
+                              <p className="text-[10px] text-muted-foreground font-mono uppercase tracking-wider mb-2">
+                                Domain Breakdown
+                              </p>
+                              {Object.entries(c.domainScores!).map(([domain, stats]) => {
+                                const pct =
+                                  stats.total > 0
+                                    ? Math.round((stats.correct / stats.total) * 100)
+                                    : 0;
+                                const isWeak = pct < (passingScore ?? 70);
+                                return (
+                                  <div key={domain} className="flex items-center gap-3">
+                                    <span className="w-40 truncate text-[10px] font-mono text-muted-foreground shrink-0">
+                                      {domain}
+                                    </span>
+                                    <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                                      <div
+                                        className={`h-full rounded-full transition-all ${
+                                          isWeak ? 'bg-red-500' : 'bg-emerald-500'
+                                        }`}
+                                        style={{ width: `${pct}%` }}
+                                      />
+                                    </div>
+                                    <span
+                                      className={`text-[10px] font-mono w-16 text-right shrink-0 ${
+                                        isWeak ? 'text-red-400' : 'text-emerald-400'
+                                      }`}
+                                    >
+                                      {stats.correct}/{stats.total} ({pct}%)
+                                    </span>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <CandidateDetailDrawer
+        candidate={drawerCandidate}
+        passingScore={passingScore}
+        slug={slug}
+        aid={aid}
+        onClose={() => setDrawerCandidate(null)}
+        onUpdated={handleUpdated}
+      />
+    </>
   );
 };
 

--- a/src/components/org/CandidateRanking.tsx
+++ b/src/components/org/CandidateRanking.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -108,6 +108,12 @@ const CandidateDetailDrawer = ({
 }: DrawerProps) => {
   const [note, setNote] = useState(candidate?.recruiterNote ?? '');
   const [rating, setRating] = useState<number | null>(candidate?.rating ?? null);
+
+  // Sync state when a different candidate is opened
+  useEffect(() => {
+    setNote(candidate?.recruiterNote ?? '');
+    setRating(candidate?.rating ?? null);
+  }, [candidate?.id]);
 
   const mutation = useMutation({
     mutationFn: (data: Parameters<typeof updateCandidateDecision>[3]) =>
@@ -337,9 +343,8 @@ const CandidateRanking = ({
                   const StageCfg = stageConfig[stage];
 
                   return (
-                    <>
+                    <Fragment key={c.id}>
                       <tr
-                        key={c.id}
                         className="border-b border-border/50 hover:bg-muted/20 transition-colors"
                       >
                         {/* expand toggle */}
@@ -503,7 +508,7 @@ const CandidateRanking = ({
                           </td>
                         </tr>
                       )}
-                    </>
+                    </Fragment>
                   );
                 })}
               </tbody>

--- a/src/components/org/CsvImportModal.tsx
+++ b/src/components/org/CsvImportModal.tsx
@@ -1,0 +1,245 @@
+import { useState, useRef } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Upload, FileText, AlertTriangle, CheckCircle2, X, Download } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface CandidateRow {
+  email: string;
+  name?: string;
+  error?: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onImport: (candidates: { email: string; name?: string }[]) => void;
+  isPending: boolean;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const parseCsv = (text: string): CandidateRow[] => {
+  const lines = text.trim().split('\n');
+  if (lines.length === 0) return [];
+
+  // Detect header
+  const firstLine = lines[0].toLowerCase();
+  const hasHeader =
+    firstLine.includes('email') || firstLine.includes('name');
+  const dataLines = hasHeader ? lines.slice(1) : lines;
+
+  return dataLines
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      // Handle quoted CSV
+      const cols = line
+        .split(',')
+        .map((c) => c.trim().replace(/^"|"$/g, '').trim());
+
+      const email = cols[0] ?? '';
+      const name = cols[1] || undefined;
+
+      if (!email) return { email, name, error: 'Empty email' };
+      if (!EMAIL_RE.test(email)) return { email, name, error: 'Invalid email' };
+      return { email, name };
+    });
+};
+
+const EXAMPLE_CSV = `email,name
+alice@example.com,Alice Nguyen
+bob@example.com,Bob Tran
+carol@example.com`;
+
+const CsvImportModal = ({ open, onClose, onImport, isPending }: Props) => {
+  const [rows, setRows] = useState<CandidateRow[]>([]);
+  const [fileName, setFileName] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const validRows = rows.filter((r) => !r.error);
+  const errorRows = rows.filter((r) => !!r.error);
+
+  const handleFile = (file: File) => {
+    if (!file.name.endsWith('.csv') && !file.name.endsWith('.txt')) {
+      toast.error('Please upload a .csv or .txt file');
+      return;
+    }
+    setFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = e.target?.result as string;
+      setRows(parseCsv(text));
+    };
+    reader.readAsText(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDownloadExample = () => {
+    const blob = new Blob([EXAMPLE_CSV], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'candidates-template.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleSubmit = () => {
+    if (validRows.length === 0) {
+      toast.error('No valid candidates to import');
+      return;
+    }
+    onImport(validRows.map(({ email, name }) => ({ email, name })));
+  };
+
+  const handleClose = () => {
+    setRows([]);
+    setFileName('');
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-lg bg-card border-border">
+        <DialogHeader>
+          <DialogTitle className="font-mono flex items-center gap-2">
+            <Upload className="h-4 w-4 text-primary" />
+            Import Candidates from CSV
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Drop zone */}
+          {rows.length === 0 ? (
+            <div
+              className="border-2 border-dashed border-border rounded-lg p-8 text-center cursor-pointer hover:border-primary/50 transition-colors"
+              onClick={() => fileRef.current?.click()}
+              onDrop={handleDrop}
+              onDragOver={(e) => e.preventDefault()}
+            >
+              <FileText className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+              <p className="text-sm font-mono text-muted-foreground">
+                Drop your CSV here, or <span className="text-primary underline">browse</span>
+              </p>
+              <p className="text-[11px] text-muted-foreground mt-1">
+                Columns: <code className="bg-muted px-1 rounded">email</code>,{' '}
+                <code className="bg-muted px-1 rounded">name</code> (optional)
+              </p>
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".csv,.txt"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleFile(file);
+                }}
+              />
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {/* File info */}
+              <div className="flex items-center justify-between bg-muted/30 rounded-lg px-3 py-2">
+                <span className="text-xs font-mono text-muted-foreground">
+                  <FileText className="h-3.5 w-3.5 inline mr-1.5" />
+                  {fileName}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5"
+                  onClick={() => { setRows([]); setFileName(''); }}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+
+              {/* Summary badges */}
+              <div className="flex gap-2">
+                <Badge className="bg-emerald-500/15 text-emerald-400 text-[10px]">
+                  <CheckCircle2 className="h-3 w-3 mr-1" />
+                  {validRows.length} valid
+                </Badge>
+                {errorRows.length > 0 && (
+                  <Badge className="bg-red-500/15 text-red-400 text-[10px]">
+                    <AlertTriangle className="h-3 w-3 mr-1" />
+                    {errorRows.length} error{errorRows.length > 1 ? 's' : ''}
+                  </Badge>
+                )}
+              </div>
+
+              {/* Preview table */}
+              <div className="max-h-48 overflow-y-auto rounded-lg border border-border">
+                <table className="w-full text-[11px] font-mono">
+                  <thead className="sticky top-0 bg-muted/50">
+                    <tr className="border-b border-border text-muted-foreground">
+                      <th className="text-left p-2">Email</th>
+                      <th className="text-left p-2">Name</th>
+                      <th className="text-left p-2"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, i) => (
+                      <tr
+                        key={i}
+                        className={`border-b border-border/50 ${row.error ? 'bg-red-500/5' : ''}`}
+                      >
+                        <td className="p-2">{row.email || '—'}</td>
+                        <td className="p-2 text-muted-foreground">{row.name || '—'}</td>
+                        <td className="p-2">
+                          {row.error ? (
+                            <span className="text-red-400 flex items-center gap-1">
+                              <AlertTriangle className="h-3 w-3" /> {row.error}
+                            </span>
+                          ) : (
+                            <CheckCircle2 className="h-3 w-3 text-emerald-400" />
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Example download */}
+          <button
+            className="text-[11px] font-mono text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+            onClick={handleDownloadExample}
+          >
+            <Download className="h-3 w-3" /> Download example CSV
+          </button>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={handleClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            className="glow-cyan"
+            onClick={handleSubmit}
+            disabled={isPending || validRows.length === 0}
+          >
+            {isPending ? 'Importing…' : `Import ${validRows.length} candidate${validRows.length !== 1 ? 's' : ''}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CsvImportModal;

--- a/src/components/org/CsvImportModal.tsx
+++ b/src/components/org/CsvImportModal.tsx
@@ -26,11 +26,33 @@ interface Props {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/** RFC-4180 compliant CSV column splitter — handles quoted fields with commas. */
+const splitCsvLine = (line: string): string[] => {
+  const cols: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') { cur += '"'; i++; } // escaped quote
+      else inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      cols.push(cur.trim());
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  cols.push(cur.trim());
+  return cols;
+};
+
 const parseCsv = (text: string): CandidateRow[] => {
-  const lines = text.trim().split('\n');
+  // Normalise Windows \r\n line endings
+  const lines = text.trim().replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
   if (lines.length === 0) return [];
 
-  // Detect header
+  // Detect header row
   const firstLine = lines[0].toLowerCase();
   const hasHeader =
     firstLine.includes('email') || firstLine.includes('name');
@@ -40,11 +62,7 @@ const parseCsv = (text: string): CandidateRow[] => {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      // Handle quoted CSV
-      const cols = line
-        .split(',')
-        .map((c) => c.trim().replace(/^"|"$/g, '').trim());
-
+      const cols = splitCsvLine(line);
       const email = cols[0] ?? '';
       const name = cols[1] || undefined;
 

--- a/src/components/org/OrgSidebar.tsx
+++ b/src/components/org/OrgSidebar.tsx
@@ -2,13 +2,10 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useOrgStore } from '@/stores/org.store';
 import {
   LayoutDashboard, Users, Settings, Shield, BookOpen,
-  GraduationCap, Library, BookMarked, ClipboardList, BarChart3,
+  GraduationCap, Library, BookMarked, ClipboardList, BarChart3, Briefcase,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { OrgRole } from '@/types/org-types';
-
-const canManage = (role: OrgRole | undefined) =>
-  role === 'OWNER' || role === 'ADMIN' || role === 'MANAGER';
 
 const OrgSidebar = () => {
   const navigate = useNavigate();
@@ -19,17 +16,33 @@ const OrgSidebar = () => {
 
   if (!slug) return null;
 
+  // RECRUITER: only assessments + job-roles visible; no question bank / settings / catalog
   const links = [
-    { label: 'Dashboard', href: `/org/${slug}`, icon: LayoutDashboard, exact: true },
-    { label: 'Members', href: `/org/${slug}/members`, icon: Users },
-    { label: 'Groups', href: `/org/${slug}/groups`, icon: Shield },
-    { label: 'Questions', href: `/org/${slug}/questions`, icon: BookOpen },
-    { label: 'Exam Catalog', href: `/org/${slug}/catalog`, icon: GraduationCap },
-    { label: 'Manage Catalog', href: `/org/${slug}/catalog/manage`, icon: Library, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
-    { label: 'Tracks', href: `/org/${slug}/tracks`, icon: BookMarked, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
-    { label: 'Assessments', href: `/org/${slug}/assessments`, icon: ClipboardList, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
-    { label: 'Analytics', href: `/org/${slug}/analytics`, icon: BarChart3, roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
-    { label: 'Settings', href: `/org/${slug}/settings`, icon: Settings, roles: ['OWNER', 'ADMIN'] as OrgRole[] },
+    { label: 'Dashboard',      href: `/org/${slug}`,               icon: LayoutDashboard, exact: true,
+      hidden: role === 'RECRUITER' },
+    { label: 'Members',        href: `/org/${slug}/members`,        icon: Users,
+      hidden: role === 'RECRUITER' },
+    { label: 'Groups',         href: `/org/${slug}/groups`,         icon: Shield,
+      hidden: role === 'RECRUITER' },
+    { label: 'Questions',      href: `/org/${slug}/questions`,      icon: BookOpen,
+      hidden: role === 'RECRUITER' },
+    { label: 'Exam Catalog',   href: `/org/${slug}/catalog`,        icon: GraduationCap,
+      hidden: role === 'RECRUITER' },
+    { label: 'Manage Catalog', href: `/org/${slug}/catalog/manage`, icon: Library,
+      roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[],
+      hidden: role === 'RECRUITER' },
+    { label: 'Tracks',         href: `/org/${slug}/tracks`,         icon: BookMarked,
+      roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[],
+      hidden: role === 'RECRUITER' },
+    // P1: Recruiting — visible to OWNER/ADMIN/MANAGER/RECRUITER
+    { label: 'Assessments',    href: `/org/${slug}/assessments`,    icon: ClipboardList,
+      roles: ['OWNER', 'ADMIN', 'MANAGER', 'RECRUITER'] as OrgRole[] },
+    { label: 'Job Roles',      href: `/org/${slug}/job-roles`,      icon: Briefcase,
+      roles: ['OWNER', 'ADMIN', 'MANAGER', 'RECRUITER'] as OrgRole[] },
+    { label: 'Analytics',      href: `/org/${slug}/analytics`,      icon: BarChart3,
+      roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
+    { label: 'Settings',       href: `/org/${slug}/settings`,       icon: Settings,
+      roles: ['OWNER', 'ADMIN'] as OrgRole[] },
   ];
 
   const isActive = (href: string, exact?: boolean) =>
@@ -55,6 +68,7 @@ const OrgSidebar = () => {
         <span className="text-xs font-mono font-medium truncate">{currentOrg?.name}</span>
       </div>
       {links
+        .filter((link) => !link.hidden)
         .filter((link) => !link.roles || (role && link.roles.includes(role)))
         .map((link) => (
           <Button

--- a/src/pages/org/AssessmentBuilder.tsx
+++ b/src/pages/org/AssessmentBuilder.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/services/assessments';
 import { getOrgQuestions } from '@/services/org-questions';
 import { getCertifications } from '@/services/certifications';
+import { getJobRoles } from '@/services/job-roles';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -365,6 +366,7 @@ const AssessmentBuilder = () => {
   // ── Common settings ──
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [jobRoleId, setJobRoleId] = useState<string>('none');
   const [timeLimit, setTimeLimit] = useState(60);
   const [passingScore, setPassingScore] = useState<number | ''>('');
   const [randomizeQuestions, setRandomizeQuestions] = useState(true);
@@ -401,6 +403,13 @@ const AssessmentBuilder = () => {
   const { data: certifications = [] } = useQuery({
     queryKey: ['certifications'],
     queryFn: getCertifications,
+  });
+
+  // ── Job Roles ──
+  const { data: jobRoles = [] } = useQuery({
+    queryKey: ['job-roles', slug],
+    queryFn: () => getJobRoles(slug),
+    enabled: !!slug,
   });
 
   // ── Load existing assessment ──
@@ -466,6 +475,7 @@ const AssessmentBuilder = () => {
     if (!existingItem) return;
     setTitle(existingItem.title);
     setDescription(existingItem.description ?? '');
+    setJobRoleId(existingItem.jobRoleId ?? 'none');
     setTimeLimit(existingItem.timeLimit);
     setPassingScore(existingItem.passingScore ?? '');
     setRandomizeQuestions(existingItem.randomizeQuestions);
@@ -553,6 +563,7 @@ const AssessmentBuilder = () => {
       const base = {
         title,
         description: description || undefined,
+        jobRoleId: jobRoleId !== 'none' ? jobRoleId : undefined,
         timeLimit,
         passingScore: passingScore !== '' ? Number(passingScore) : undefined,
         randomizeQuestions,
@@ -661,6 +672,26 @@ const AssessmentBuilder = () => {
             placeholder="Brief description..."
           />
         </div>
+        {jobRoles.length > 0 && (
+          <div>
+            <Label className="text-xs font-mono">Job Role (optional)</Label>
+            <Select value={jobRoleId} onValueChange={setJobRoleId}>
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Link to a job role…" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">— No job role —</SelectItem>
+                {jobRoles
+                  .filter((r) => r.isActive)
+                  .map((r) => (
+                    <SelectItem key={r.id} value={r.id}>
+                      {r.title}{r.department ? ` · ${r.department}` : ''}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
       </div>
 
       {/* Settings */}

--- a/src/pages/org/AssessmentResults.tsx
+++ b/src/pages/org/AssessmentResults.tsx
@@ -11,10 +11,11 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
   ArrowLeft, Loader2, ClipboardList, UserPlus, Download,
-  Play, Pause, Users, CheckCircle2, XCircle, Clock, Eye,
+  Play, Pause, Users, Upload, Briefcase,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import InviteCandidatesModal from '@/components/org/InviteCandidatesModal';
+import CsvImportModal from '@/components/org/CsvImportModal';
 import CandidateRanking from '@/components/org/CandidateRanking';
 import AssessmentFunnel from '@/components/org/AssessmentFunnel';
 
@@ -32,6 +33,7 @@ const AssessmentResults = () => {
   const currentOrg = useOrgStore((s) => s.currentOrg);
   const slug = currentOrg?.slug || '';
   const [showInvite, setShowInvite] = useState(false);
+  const [showCsvImport, setShowCsvImport] = useState(false);
 
   const { data, isLoading } = useQuery({
     queryKey: ['assessment-results', slug, aid],
@@ -45,6 +47,7 @@ const AssessmentResults = () => {
     onSuccess: (result) => {
       toast.success(`${result.invited} candidate(s) invited`);
       setShowInvite(false);
+      setShowCsvImport(false);
       queryClient.invalidateQueries({ queryKey: ['assessment-results', slug, aid] });
     },
     onError: (e: any) => toast.error(e?.response?.data?.message || 'Invite failed'),
@@ -106,7 +109,7 @@ const AssessmentResults = () => {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
         <div className="flex items-center gap-3">
           <Button variant="ghost" size="icon" onClick={() => navigate(`/org/${slug}/assessments`)}>
             <ArrowLeft className="h-4 w-4" />
@@ -116,10 +119,17 @@ const AssessmentResults = () => {
               <ClipboardList className="h-6 w-6 text-primary" />
               {assessment.title}
             </h1>
-            <div className="flex items-center gap-2 mt-1">
+            <div className="flex items-center gap-2 mt-1 flex-wrap">
               <Badge className={`text-[10px] ${statusColors[assessment.status]}`}>
                 {assessment.status}
               </Badge>
+              {assessment.jobRole && (
+                <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
+                  <Briefcase className="h-3 w-3" />
+                  {assessment.jobRole.title}
+                  {assessment.jobRole.department && ` · ${assessment.jobRole.department}`}
+                </span>
+              )}
               <span className="text-xs text-muted-foreground font-mono">
                 {assessment.questionCount} questions · {assessment.timeLimit} min
                 {assessment.passingScore != null && ` · ${assessment.passingScore}% to pass`}
@@ -128,9 +138,10 @@ const AssessmentResults = () => {
           </div>
         </div>
 
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex items-center gap-2 shrink-0 flex-wrap">
           {assessment.status === 'DRAFT' && (
-            <Button size="sm" variant="outline" onClick={() => statusMutation.mutate('ACTIVE')}>
+            <Button size="sm" variant="outline" onClick={() => statusMutation.mutate('ACTIVE')}
+              disabled={statusMutation.isPending}>
               <Play className="h-4 w-4 mr-1.5" /> Activate
             </Button>
           )}
@@ -139,7 +150,11 @@ const AssessmentResults = () => {
               <Button size="sm" className="glow-cyan" onClick={() => setShowInvite(true)}>
                 <UserPlus className="h-4 w-4 mr-1.5" /> Invite
               </Button>
-              <Button size="sm" variant="outline" onClick={() => statusMutation.mutate('CLOSED')}>
+              <Button size="sm" variant="outline" onClick={() => setShowCsvImport(true)}>
+                <Upload className="h-4 w-4 mr-1.5" /> Import CSV
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => statusMutation.mutate('CLOSED')}
+                disabled={statusMutation.isPending}>
                 <Pause className="h-4 w-4 mr-1.5" /> Close
               </Button>
             </>
@@ -152,14 +167,21 @@ const AssessmentResults = () => {
         </div>
       </div>
 
-      {/* Funnel Stats */}
+      {/* Funnel */}
       <AssessmentFunnel funnel={funnel} />
 
-      {/* Candidate Rankings */}
+      {/* Stage pipeline summary */}
+      {candidates.length > 0 && (
+        <StageSummary candidates={candidates} />
+      )}
+
+      {/* Candidate table */}
       {candidates.length > 0 ? (
         <CandidateRanking
           candidates={candidates}
           passingScore={assessment.passingScore}
+          slug={slug}
+          aid={aid!}
           onReinvite={assessment.status === 'ACTIVE' ? (email) => reinviteMutation.mutate(email) : undefined}
           isReinviting={reinviteMutation.isPending}
         />
@@ -168,20 +190,71 @@ const AssessmentResults = () => {
           <Users className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
           <p className="text-muted-foreground font-mono text-sm">No candidates yet</p>
           {assessment.status === 'ACTIVE' && (
-            <Button className="mt-4 glow-cyan" onClick={() => setShowInvite(true)}>
-              <UserPlus className="h-4 w-4 mr-1.5" /> Invite Candidates
-            </Button>
+            <div className="flex justify-center gap-2 mt-4">
+              <Button className="glow-cyan" onClick={() => setShowInvite(true)}>
+                <UserPlus className="h-4 w-4 mr-1.5" /> Invite Candidates
+              </Button>
+              <Button variant="outline" onClick={() => setShowCsvImport(true)}>
+                <Upload className="h-4 w-4 mr-1.5" /> Import CSV
+              </Button>
+            </div>
           )}
         </div>
       )}
 
-      {/* Invite Modal */}
+      {/* Invite modal */}
       <InviteCandidatesModal
         open={showInvite}
         onClose={() => setShowInvite(false)}
         onInvite={(candidates) => inviteMutation.mutate(candidates)}
         isPending={inviteMutation.isPending}
       />
+
+      {/* CSV import modal */}
+      <CsvImportModal
+        open={showCsvImport}
+        onClose={() => setShowCsvImport(false)}
+        onImport={(candidates) => inviteMutation.mutate(candidates)}
+        isPending={inviteMutation.isPending}
+      />
+    </div>
+  );
+};
+
+// ─── Stage summary bar ────────────────────────────────────────────────────────
+
+import type { CandidateInvite, CandidateStage } from '@/types/assessment-types';
+
+const STAGES: { stage: CandidateStage; label: string; color: string }[] = [
+  { stage: 'APPLIED',     label: 'Applied',     color: 'bg-blue-500/20 text-blue-400' },
+  { stage: 'SCREENING',   label: 'Screening',   color: 'bg-amber-500/20 text-amber-400' },
+  { stage: 'SHORTLISTED', label: 'Shortlisted', color: 'bg-violet-500/20 text-violet-400' },
+  { stage: 'HIRED',       label: 'Hired',       color: 'bg-emerald-500/20 text-emerald-400' },
+  { stage: 'REJECTED',    label: 'Rejected',    color: 'bg-red-500/20 text-red-400' },
+];
+
+const StageSummary = ({ candidates }: { candidates: CandidateInvite[] }) => {
+  const counts = candidates.reduce<Record<string, number>>((acc, c) => {
+    const stage = c.stage ?? 'APPLIED';
+    acc[stage] = (acc[stage] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {STAGES.map(({ stage, label, color }) => {
+        const count = counts[stage] ?? 0;
+        if (count === 0) return null;
+        return (
+          <span
+            key={stage}
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[11px] font-mono ${color}`}
+          >
+            {label}
+            <span className="font-bold">{count}</span>
+          </span>
+        );
+      })}
     </div>
   );
 };

--- a/src/pages/org/OrgJobRoles.tsx
+++ b/src/pages/org/OrgJobRoles.tsx
@@ -1,0 +1,333 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useOrgStore } from '@/stores/org.store';
+import {
+  getJobRoles, createJobRole, updateJobRole, deleteJobRole,
+} from '@/services/job-roles';
+import type { JobRole } from '@/types/assessment-types';
+import type { CreateJobRolePayload, UpdateJobRolePayload } from '@/services/job-roles';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Briefcase, Plus, MoreVertical, Pencil, Trash2,
+  Loader2, Building2, ClipboardList, ToggleLeft, ToggleRight,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+// ─── Job Role Form Modal ──────────────────────────────────────────────────────
+
+interface FormModalProps {
+  open: boolean;
+  onClose: () => void;
+  initial?: JobRole | null;
+  onSave: (data: CreateJobRolePayload | UpdateJobRolePayload) => void;
+  isPending: boolean;
+}
+
+const JobRoleFormModal = ({
+  open,
+  onClose,
+  initial,
+  onSave,
+  isPending,
+}: FormModalProps) => {
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [department, setDepartment] = useState(initial?.department ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+
+  // Reset when opened with new initial value
+  const handleOpen = () => {
+    setTitle(initial?.title ?? '');
+    setDepartment(initial?.department ?? '');
+    setDescription(initial?.description ?? '');
+  };
+
+  const handleSubmit = () => {
+    if (!title.trim()) return;
+    onSave({
+      title: title.trim(),
+      department: department.trim() || undefined,
+      description: description.trim() || undefined,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); else handleOpen(); }}>
+      <DialogContent className="max-w-md bg-card border-border">
+        <DialogHeader>
+          <DialogTitle className="font-mono flex items-center gap-2">
+            <Briefcase className="h-4 w-4 text-primary" />
+            {initial ? 'Edit Job Role' : 'New Job Role'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <label className="text-[11px] font-mono text-muted-foreground uppercase tracking-wider">
+              Title *
+            </label>
+            <Input
+              className="mt-1 font-mono text-sm bg-muted/30 border-border"
+              placeholder="e.g. Senior Backend Engineer"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-mono text-muted-foreground uppercase tracking-wider">
+              Department
+            </label>
+            <Input
+              className="mt-1 font-mono text-sm bg-muted/30 border-border"
+              placeholder="e.g. Engineering"
+              value={department}
+              onChange={(e) => setDepartment(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-mono text-muted-foreground uppercase tracking-wider">
+              Description
+            </label>
+            <Textarea
+              className="mt-1 font-mono text-xs bg-muted/30 border-border resize-none min-h-[80px]"
+              placeholder="Optional role description…"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            className="glow-cyan"
+            onClick={handleSubmit}
+            disabled={isPending || !title.trim()}
+          >
+            {isPending ? 'Saving…' : initial ? 'Save changes' : 'Create role'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+const OrgJobRoles = () => {
+  const queryClient = useQueryClient();
+  const currentOrg = useOrgStore((s) => s.currentOrg);
+  const slug = currentOrg?.slug || '';
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [editTarget, setEditTarget] = useState<JobRole | null>(null);
+
+  const { data: roles = [], isLoading } = useQuery({
+    queryKey: ['job-roles', slug],
+    queryFn: () => getJobRoles(slug),
+    enabled: !!slug,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateJobRolePayload) => createJobRole(slug, data),
+    onSuccess: () => {
+      toast.success('Job role created');
+      setShowCreate(false);
+      queryClient.invalidateQueries({ queryKey: ['job-roles', slug] });
+    },
+    onError: (e: any) => toast.error(e?.response?.data?.message || 'Create failed'),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateJobRolePayload }) =>
+      updateJobRole(slug, id, data),
+    onSuccess: () => {
+      toast.success('Updated');
+      setEditTarget(null);
+      queryClient.invalidateQueries({ queryKey: ['job-roles', slug] });
+    },
+    onError: (e: any) => toast.error(e?.response?.data?.message || 'Update failed'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteJobRole(slug, id),
+    onSuccess: () => {
+      toast.success('Deleted');
+      queryClient.invalidateQueries({ queryKey: ['job-roles', slug] });
+    },
+    onError: (e: any) => toast.error(e?.response?.data?.message || 'Delete failed'),
+  });
+
+  const toggleActive = (role: JobRole) => {
+    updateMutation.mutate({ id: role.id, data: { isActive: !role.isActive } });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-mono font-bold flex items-center gap-2">
+            <Briefcase className="h-6 w-6 text-primary" />
+            Job Roles
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage open positions and link them to assessments
+          </p>
+        </div>
+        <Button className="glow-cyan" onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4 mr-1.5" /> New Role
+        </Button>
+      </div>
+
+      {/* Empty state */}
+      {roles.length === 0 ? (
+        <div className="text-center py-16 space-y-3">
+          <Briefcase className="h-12 w-12 text-muted-foreground mx-auto" />
+          <p className="text-muted-foreground font-mono text-sm">No job roles yet</p>
+          <Button onClick={() => setShowCreate(true)}>
+            <Plus className="h-4 w-4 mr-1.5" /> Create first role
+          </Button>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {roles.map((role) => (
+            <Card
+              key={role.id}
+              className={`bg-card border-border transition-opacity ${
+                role.isActive ? '' : 'opacity-50'
+              }`}
+            >
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <h3 className="font-mono font-semibold text-sm truncate">
+                      {role.title}
+                    </h3>
+                    {role.department && (
+                      <p className="text-[11px] text-muted-foreground flex items-center gap-1 mt-0.5">
+                        <Building2 className="h-3 w-3 shrink-0" />
+                        {role.department}
+                      </p>
+                    )}
+                  </div>
+
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+                      >
+                        <MoreVertical className="h-3.5 w-3.5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="text-xs font-mono w-40">
+                      <DropdownMenuItem onClick={() => setEditTarget(role)}>
+                        <Pencil className="h-3.5 w-3.5 mr-2" /> Edit
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => toggleActive(role)}>
+                        {role.isActive ? (
+                          <>
+                            <ToggleLeft className="h-3.5 w-3.5 mr-2" /> Deactivate
+                          </>
+                        ) : (
+                          <>
+                            <ToggleRight className="h-3.5 w-3.5 mr-2" /> Activate
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-red-400 focus:text-red-400"
+                        onClick={() => {
+                          if (confirm(`Delete "${role.title}"? This cannot be undone.`)) {
+                            deleteMutation.mutate(role.id);
+                          }
+                        }}
+                      >
+                        <Trash2 className="h-3.5 w-3.5 mr-2" /> Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                {role.description && (
+                  <p className="text-[11px] text-muted-foreground line-clamp-2">
+                    {role.description}
+                  </p>
+                )}
+
+                <div className="flex items-center justify-between">
+                  <Badge
+                    className={
+                      role.isActive
+                        ? 'bg-emerald-500/15 text-emerald-400 text-[10px]'
+                        : 'bg-zinc-500/15 text-zinc-400 text-[10px]'
+                    }
+                  >
+                    {role.isActive ? 'Active' : 'Inactive'}
+                  </Badge>
+                  {role._count?.assessments != null && role._count.assessments > 0 && (
+                    <span className="flex items-center gap-1 text-[10px] text-muted-foreground font-mono">
+                      <ClipboardList className="h-3 w-3" />
+                      {role._count.assessments} assessment{role._count.assessments !== 1 ? 's' : ''}
+                    </span>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Create modal */}
+      <JobRoleFormModal
+        open={showCreate}
+        onClose={() => setShowCreate(false)}
+        onSave={(data) => createMutation.mutate(data as CreateJobRolePayload)}
+        isPending={createMutation.isPending}
+      />
+
+      {/* Edit modal */}
+      <JobRoleFormModal
+        open={!!editTarget}
+        onClose={() => setEditTarget(null)}
+        initial={editTarget}
+        onSave={(data) =>
+          editTarget && updateMutation.mutate({ id: editTarget.id, data })
+        }
+        isPending={updateMutation.isPending}
+      />
+    </div>
+  );
+};
+
+export default OrgJobRoles;

--- a/src/services/assessments.ts
+++ b/src/services/assessments.ts
@@ -11,6 +11,8 @@ import type {
   CandidateExamPayload,
   CandidateSubmitResult,
   CandidateAnswerPayload,
+  CandidateInvite,
+  UpdateCandidateDecisionPayload,
   PoolConfig,
 } from '@/types/assessment-types';
 
@@ -135,4 +137,29 @@ export const reportCandidateEvent = async (
   eventType: string,
 ): Promise<void> => {
   await api.post(`/assessments/take/${token}/event`, { eventType });
+};
+
+export const updateCandidateDecision = async (
+  slug: string,
+  aid: string,
+  inviteId: string,
+  data: UpdateCandidateDecisionPayload,
+): Promise<CandidateInvite> => {
+  const res = await api.patch<CandidateInvite>(
+    `${base(slug)}/${aid}/candidates/${inviteId}`,
+    data,
+  );
+  return res.data;
+};
+
+export const bulkInviteCandidatesFromCsv = async (
+  slug: string,
+  aid: string,
+  candidates: { email: string; name?: string }[],
+): Promise<{ invited: number }> => {
+  const res = await api.post<{ invited: number }>(
+    `${base(slug)}/${aid}/invite`,
+    { candidates },
+  );
+  return res.data;
 };

--- a/src/services/job-roles.ts
+++ b/src/services/job-roles.ts
@@ -1,0 +1,46 @@
+import api from './api';
+import type { JobRole } from '@/types/assessment-types';
+
+const base = (slug: string) => `/organizations/${slug}/job-roles`;
+
+export const getJobRoles = async (slug: string): Promise<JobRole[]> => {
+  const res = await api.get<JobRole[]>(base(slug));
+  return res.data;
+};
+
+export interface CreateJobRolePayload {
+  title: string;
+  department?: string;
+  description?: string;
+}
+
+export interface UpdateJobRolePayload {
+  title?: string;
+  department?: string;
+  description?: string;
+  isActive?: boolean;
+}
+
+export const createJobRole = async (
+  slug: string,
+  data: CreateJobRolePayload,
+): Promise<JobRole> => {
+  const res = await api.post<JobRole>(base(slug), data);
+  return res.data;
+};
+
+export const updateJobRole = async (
+  slug: string,
+  roleId: string,
+  data: UpdateJobRolePayload,
+): Promise<JobRole> => {
+  const res = await api.patch<JobRole>(`${base(slug)}/${roleId}`, data);
+  return res.data;
+};
+
+export const deleteJobRole = async (
+  slug: string,
+  roleId: string,
+): Promise<void> => {
+  await api.delete(`${base(slug)}/${roleId}`);
+};

--- a/src/types/assessment-types.ts
+++ b/src/types/assessment-types.ts
@@ -3,6 +3,19 @@ import type { PaginatedResponse } from './api-types';
 export type AssessmentStatus = 'DRAFT' | 'ACTIVE' | 'CLOSED' | 'ARCHIVED';
 export type CandidateAttemptStatus = 'INVITED' | 'STARTED' | 'SUBMITTED' | 'EXPIRED';
 export type AssessmentSelectionMode = 'MANUAL' | 'BLUEPRINT' | 'POOL';
+export type CandidateStage = 'APPLIED' | 'SCREENING' | 'SHORTLISTED' | 'REJECTED' | 'HIRED';
+
+export interface JobRole {
+  id: string;
+  orgId: string;
+  title: string;
+  department: string | null;
+  description: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  _count?: { assessments: number };
+}
 
 // ─── Blueprint / Pool config shapes ──────────────────────────────────────────
 
@@ -55,6 +68,8 @@ export interface Assessment {
   detectTabSwitch: boolean;
   blockCopyPaste: boolean;
   linkExpiryHours: number;
+  jobRoleId: string | null;
+  jobRole?: { id: string; title: string; department: string | null } | null;
   createdBy: string;
   createdAt: string;
   updatedAt: string;
@@ -82,7 +97,20 @@ export interface CandidateInvite {
   submittedAt: string | null;
   expiresAt: string;
   drawnQuestionIds: string[];
+  // P1: Recruiting pipeline
+  stage: CandidateStage;
+  rating: number | null;
+  recruiterNote: string | null;
+  decidedBy: string | null;
+  decidedAt: string | null;
+  percentile: number | null;
   createdAt: string;
+}
+
+export interface UpdateCandidateDecisionPayload {
+  stage?: CandidateStage;
+  rating?: number;
+  recruiterNote?: string;
 }
 
 export interface AssessmentResults {
@@ -151,6 +179,7 @@ export interface CreateAssessmentPayload {
   detectTabSwitch?: boolean;
   blockCopyPaste?: boolean;
   linkExpiryHours?: number;
+  jobRoleId?: string;
   // Selection mode fields
   selectionMode?: AssessmentSelectionMode;
   selectionConfig?: SelectionConfig;

--- a/src/types/org-types.ts
+++ b/src/types/org-types.ts
@@ -1,6 +1,6 @@
 // Organization types — aligned with backend Prisma responses
 
-export type OrgRole = 'OWNER' | 'ADMIN' | 'MANAGER' | 'MEMBER';
+export type OrgRole = 'OWNER' | 'ADMIN' | 'MANAGER' | 'RECRUITER' | 'MEMBER';
 export type OrgInviteStatus = 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
 
 export interface Organization {


### PR DESCRIPTION
## Summary

Implements **P1 of the Enterprise Entrance Exam upgrade** — an ATS-lite recruiting pipeline on top of the existing Candidate Assessment feature built in P0.

- **JobRole model** — orgs can define open positions and link assessments to them
- **RECRUITER role** — new org role with scoped access (Assessments + Job Roles only; no question bank / settings)
- **Candidate pipeline** — stage transitions (Applied → Screening → Shortlisted → Hired / Rejected), 1–5 star rating, internal recruiter notes with `decidedBy` / `decidedAt` audit trail
- **Percentile ranking** — each submitted candidate gets a percentile score relative to peers on the same assessment
- **CSV bulk import** — drag-drop RFC-4180 compliant parser with preview + error rows; bulk-invite from file
- **P1 CSV export** — extended with Stage, Percentile, Rating, Recruiter Note columns + proper field escaping

## Commits

| Commit | Description |
|--------|-------------|
| `aa9e1ae` | feat: P1 Recruiting Workflow — schema, backend, frontend |
| `2ab3f34` | fix: code review findings (Fragment key, drawer state sync, CSV parser, export fields) |
| `780f2e5` | chore: package-lock after prisma generate |

## Changes

### Database (`20260712000001_p1_recruiting_workflow`)
- `OrgRole`: add `RECRUITER`
- `CandidateStage` enum: APPLIED / SCREENING / SHORTLISTED / REJECTED / HIRED
- `JobRole` table: title, department, description, isActive, org FK (CASCADE)
- `Assessment.job_role_id`: optional FK → JobRole (SET NULL on delete)
- `CandidateInvite`: stage, rating, recruiter_note, decided_by, decided_at

### Backend
- **`job-roles` module** — `GET/POST/PATCH/DELETE /organizations/:orgId/job-roles`; RECRUITER can create/update, only OWNER/ADMIN can delete
- **`PATCH .../assessments/:aid/candidates/:inviteId`** — update stage/rating/note; auto-sets decidedBy/decidedAt on SHORTLISTED/HIRED/REJECTED; no-op guard for empty payload
- **`getResults`** — percentile rank per submitted candidate; includes `jobRole` on assessment
- **`create/update assessment`** — accepts `jobRoleId`
- **`exportCsv`** — Stage, Percentile, Rating, Recruiter Note columns; CSV-safe quoting
- **RECRUITER guard** — added to `AssessmentsController` class-level `@OrgRoles`
- Unit tests: `job-roles.service.spec.ts` (CRUD, 404 paths), `assessments-p1.service.spec.ts` (percentile calculation, decision update, empty-payload guard)

### Frontend
- **`CandidateRanking`** — Stage badge column, Percentile column, ⭐ star rating (readonly in table), action dropdown (Move to stage, View details, Re-send); detail drawer with domain breakdown + editable rating/note; Fragment key fix; drawer state syncs on candidate change
- **`CsvImportModal`** — RFC-4180 parser (quoted commas, `\r\n`), drag-drop + browse, preview table with per-row validation, example CSV download
- **`AssessmentResults`** — Import CSV button, stage summary bar (counts per stage), job role chip in header
- **`AssessmentBuilder`** — Job Role selector (shown when org has active roles); persists `jobRoleId`
- **`OrgJobRoles` page** — card grid with create/edit/deactivate/delete; linked assessment count badge
- **`OrgSidebar`** — "Job Roles" nav item (OWNER/ADMIN/MANAGER/RECRUITER); RECRUITER hides Dashboard/Members/Groups/Questions/Catalog/Tracks/Settings
- **`App.tsx`** — `/org/:slug/job-roles` lazy route

## Test plan

- [ ] Create a Job Role → appears in AssessmentBuilder selector
- [ ] Create assessment linked to Job Role → shows role chip in Results header
- [ ] Invite candidate via manual form → appears in table with stage APPLIED
- [ ] Import 3 candidates via CSV (including one with quoted name "Smith, John") → 3 invites created
- [ ] Import CSV with invalid email → error row shown, not imported
- [ ] Move candidate to SHORTLISTED via action menu → stage badge updates; decidedAt set
- [ ] Open candidate detail drawer → edit rating + note → save → reopen → values persist
- [ ] Open drawer for candidate A, then candidate B → note/rating resets correctly
- [ ] Export CSV → verify Stage, Percentile, Rating, Recruiter Note columns present
- [ ] Log in as RECRUITER → only sees Assessments + Job Roles in sidebar; `/questions` → 403
- [ ] MEMBER user → cannot call `POST /job-roles` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)