### PR TITLE
docs: add SRS for P0–P3 Enterprise Entrance Exam phases

### DIFF
--- a/docs/specs/p0-smart-assessment-builder-srs.md
+++ b/docs/specs/p0-smart-assessment-builder-srs.md
@@ -1,0 +1,234 @@
+# SRS — P0: Smart Assessment Builder
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | P0 — Smart Assessment Builder (Tạo đề thông minh cho Enterprise) |
+| **Phiên bản** | 1.0 (Implemented) |
+| **Ngày** | 2026-06-05 |
+| **Trạng thái** | Đã triển khai — tài liệu hóa sau implement |
+| **Phụ thuộc** | Không (P0 là phase đầu tiên) |
+| **Module liên quan** | `assessments` (backend) · `AssessmentBuilder.tsx` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Tài liệu này đặc tả yêu cầu cho **P0 — Smart Assessment Builder**, bổ sung hai chế độ tạo đề thông minh (**Blueprint** và **Pool**) vào tính năng Candidate Assessment của CertGym Enterprise. Thay vì chọn tay từng câu hỏi (MANUAL), Admin org có thể khai báo cấu hình và hệ thống tự động lấy câu hỏi từ ngân hàng câu hỏi riêng của org.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Thêm enum `AssessmentSelectionMode`: MANUAL / BLUEPRINT / POOL.
+- Chế độ BLUEPRINT: tự build danh sách câu hỏi cố định theo % domain tại thời điểm tạo đề.
+- Chế độ POOL: mỗi ứng viên nhận bộ câu ngẫu nhiên khác nhau khi bắt đầu; snapshot để reload bất biến.
+- API preview đếm số câu khả dụng cho pool filter.
+- Validation chặn tạo đề khi không đủ câu.
+- Frontend: UI chọn 3 chế độ trong AssessmentBuilder.
+
+**Ngoài phạm vi:**
+- Blueprint theo ma trận domain × difficulty (để dành P3 của Smart Exam Builder cộng đồng).
+- Sinh câu hỏi mới bằng AI.
+- Chế độ MANUAL (đã có từ trước P0).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **MANUAL** | Chế độ cũ — Admin chọn câu hỏi cụ thể, lưu thành `AssessmentQuestion` rows |
+| **BLUEPRINT** | Build 1 bộ câu cố định tại thời điểm tạo assessment theo % domain từ `OrgQuestion` APPROVED |
+| **POOL** | Không vật chất hóa trước; rút ngẫu nhiên N câu cho từng ứng viên khi họ bắt đầu |
+| **selectionConfig** | JSON config mô tả blueprint/pool (totalQuestions, domains, drawCount, v.v.) |
+| **drawnQuestionIds** | Snapshot IDs đã rút cho một `CandidateInvite` cụ thể (POOL mode, idempotent) |
+| **pool-count** | Số câu `OrgQuestion` APPROVED khớp filter config của pool |
+
+### 1.4. Hiện trạng trước P0
+
+- `Assessment.questions` là mảng `AssessmentQuestion` — Admin tick tay từng câu.
+- Không kiểm soát domain/difficulty distribution.
+- Mỗi ứng viên nhận cùng bộ câu (chỉ random thứ tự nếu bật).
+
+---
+
+## 2. Mô tả tổng quan
+
+### 2.1. Bối cảnh sản phẩm
+
+P0 tận dụng logic blueprint đã có trong Smart Exam Builder cộng đồng (PR #69/#70) và tái sử dụng `OrgQuestion` APPROVED. BLUEPRINT phù hợp khi muốn đảm bảo tỉ lệ domain cố định (ví dụ: AWS exam có 35% Security, 30% Compute). POOL phù hợp khi cần ngăn chia sẻ đề giữa các ứng viên.
+
+### 2.2. Nguyên tắc thiết kế
+
+- MANUAL/BLUEPRINT: vật chất hóa qua `AssessmentQuestion` (có thể xem/sửa danh sách).
+- POOL: không vật chất hóa; `CandidateInvite.drawnQuestionIds` là snapshot idempotent (lần đầu rút, các lần sau load lại).
+- `selectionMode` **không thể thay đổi** sau khi assessment được tạo (tránh inconsistency với invites đã có).
+- Nguồn câu hỏi: chỉ dùng `OrgQuestion` với `status = APPROVED` của org đó.
+
+---
+
+## 3. Yêu cầu chức năng
+
+### FR-1 — Ba chế độ tạo đề
+
+**FR-1.1**: `Assessment` có field `selectionMode: AssessmentSelectionMode` (default: `MANUAL`) và `selectionConfig: Json?`.
+
+**FR-1.2**: Khi tạo assessment:
+- `MANUAL` → payload chứa danh sách `questionIds` → backend ghi `AssessmentQuestion` rows (hành vi cũ).
+- `BLUEPRINT` → payload chứa `selectionConfig` với danh sách domain + % → backend tự rút câu và ghi `AssessmentQuestion` rows.
+- `POOL` → payload chứa `selectionConfig` với `drawCount` + filter → backend validate đủ câu, ghi `selectionConfig`, **không ghi** `AssessmentQuestion`.
+
+**FR-1.3**: `selectionMode` không được đổi sau khi tạo (`PATCH` nhận `selectionMode` → `400 Bad Request`).
+
+**FR-1.4**: Khi `PATCH` (sửa assessment):
+- `MANUAL` → có thể cập nhật `questionIds`.
+- `BLUEPRINT` → có thể cập nhật `selectionConfig` → backend rebuild `AssessmentQuestion` (xóa cũ, tạo mới).
+- `POOL` → có thể cập nhật `selectionConfig` → validate lại đủ câu.
+
+---
+
+### FR-2 — BLUEPRINT: build câu theo domain %
+
+**FR-2.1**: `selectionConfig` cho BLUEPRINT:
+
+```jsonc
+{
+  "totalQuestions": 30,
+  "domains": [
+    { "domain": "Security", "percentage": 40 },
+    { "domain": "Compute",  "percentage": 35 },
+    { "domain": "Storage",  "percentage": 25 }
+  ],
+  "difficulty": "MEDIUM"   // optional — filter thêm theo difficulty
+}
+```
+
+**FR-2.2**: Backend tính số câu mỗi domain: `Math.round(total × pct/100)`. Dư/thiếu do làm tròn → dồn vào domain có % lớn nhất.
+
+**FR-2.3**: Với mỗi domain, query ngẫu nhiên đúng số câu `OrgQuestion` có `status=APPROVED`, `category` khớp domain (và `difficulty` nếu có). Shuffle và chọn.
+
+**FR-2.4**: Nếu bất kỳ domain nào không đủ câu → `400 Bad Request` với thông báo rõ domain thiếu, số cần, số có.
+
+**FR-2.5**: Ghi kết quả vào `AssessmentQuestion` (cùng cấu trúc với MANUAL).
+
+---
+
+### FR-3 — POOL: rút ngẫu nhiên per-candidate
+
+**FR-3.1**: `selectionConfig` cho POOL:
+
+```jsonc
+{
+  "drawCount": 15,
+  "certificationId": "uuid",   // optional filter
+  "difficulty": "HARD",        // optional filter
+  "categories": ["Security"],  // optional filter
+  "tags": ["aws", "iam"]       // optional filter
+}
+```
+
+**FR-3.2**: Khi tạo assessment POOL → backend validate `available >= drawCount` (gọi `countPoolQuestions`). Nếu không đủ → `400 Bad Request`.
+
+**FR-3.3**: `questionCount` của assessment được set = `drawCount` (để UI hiển thị "X câu").
+
+**FR-3.4**: Khi ứng viên gọi `POST /take/:token/start`:
+- Lần đầu: rút ngẫu nhiên `drawCount` câu từ pool, lưu IDs vào `CandidateInvite.drawnQuestionIds`.
+- Lần sau (reload): load theo `drawnQuestionIds` — **cùng bộ câu**.
+
+**FR-3.5**: Hai ứng viên khác nhau của cùng assessment POOL nhận bộ câu khác nhau (xác suất cao với pool đủ lớn).
+
+---
+
+### FR-4 — Preview pool count
+
+**Endpoint**: `GET /organizations/:orgId/assessments/pool-count?config=<JSON>`
+
+- `config` là URL-encoded JSON của pool filter (drawCount, certificationId, difficulty, categories, tags).
+- Response: `{ available: number }`.
+- Guard: `JwtAuthGuard + OrgRoleGuard(OWNER, ADMIN, MANAGER, RECRUITER)`.
+- Dùng bởi frontend để hiển thị "X câu khả dụng" realtime khi Admin cấu hình pool.
+
+---
+
+### FR-5 — Validation lỗi thiếu câu
+
+**FR-5.1**: `400 Bad Request` với body:
+
+```jsonc
+{
+  "message": "Not enough approved questions for blueprint: domain 'Security' needs 12, found 8",
+  "error": "Bad Request",
+  "statusCode": 400
+}
+```
+
+**FR-5.2**: Frontend disable nút "Tạo Assessment" nếu:
+- BLUEPRINT: tổng % ≠ 100%.
+- POOL: `poolAvailable < drawCount` hoặc `poolAvailable === null`.
+
+---
+
+### FR-6 — Frontend: 3-mode selector trong AssessmentBuilder
+
+**FR-6.1**: UI hiển thị 3 tab/card chọn chế độ: **Manual**, **Blueprint**, **Pool**.
+
+**FR-6.2**: Chọn BLUEPRINT → hiển thị `BlueprintDomainEditor`: mỗi domain một dòng với input % (tổng phải = 100%).
+
+**FR-6.3**: Chọn POOL → hiển thị các filter (drawCount, difficulty, categories) + badge "X câu khả dụng" (gọi `pool-count` debounced).
+
+**FR-6.4**: Khi edit assessment đã tạo → mode selector disabled (không cho đổi mode); hiển thị mode hiện tại read-only.
+
+---
+
+## 4. Yêu cầu phi chức năng
+
+| ID | Yêu cầu |
+|---|---|
+| NFR-1 (Hiệu năng) | `buildBlueprintQuestions` và `countPoolQuestions` < 500ms với 10k OrgQuestion. Index cần: `(orgId, status, category, difficulty)` trên `org_questions`. |
+| NFR-2 (Idempotency) | `drawnQuestionIds` snapshot bất biến — reload không thay đổi bộ câu của ứng viên. |
+| NFR-3 (Backward compat) | MANUAL behavior không thay đổi; assessment cũ không có `selectionMode` → mặc định MANUAL. |
+| NFR-4 (Atomic blueprint build) | Build + ghi `AssessmentQuestion` trong Prisma `$transaction` để tránh partial state. |
+
+---
+
+## 5. Schema Prisma
+
+```prisma
+enum AssessmentSelectionMode {
+  MANUAL
+  BLUEPRINT
+  POOL
+}
+
+model Assessment {
+  // ... existing fields ...
+  selectionMode   AssessmentSelectionMode @default(MANUAL) @map("selection_mode")
+  selectionConfig Json?                   @map("selection_config")
+}
+
+model CandidateInvite {
+  // ... existing fields ...
+  drawnQuestionIds String[] @default([]) @map("drawn_question_ids")
+}
+```
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] Tạo assessment BLUEPRINT 30 câu (Security 40%, Compute 35%, Storage 25%) → `AssessmentQuestion` có đúng 12/11/7 câu (làm tròn dồn domain lớn nhất).
+- [ ] Tạo assessment POOL drawCount=15 → 2 ứng viên start → 2 bộ câu khác nhau; cùng token reload → cùng bộ câu.
+- [ ] POOL config vượt số câu khả dụng → `400` khi tạo.
+- [ ] `GET pool-count` trả đúng số câu APPROVED khớp filter.
+- [ ] PATCH đổi `selectionMode` → `400`.
+- [ ] MANUAL assessment vẫn hoạt động đúng (regression).
+
+---
+
+## 7. Liên kết
+
+- **Kế hoạch tổng**: [enterprise-entrance-exam-plan.md](../enterprise-entrance-exam-plan.md)
+- **Schema**: [backend/prisma/schema.prisma](../../backend/prisma/schema.prisma)
+- **Service**: [backend/src/assessments/assessments.service.ts](../../backend/src/assessments/assessments.service.ts)
+- **Candidate service**: [backend/src/assessments/candidate.service.ts](../../backend/src/assessments/candidate.service.ts)
+- **Frontend builder**: [src/pages/org/AssessmentBuilder.tsx](../../src/pages/org/AssessmentBuilder.tsx)

--- a/docs/specs/p1-recruiting-workflow-srs.md
+++ b/docs/specs/p1-recruiting-workflow-srs.md
@@ -1,0 +1,255 @@
+# SRS — P1: Recruiting Workflow (ATS-lite)
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | P1 — Recruiting Workflow (ATS-lite) |
+| **Phiên bản** | 1.0 (Implemented) |
+| **Ngày** | 2026-06-05 |
+| **Trạng thái** | Đã triển khai — tài liệu hóa sau implement |
+| **Phụ thuộc** | P0 (Smart Assessment Builder) — nên có trước |
+| **Module liên quan** | `assessments`, `organizations` (backend) · `AssessmentResults.tsx`, `CandidateRanking.tsx` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Tài liệu này đặc tả yêu cầu cho **P1 — Recruiting Workflow (ATS-lite)**, biến danh sách invite ứng viên thành một pipeline tuyển dụng đơn giản. Admin/Recruiter có thể gắn assessment với vị trí tuyển dụng (Job Role), xem xếp hạng ứng viên, đánh dấu quyết định (shortlist/reject/hire), import hàng loạt từ CSV, và phân quyền RECRUITER riêng biệt.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Role `RECRUITER` cho org member — quyền hạn chế chỉ đọc/ghi assessment & candidates.
+- Model `JobRole` — vị trí tuyển dụng gắn với assessment.
+- Pipeline stage cho `CandidateInvite`: APPLIED → SCREENING → SHORTLISTED → REJECTED / HIRED.
+- Recruiter rating (1–5 sao) và ghi chú nội bộ.
+- Tính toán và hiển thị percentile theo điểm trong cùng assessment.
+- Bulk import ứng viên từ CSV (client-side parse).
+- Export kết quả ra CSV (mở rộng từ export đã có).
+- Frontend: bảng ứng viên đầy đủ với drawer chi tiết, stage pipeline summary.
+
+**Ngoài phạm vi:**
+- Tích hợp ATS bên ngoài (Greenhouse, Lever, Workday).
+- Email thông báo khi stage thay đổi (thuộc P3).
+- Lịch phỏng vấn / calendar integration.
+- Scorecard / structured interview templates.
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **RECRUITER** | Org role mới — chỉ xem/quản lý assessment & candidates; không sửa question bank, org settings, members |
+| **JobRole** | Vị trí tuyển dụng (tên + department) gắn với một hoặc nhiều assessment |
+| **CandidateStage** | Trạng thái trong pipeline tuyển dụng của ứng viên |
+| **Percentile** | Xếp hạng điểm của ứng viên so với toàn bộ ứng viên SUBMITTED cùng assessment (0–100) |
+| **Decision** | Hành động recruiter: cập nhật stage thành SHORTLISTED / REJECTED / HIRED + ghi chú |
+
+### 1.4. Hiện trạng trước P1
+
+- Không có khái niệm vị trí tuyển dụng.
+- Danh sách invite chỉ có: email, điểm, trạng thái — không có pipeline.
+- Tất cả member đều dùng chung role OWNER/ADMIN/MANAGER/MEMBER; không có role chuyên cho recruiter.
+- Không có bulk import.
+
+---
+
+## 2. Mô tả tổng quan
+
+### 2.1. Bối cảnh sản phẩm
+
+Doanh nghiệp thường có HR/Recruiter không phải technical person — họ cần xem điểm thi, ra quyết định shortlist/reject, nhưng không được quyền chỉnh đề thi hay cài đặt org. P1 tạo role và UI phù hợp cho nhóm người dùng này.
+
+### 2.2. Nhóm người dùng
+
+| Vai trò | Nhu cầu P1 |
+|---|---|
+| **Owner / Admin** | Gán role RECRUITER cho member HR; tạo JobRole; xem toàn bộ pipeline |
+| **Recruiter** | Xem bảng ứng viên xếp hạng; đổi stage; ghi chú; import CSV |
+| **Manager** | Tạo assessment gắn JobRole; xem kết quả |
+
+---
+
+## 3. Yêu cầu chức năng
+
+### FR-1 — RECRUITER org role
+
+**FR-1.1**: Thêm `RECRUITER` vào enum `OrgRole`. Thứ tự: OWNER > ADMIN > MANAGER > RECRUITER > MEMBER.
+
+**FR-1.2**: Ma trận quyền RECRUITER:
+
+| Endpoint | Allowed |
+|---|---|
+| `GET /organizations/:orgId/assessments` | ✅ |
+| `POST /organizations/:orgId/assessments` | ✅ |
+| `GET /organizations/:orgId/assessments/:aid` | ✅ |
+| `PATCH /organizations/:orgId/assessments/:aid` | ✅ |
+| `POST /organizations/:orgId/assessments/:aid/invite` | ✅ |
+| `GET /organizations/:orgId/assessments/:aid/results` | ✅ |
+| `GET /organizations/:orgId/assessments/:aid/results/export` | ✅ |
+| `PATCH /organizations/:orgId/assessments/:aid/candidates/:inviteId` | ✅ |
+| `GET /organizations/:orgId/questions/**` (ghi) | ❌ 403 |
+| `PATCH /organizations/:orgId` (org settings) | ❌ 403 |
+| `POST /organizations/:orgId/members/invite` | ❌ 403 |
+
+**FR-1.3**: `OrgRoleGuard` sử dụng `@OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'RECRUITER')` cho assessment endpoints.
+
+**FR-1.4**: RECRUITER không thấy menu "Question Bank", "Settings", "Members" trong sidebar org.
+
+---
+
+### FR-2 — Job Role
+
+**FR-2.1**: Model `JobRole`:
+
+```prisma
+model JobRole {
+  id           String   @id @default(uuid())
+  orgId        String   @map("org_id")
+  title        String
+  department   String?
+  description  String?
+  isActive     Boolean  @default(true) @map("is_active")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  organization Organization @relation(...)
+  assessments  Assessment[]
+  @@map("job_roles")
+}
+```
+
+**FR-2.2**: `Assessment` có field `jobRoleId String? @map("job_role_id")` — optional, nullable.
+
+**FR-2.3**: Endpoints JobRole (guard: OWNER, ADMIN, MANAGER):
+- `GET /organizations/:orgId/job-roles` — list active job roles.
+- `POST /organizations/:orgId/job-roles` — tạo mới.
+- `PATCH /organizations/:orgId/job-roles/:jid` — sửa.
+- `DELETE /organizations/:orgId/job-roles/:jid` (soft: `isActive = false`).
+
+**FR-2.4**: `CreateAssessmentDto` / `UpdateAssessmentDto` có field `jobRoleId?: string`.
+
+**FR-2.5**: Response `GET /assessments/:aid` include `jobRole: { id, title, department }`.
+
+---
+
+### FR-3 — CandidateStage pipeline
+
+**FR-3.1**: Enum `CandidateStage`: `APPLIED | SCREENING | SHORTLISTED | REJECTED | HIRED`.
+
+**FR-3.2**: `CandidateInvite` thêm fields:
+
+```prisma
+stage         CandidateStage @default(APPLIED)
+rating        Int?           // 1–5
+recruiterNote String?        @map("recruiter_note")
+decidedBy     String?        @map("decided_by")   // userId
+decidedAt     DateTime?      @map("decided_at")
+```
+
+**FR-3.3**: Khi stage chuyển sang `HIRED`, `REJECTED`, hoặc `SHORTLISTED` → set `decidedBy = userId` người thực hiện, `decidedAt = now()`.
+
+**FR-3.4**: Endpoint cập nhật decision:
+
+```
+PATCH /organizations/:orgId/assessments/:aid/candidates/:inviteId
+Body: { stage?, rating?, recruiterNote? }
+Guard: OrgRole(OWNER, ADMIN, MANAGER, RECRUITER)
+```
+
+**FR-3.5**: Không có ràng buộc transition (có thể nhảy từ APPLIED thẳng sang HIRED).
+
+---
+
+### FR-4 — Xếp hạng & Percentile
+
+**FR-4.1**: `GET /organizations/:orgId/assessments/:aid/results` tính `percentile` cho mỗi invite có `status = SUBMITTED`.
+
+**FR-4.2**: Công thức: `percentile = Math.round((rank_below_or_equal - 1) / total_submitted * 100)` — ứng viên điểm cao nhất = percentile cao nhất.
+
+**FR-4.3**: Invite chưa submit → `percentile = null`.
+
+**FR-4.4**: Frontend hiển thị percentile dạng "82nd" trong cột bảng và drawer chi tiết.
+
+---
+
+### FR-5 — Bulk import ứng viên từ CSV
+
+**FR-5.1**: Frontend có modal "Import CSV" (`CsvImportModal`):
+- Chọn file `.csv`; parse client-side.
+- CSV format: `name,email` (header row optional, detect tự động).
+- Preview danh sách với highlight dòng lỗi (email không hợp lệ, thiếu email, duplicate).
+
+**FR-5.2**: Submit → gọi `POST /organizations/:orgId/assessments/:aid/invite` với mảng `[{ name, email }]`.
+
+**FR-5.3**: Backend xử lý từng item; item email đã tồn tại trong assessment → skip (không throw, trả warning).
+
+**FR-5.4**: Response: `{ invited: number, skipped: number, errors: [{ row, reason }] }`.
+
+**FR-5.5**: Hỗ trợ tối thiểu 200 dòng/lần import (không yêu cầu streaming).
+
+---
+
+### FR-6 — Export CSV kết quả (mở rộng)
+
+**FR-6.1**: `GET /organizations/:orgId/assessments/:aid/results/export` trả CSV với các cột:
+
+```
+Name, Email, Score (%), Pass/Fail, Percentile, Domain Scores (JSON), Stage, Rating, Recruiter Note, Submitted At, Time Spent (s), Tab Switches, Integrity Score
+```
+
+**FR-6.2**: Cột `Recruiter Note` escape dấu phẩy/xuống dòng (wrap bằng double-quote).
+
+---
+
+### FR-7 — Frontend: bảng ứng viên nâng cấp
+
+**FR-7.1**: `CandidateRanking` component (trong `AssessmentResults.tsx`): bảng với cột Rank, Name, Email, Score, Percentile, Stage (badge màu), Integrity Score, Actions.
+
+**FR-7.2**: Click row → mở `CandidateDetailDrawer`:
+- Thông tin cơ bản: email, tên, điểm, percentile, thời gian làm, submit at.
+- Domain breakdown (từ `domainScores`).
+- Stage selector (dropdown badge).
+- StarRating 1–5 (click để chọn, gọi `PATCH`).
+- Recruiter note textarea (auto-save on blur hoặc nút Save).
+- Integrity timeline: danh sách `CandidateEvent` theo thời gian (từ `GET .../events`).
+
+**FR-7.3**: `StageSummary` bar trên đầu trang: đếm số ứng viên theo stage (APPLIED/SCREENING/SHORTLISTED/REJECTED/HIRED).
+
+**FR-7.4**: RECRUITER không thấy nút "Xóa assessment", "Edit assessment settings" — chỉ thấy nút "Invite", "Import CSV", "Export CSV".
+
+---
+
+## 4. Yêu cầu phi chức năng
+
+| ID | Yêu cầu |
+|---|---|
+| NFR-1 (Hiệu năng) | `getResults` với 500 ứng viên (kèm percentile) < 800ms. Percentile tính bằng sort in-memory (không cần window function ở scale hiện tại). |
+| NFR-2 (Bảo mật) | RECRUITER không được gọi bất kỳ endpoint nào ngoài assessment/candidate — guard phải reject `403`, không `404`. |
+| NFR-3 (CSV parsing) | Parse client-side để không gửi file raw lên server; chỉ gửi JSON array. |
+| NFR-4 (Audit) | `updateCandidateDecision` (stage = HIRED/REJECTED/SHORTLISTED) được ghi vào `AuditLog` (thực hiện ở P3, nhưng service phải gọi `auditService.log(...)` — stub OK ở P1). |
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] RECRUITER đăng nhập → không thấy "Question Bank", "Settings", "Members" trong sidebar.
+- [ ] RECRUITER gọi `PATCH /organizations/:orgId` (sửa org) → `403`.
+- [ ] Tạo JobRole "Senior Backend Engineer" → gắn vào assessment → `GET /assessments/:aid` trả `jobRole: { title: "Senior Backend Engineer" }`.
+- [ ] 3 ứng viên điểm 90/80/70 → percentile tương ứng 100/67/33 (xấp xỉ).
+- [ ] Import CSV 50 dòng (5 email trùng) → response `{ invited: 45, skipped: 5, errors: [] }`.
+- [ ] Đổi stage sang HIRED → `decidedBy` và `decidedAt` được ghi; phản ánh trong stage summary.
+- [ ] Export CSV chứa cột Stage, Rating, Recruiter Note.
+
+---
+
+## 6. Liên kết
+
+- **Kế hoạch tổng**: [enterprise-entrance-exam-plan.md](../enterprise-entrance-exam-plan.md)
+- **Schema**: [backend/prisma/schema.prisma](../../backend/prisma/schema.prisma)
+- **Service**: [backend/src/assessments/assessments.service.ts](../../backend/src/assessments/assessments.service.ts)
+- **Unit tests P1**: [backend/src/assessments/assessments-p1.service.spec.ts](../../backend/src/assessments/assessments-p1.service.spec.ts)
+- **Frontend results**: [src/pages/org/AssessmentResults.tsx](../../src/pages/org/AssessmentResults.tsx)
+- **Frontend ranking**: [src/components/org/CandidateRanking.tsx](../../src/components/org/CandidateRanking.tsx)
+- **Frontend CSV import**: [src/components/org/CsvImportModal.tsx](../../src/components/org/CsvImportModal.tsx)

--- a/docs/specs/p2-proctoring-integrity-srs.md
+++ b/docs/specs/p2-proctoring-integrity-srs.md
@@ -1,0 +1,323 @@
+# SRS — P2: Proctoring & Integrity
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | P2 — Proctoring & Integrity |
+| **Phiên bản** | 1.0 (Implemented) |
+| **Ngày** | 2026-06-05 |
+| **Trạng thái** | Đã triển khai — tài liệu hóa sau implement |
+| **Phụ thuộc** | P1 (ATS-lite) — để recruiter xem Integrity Score trong pipeline |
+| **Module liên quan** | `assessments` (backend) · `CandidateExam.tsx`, `CandidateRanking.tsx` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Tài liệu này đặc tả yêu cầu cho **P2 — Proctoring & Integrity**, nâng cao độ tin cậy của bài thi ứng viên thông qua ba cơ chế: xác thực danh tính bằng OTP trước khi làm bài, ép buộc fullscreen để hạn chế gian lận, và ghi nhận sự kiện hành vi để tính toán điểm liêm chính (Integrity Score). Recruiter xem kết quả kèm timeline sự kiện để đưa ra quyết định tuyển dụng sáng suốt hơn.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Cấu hình per-assessment: `requireFullscreen`, `requireOtp`, `maxAttempts`.
+- Luồng OTP: request → email → verify → bắt đầu làm bài (nếu `requireOtp = true`).
+- Fullscreen enforcement: yêu cầu, phát hiện thoát, cảnh báo, ghi event.
+- `CandidateEvent` model: lưu mọi sự kiện hành vi trong quá trình làm bài.
+- `reportEvent` endpoint: nhận event từ frontend.
+- Tính `integrityScore` tại thời điểm submit (0–100).
+- Chặn làm lại: một token chỉ làm được một lần (`maxAttempts = 1` là default).
+- Frontend: màn OTP, cảnh báo fullscreen, hiển thị Integrity Score + event timeline.
+
+**Ngoài phạm vi:**
+- Webcam proctoring / AI face detection.
+- Screen recording.
+- Browser lockdown (chặn cài extension, mở DevTools).
+- OTP qua SMS.
+- OTP lưu Redis (hiện tại in-memory — TODO khi deploy multi-pod).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **requireFullscreen** | Assessment flag: bắt ứng viên vào fullscreen khi bắt đầu; phát hiện thoát |
+| **requireOtp** | Assessment flag: ứng viên phải nhập mã OTP gửi qua email trước khi xem đề |
+| **maxAttempts** | Số lần tối đa được làm bài (default 1 — enterprise use case) |
+| **CandidateEvent** | Bản ghi một sự kiện hành vi: loại, thời điểm client, payload JSON |
+| **Integrity Score** | Điểm 0–100 tính từ số vi phạm: tab switch, fullscreen exit, copy/paste |
+| **Phase** | Trạng thái UI của CandidateExam: `loading → intro → otp → exam → submitting` |
+
+### 1.4. Hiện trạng trước P2
+
+- `detectTabSwitch` và `blockCopyPaste` đã có nhưng chỉ ghi `tabSwitchCount` — không có event table.
+- Không có OTP.
+- Không có fullscreen enforcement.
+- Không có `integrityScore`.
+- Token đã submit có thể bị load lại (lỗ hổng).
+
+---
+
+## 2. Mô tả tổng quan
+
+### 2.1. Bối cảnh sản phẩm
+
+Bài thi tuyển dụng thật cần mức độ tin cậy cao hơn flashcard hay exam thực hành. P2 thêm 3 lớp bảo vệ độc lập:
+
+1. **OTP** — xác thực email ứng viên trước khi xem đề (chặn người khác dùng thay).
+2. **Fullscreen** — giảm cơ hội tra cứu công khai trong khi làm bài.
+3. **Event logging + Integrity Score** — không chặn hoàn toàn gian lận nhưng tạo bằng chứng cho recruiter.
+
+### 2.2. Thiết kế nguyên tắc
+
+- Proctoring chỉ **ghi nhận và tính điểm**, không tự động disqualify ứng viên.
+- Recruiter là người đưa ra quyết định cuối dựa trên Integrity Score + timeline.
+- Mọi mechanism là **per-assessment opt-in** (default: tắt) — không ảnh hưởng assessment cũ.
+
+---
+
+## 3. Yêu cầu chức năng
+
+### FR-1 — Cấu hình proctoring per-assessment
+
+**FR-1.1**: Thêm fields vào `Assessment`:
+
+```prisma
+requireFullscreen Boolean @default(false) @map("require_fullscreen")
+requireOtp        Boolean @default(false) @map("require_otp")
+maxAttempts       Int     @default(1)     @map("max_attempts")
+```
+
+**FR-1.2**: `CreateAssessmentDto` và `UpdateAssessmentDto` expose các fields này.
+
+**FR-1.3**: `GET /take/:token` (public) trả `requireFullscreen`, `requireOtp`, `otpVerifiedAt` (của invite) để frontend quyết định luồng.
+
+---
+
+### FR-2 — Chặn làm lại (maxAttempts)
+
+**FR-2.1**: `POST /take/:token/start`: nếu `invite.status === 'SUBMITTED'` → `403 Forbidden: "This assessment has already been submitted"`.
+
+**FR-2.2**: `maxAttempts` hiện tại enforce ở mức: 1 lần submit = hết. Mở rộng trong tương lai nếu `maxAttempts > 1`.
+
+**FR-2.3**: Invite có `status = 'EXPIRED'` → `403 Forbidden: "This assessment link has expired"`.
+
+---
+
+### FR-3 — OTP verification
+
+**FR-3.1**: Luồng OTP (chỉ áp dụng nếu `requireOtp = true`):
+
+```
+Ứng viên mở link → GET /take/:token (check requireOtp)
+                 → POST /take/:token/otp/request  (gửi mã qua email)
+                 → Nhập mã → POST /take/:token/otp/verify
+                 → Nếu đúng → cho phép POST /take/:token/start
+```
+
+**FR-3.2**: `POST /take/:token/otp/request`:
+- Sinh mã 6 chữ số ngẫu nhiên.
+- Hash bằng `crypto.scryptSync` (salt cố định per-request).
+- Lưu vào in-memory store: `Map<inviteId, { hash, expiresAt }>` với TTL = 10 phút.
+- Gửi email qua `MailService` đến `invite.candidateEmail`.
+- Log email ẩn danh (ví dụ: `t***@example.com`) để trace, không log mã OTP.
+- Trả: `{ message: "OTP sent to t***@example.com" }`.
+
+**FR-3.3**: `POST /take/:token/otp/verify`:
+- Body: `{ code: string }`.
+- Lấy entry từ store; nếu không có → `400: "No OTP requested"`.
+- Nếu `expiresAt < now()` → xóa khỏi store, `400: "OTP has expired"`.
+- Nếu hash không khớp → `400: "Invalid OTP"`.
+- Nếu đúng → xóa khỏi store, set `invite.otpVerifiedAt = now()`.
+
+**FR-3.4**: `POST /take/:token/start`:
+- Nếu `assessment.requireOtp && !invite.otpVerifiedAt` → `403: "OTP verification required before starting"`.
+
+**FR-3.5**: ⚠️ **Known limitation**: OTP store in-memory — không hoạt động với multiple server instances. Cần migrate sang Redis SETEX/GET/DEL khi deploy multi-pod. Đây là intentional shortcut cho single-pod MVP.
+
+---
+
+### FR-4 — Fullscreen enforcement
+
+**FR-4.1**: `GET /take/:token` trả `requireFullscreen`. Frontend xử lý:
+
+- Khi phase chuyển sang `exam` và `requireFullscreen = true`:
+  ```js
+  document.documentElement.requestFullscreen().catch(() => {});
+  ```
+- Lắng nghe `fullscreenchange` event: nếu `!document.fullscreenElement` trong phase `exam` → hiển thị cảnh báo overlay + gọi `reportEvent(token, 'FULLSCREEN_EXIT')`.
+- Khi submit → thoát fullscreen: `document.exitFullscreen().catch(() => {})`.
+
+**FR-4.2**: Cảnh báo overlay hiển thị: "Bạn đã thoát fullscreen. Vui lòng quay lại fullscreen để tiếp tục làm bài." + nút "Quay lại fullscreen".
+
+**FR-4.3**: Thoát fullscreen **không dừng exam** — ứng viên vẫn có thể tiếp tục; event được ghi để recruiter biết.
+
+---
+
+### FR-5 — CandidateEvent: ghi nhận sự kiện
+
+**FR-5.1**: Model:
+
+```prisma
+model CandidateEvent {
+  id        String   @id @default(uuid())
+  inviteId  String   @map("invite_id")
+  eventType String   @map("event_type")
+  payload   Json     @default("{}")
+  clientTs  DateTime @map("client_ts")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  invite CandidateInvite @relation(...)
+  @@index([inviteId, clientTs])
+  @@map("candidate_events")
+}
+```
+
+**FR-5.2**: Endpoint ghi event (public, token-based):
+
+```
+POST /assessments/take/:token/event
+Body: { eventType: string, clientTs?: string, payload?: object }
+```
+
+Các `eventType` hợp lệ:
+
+| eventType | Trigger | Payload |
+|---|---|---|
+| `FULLSCREEN_EXIT` | Thoát fullscreen | `{}` |
+| `TAB_SWITCH` | `visibilitychange` hidden | `{}` |
+| `COPY` | `copy` event trên document | `{}` |
+| `PASTE` | `paste` event trên document | `{}` |
+| `BLUR` | `window.blur` | `{}` |
+
+**FR-5.3**: `tabSwitchCount` trên `CandidateInvite` vẫn được increment khi nhận `TAB_SWITCH` event (backward compat với logic cũ).
+
+**FR-5.4**: Endpoint không validate `clientTs` nghiêm ngặt — accept ISO string hoặc null, fallback về `now()`.
+
+---
+
+### FR-6 — Tính Integrity Score
+
+**FR-6.1**: Tính tại thời điểm `POST /take/:token/submit` (trong `$transaction`):
+
+```
+score = 100
+score -= min(tabSwitchCount × 5, 40)    // mỗi tab switch -5, tối đa -40
+score -= min(fullscreenExits × 3, 30)   // mỗi fullscreen exit -3, tối đa -30
+if (hasCopyOrPaste) score -= 15          // -15 nếu có bất kỳ copy/paste nào
+score = max(0, min(100, round(score)))
+```
+
+**FR-6.2**: Lưu vào `CandidateInvite.integrityScore` (0–100).
+
+**FR-6.3**: Score chỉ tính **một lần** tại submit; không recalculate sau đó (bất biến).
+
+**FR-6.4**: `getResults` endpoint trả `integrityScore` cho mỗi invite.
+
+---
+
+### FR-7 — Xem event timeline (recruiter)
+
+**FR-7.1**: Endpoint:
+
+```
+GET /organizations/:orgId/assessments/:aid/candidates/:inviteId/events
+Guard: OrgRole(OWNER, ADMIN, MANAGER, RECRUITER)
+Response: CandidateEvent[]  (sắp xếp theo clientTs ASC)
+```
+
+**FR-7.2**: Frontend `CandidateDetailDrawer` fetch events khi mở drawer (lazy load).
+
+**FR-7.3**: Hiển thị timeline theo thứ tự thời gian: icon + label theo eventType + timestamp.
+
+---
+
+### FR-8 — Frontend: luồng 4 phase
+
+**FR-8.1**: `CandidateExam.tsx` có state `phase: 'loading' | 'intro' | 'otp' | 'exam' | 'submitting'`.
+
+**FR-8.2**: Transition:
+
+```
+loading → (check requireOtp + otpVerifiedAt)
+        → nếu requireOtp && !otpVerifiedAt → otp (gọi requestOtp auto)
+        → else → intro
+otp → (verify thành công) → intro
+intro → (click Start) → exam (request fullscreen nếu cần) → submitting → /result
+```
+
+**FR-8.3**: Màn `otp`:
+- Input 6 chữ số.
+- Nút "Gửi lại mã" (cooldown 60s sau khi gửi).
+- Hiển thị lỗi từ verify response.
+
+**FR-8.4**: `IntegrityBadge` trong `CandidateRanking`:
+- Score 80–100: badge xanh "High".
+- Score 50–79: badge vàng "Medium".
+- Score 0–49: badge đỏ "Low".
+- `null` (chưa submit): không hiển thị badge.
+
+---
+
+## 4. Yêu cầu phi chức năng
+
+| ID | Yêu cầu |
+|---|---|
+| NFR-1 (OTP security) | Mã OTP không bao giờ được log dạng plaintext. Hash trước khi lưu store. |
+| NFR-2 (Event throughput) | `reportEvent` phải response < 100ms — insert đơn giản, không cần validation nặng. |
+| NFR-3 (Score immutability) | `integrityScore` không được update sau khi submit. Nếu cần recalculate → cần endpoint admin riêng (không trong P2). |
+| NFR-4 (Fullscreen UX) | Cảnh báo fullscreen không block keyboard/mouse — ứng viên vẫn có thể trả lời câu hỏi mà không cần quay lại fullscreen. |
+| NFR-5 (Multi-pod OTP) | TODO: migrate OTP store từ in-memory sang Redis `SETEX` key = `otp:{inviteId}`, TTL = 600s khi horizontal scale. |
+| NFR-6 (A11y) | Màn OTP, cảnh báo fullscreen phải accessible bằng keyboard; `aria-live` cho thông báo lỗi OTP. |
+
+---
+
+## 5. Acceptance Criteria
+
+### AC-1 — Chặn làm lại
+- [ ] Token đã SUBMITTED → `POST /take/:token/start` trả `403` với message rõ ràng.
+- [ ] Token hết hạn (`expiresAt` quá khứ) → `403`.
+
+### AC-2 — OTP
+- [ ] `requireOtp = true`: mở link → tự động request OTP → nhận email (Mailtrap) → nhập đúng → vào intro.
+- [ ] Nhập sai → thông báo lỗi, không vào exam.
+- [ ] OTP hết hạn (10 phút) → `400: "OTP has expired"`.
+- [ ] `requireOtp = false`: mở link → thẳng vào intro, không có màn OTP.
+
+### AC-3 — Fullscreen
+- [ ] `requireFullscreen = true`: click Start → browser request fullscreen.
+- [ ] Thoát fullscreen → overlay cảnh báo hiển thị + event `FULLSCREEN_EXIT` được ghi vào `CandidateEvent`.
+- [ ] Submit → thoát fullscreen tự động.
+
+### AC-4 — Integrity Score
+- [ ] Ứng viên tab-switch 3 lần + 1 fullscreen exit + copy 1 lần → `integrityScore = 100 - 15 - 3 - 15 = 67`.
+- [ ] Ứng viên không vi phạm gì → `integrityScore = 100`.
+- [ ] 8 tab-switch + 10 fullscreen exit + copy → `integrityScore = max(0, 100 - 40 - 30 - 15) = 15`.
+- [ ] Score bất biến sau submit (gọi lại `getResults` → cùng score).
+
+### AC-5 — Event timeline
+- [ ] `GET .../candidates/:inviteId/events` trả list sự kiện theo `clientTs ASC`.
+- [ ] `CandidateDetailDrawer` hiển thị timeline khi mở.
+- [ ] RECRUITER gọi endpoint → `200` (không bị chặn).
+
+---
+
+## 6. Vấn đề mở & Known Issues
+
+| # | Vấn đề | Trạng thái |
+|---|---|---|
+| KI-1 | OTP in-memory không scale multi-pod | Documented TODO; cần Redis migration trước horizontal scale |
+| KI-2 | Fullscreen không thể enforce trên iOS Safari (API không hỗ trợ) | Accept limitation; warn user nếu mobile |
+| KI-3 | Copy-paste detection không bắt được nếu ứng viên dùng right-click menu của hệ điều hành | Known gap; `blockCopyPaste` chặn keyboard shortcut nhưng không chặn context menu |
+| KI-4 | `FAST_ANSWER` event (câu trả lời bất thường nhanh) đề xuất trong plan nhưng chưa implement | Backlog — cần thêm `timeSpent` per question analysis |
+
+---
+
+## 7. Liên kết
+
+- **Kế hoạch tổng**: [enterprise-entrance-exam-plan.md](../enterprise-entrance-exam-plan.md)
+- **Schema**: [backend/prisma/schema.prisma](../../backend/prisma/schema.prisma)
+- **Candidate service**: [backend/src/assessments/candidate.service.ts](../../backend/src/assessments/candidate.service.ts)
+- **Frontend exam**: [src/pages/CandidateExam.tsx](../../src/pages/CandidateExam.tsx)
+- **Frontend ranking + drawer**: [src/components/org/CandidateRanking.tsx](../../src/components/org/CandidateRanking.tsx)
+- **P3 SRS** (tiếp theo): [docs/specs/p3-branding-email-compliance-srs.md](./p3-branding-email-compliance-srs.md)

--- a/docs/specs/p3-branding-email-compliance-srs.md
+++ b/docs/specs/p3-branding-email-compliance-srs.md
@@ -1,0 +1,516 @@
+# SRS — P3: Branding, Email & Compliance
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | P3 — Branding, Email & Compliance (Enterprise Entrance Exam) |
+| **Phiên bản** | 0.1 (Draft — để review) |
+| **Ngày** | 2026-06-05 |
+| **Trạng thái** | Draft, chưa triển khai code |
+| **Phụ thuộc** | P0 (Smart Builder) · P1 (ATS-lite) · P2 (Proctoring & Integrity) |
+| **Module liên quan** | `assessments`, `mail`, `organizations` (backend) · `CandidateExam`, `AssessmentResults`, `OrgSettings` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Tài liệu này đặc tả yêu cầu cho **P3 — Branding, Email & Compliance**, giai đoạn cuối trong lộ trình Enterprise Entrance Exam. P3 biến quy trình đánh giá ứng viên thành một trải nghiệm chuyên nghiệp, đầy đủ thương hiệu doanh nghiệp, đồng thời đáp ứng các yêu cầu pháp lý về bảo vệ dữ liệu cá nhân (GDPR/PDPA).
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Email mời/nhắc/kết quả có thương hiệu org (logo, màu, tên).
+- Trang làm bài của ứng viên hiển thị branding của org.
+- Xuất báo cáo PDF kết quả per-candidate.
+- Retention policy và ẩn danh hóa dữ liệu PII của ứng viên (GDPR).
+- Audit log cho mọi thao tác liên quan đến assessment.
+
+**Ngoài phạm vi:**
+- Custom domain (white-label subdomain) cho org — để dành roadmap sau.
+- Email marketing / drip campaign.
+- Chữ ký điện tử lên PDF.
+- Tích hợp GDPR subject-access-request portal đầy đủ (SAR).
+- Xử lý thanh toán / billing.
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **PII** | Personally Identifiable Information — thông tin có thể nhận diện cá nhân (email, tên, IP) |
+| **Anonymization** | Ẩn danh hóa không thể đảo ngược (khác với pseudonymization) |
+| **Retention policy** | Chính sách lưu giữ dữ liệu: sau N ngày kể từ ngày submit, PII bị ẩn danh tự động |
+| **Branded email** | Email gửi bằng SMTP thật, nội dung dùng logo/màu/tên của org |
+| **Audit log** | Bản ghi bất biến mọi thao tác quản trị trên assessment |
+| **Integrity Score** | Điểm liêm chính tính từ P2 (0–100), được in vào PDF |
+
+### 1.4. Hiện trạng (baseline)
+
+| Thành phần | Trạng thái |
+|---|---|
+| `Organization.logoUrl` / `accentColor` | ✅ Có trong schema ([schema.prisma:807–810](../../backend/prisma/schema.prisma)) |
+| `MailService` (nodemailer + Mailtrap) | ✅ Có, nhưng email dùng HTML tĩnh không có branding ([mail.service.ts](../../backend/src/mail/mail.service.ts)) |
+| `AuditLog` (platform-level) | ✅ Có ([schema.prisma:781](../../backend/prisma/schema.prisma)), nhưng chưa ghi thao tác assessment |
+| `CandidateInvite.candidateEmail/Name/ipAddress` | ✅ Có — cần anonymize theo retention |
+| `CandidateInvite.integrityScore` | ✅ Có (P2) — cần đưa vào PDF |
+| PDF export | ❌ Chưa có |
+| Branded email templates | ❌ Chưa có |
+| Retention/anonymization cron | ❌ Chưa có |
+| Assessment audit log | ❌ Chưa có |
+| Reminder cron (nhắc hạn invite) | ❌ Chưa có |
+
+---
+
+## 2. Mô tả tổng quan
+
+### 2.1. Bối cảnh sản phẩm
+
+P3 là "polish layer" bắt buộc trước khi một doanh nghiệp thật có thể dùng Assessment cho tuyển dụng chính thức:
+
+- Ứng viên hiện nhận email plain-HTML từ `Brain Gym <noreply@braingym.app>` — không phản ánh thương hiệu công ty đang tuyển.
+- Trang làm bài `/assess/:token` hiện dùng giao diện generic của Brain Gym — không có nhận diện thương hiệu.
+- Khi có sự cố tranh chấp, không có audit trail đủ để tra cứu ai đã làm gì.
+- Nếu có ứng viên EU, việc không có retention policy tạo rủi ro pháp lý ngay khi go-live.
+
+### 2.2. Nhóm người dùng
+
+| Vai trò | Nhu cầu P3 |
+|---|---|
+| **Ứng viên** | Nhận email từ brand công ty, làm bài trong giao diện có thương hiệu |
+| **Recruiter** | Xuất PDF trình CHro/hiring manager, xem thao tác lịch sử |
+| **Admin org (Owner/Admin)** | Cấu hình retention, xem audit log, đảm bảo tuân thủ nội bộ |
+| **DPO / Legal** | Xác nhận PII được ẩn danh đúng hạn, có endpoint xóa theo yêu cầu ứng viên |
+
+### 2.3. Giả định & ràng buộc
+
+- `Organization.logoUrl` là URL công khai (CDN/S3) — không upload trong P3; org đã cấu hình qua OrgSettings hiện có.
+- `Organization.accentColor` là hex string, ví dụ `#1a56db`.
+- Mailtrap dùng cho dev; prod dùng SMTP thật (Gmail/SES) cấu hình qua env vars — **không thay đổi transport layer trong P3**.
+- PDF render phía server bằng thư viện `@playwright/browser` hoặc `puppeteer` (headless) nếu đã available trong Docker image; nếu không có sẵn, fallback về `pdfkit` (pure Node.js).
+- Retention anonymization **không xóa** bản ghi — chỉ nullify/mask PII để aggregate statistics còn intact.
+- TypeScript loose (`strictNullChecks: false`) — tuân theo style sẵn có.
+
+### 2.4. Quyết định cần chốt (mở)
+
+| # | Câu hỏi | Khuyến nghị |
+|---|---|---|
+| D1 | PDF render: server-side (puppeteer/Playwright) hay client-side (browser `window.print`)? | **Server-side** (puppeteer/pdfkit) — nhất quán, không phụ thuộc browser của recruiter |
+| D2 | Thư viện PDF: `puppeteer` (HTML→PDF, đẹp hơn) hay `pdfkit` (pure Node, nhẹ hơn)? | `pdfkit` nếu Docker image không có Chromium; `puppeteer` nếu có — cần xác nhận môi trường |
+| D3 | Reminder email: gửi trước bao nhiêu giờ? | 24h trước `expiresAt`, gửi 1 lần, không lặp |
+| D4 | Retention default: bao nhiêu ngày? | **365 ngày** mặc định; org có thể tự hạ xuống tối thiểu 30 ngày |
+| D5 | Endpoint xóa PII: ai gọi? | Recruiter/Admin gọi thay ứng viên (vì ứng viên không có tài khoản); hoặc ứng viên gửi email support → admin trigger |
+
+---
+
+## 3. Yêu cầu chức năng
+
+> Quy ước độ ưu tiên: **P1** = MVP (phải có) · **P2** = nên có · **P3** = nâng cao.
+
+---
+
+### FR-1 — Branded email templates `[P1]` ← US-P3-1
+
+#### FR-1.1 Template layout
+
+Tất cả email gửi cho ứng viên (invite, reminder, result) phải dùng **HTML template có branding** bao gồm:
+- Header: `logoUrl` của org (img tag, max-height 48px, fallback text = org name nếu null).
+- Accent color: nút CTA, đường kẻ header dùng `accentColor` (fallback `#6366f1` nếu null).
+- Footer: tên org, không có branding "Brain Gym" nếu org đã cấu hình logo.
+
+#### FR-1.2 Loại email bắt buộc có branding
+
+| Event | Template | Trigger |
+|---|---|---|
+| **Invite** | `assessment-invite.html` | Khi tạo `CandidateInvite` (đã có, cần rebrand) |
+| **Reminder** | `assessment-reminder.html` | Cron 24h trước `expiresAt`, chỉ gửi nếu `status = INVITED` |
+| **Result (pass/fail)** | `assessment-result.html` | Sau khi ứng viên submit, nếu org bật `sendResultEmail` |
+
+#### FR-1.3 Cấu hình gửi email kết quả
+
+- Thêm field `sendResultEmail Boolean @default(false)` vào `Assessment`.
+- Nếu bật: sau submit, gửi email tóm tắt điểm + pass/fail (không tiết lộ câu đúng/sai).
+
+#### FR-1.4 Nội dung template
+
+Email invite phải chứa: tên org, tên assessment, link (token), hạn (expiresAt format ngày/giờ timezone UTC). Email reminder: tương tự + thông điệp "hạn còn X giờ". Email result: điểm, pass/fail, (tùy chọn) domain breakdown.
+
+---
+
+### FR-2 — Branded candidate exam page `[P1]` ← US-P3-2
+
+#### FR-2.1 Load branding khi mở `/assess/:token`
+
+- `GET /assessments/take/:token` (public) mở rộng response trả thêm `branding: { orgName, logoUrl, accentColor }`.
+- Backend query `assessment → organization` để lấy branding fields.
+
+#### FR-2.2 Áp dụng branding trong CandidateExam
+
+- Header trang: logo org (nếu có) thay thế logo Brain Gym; tên org hiển thị làm subtitle.
+- Accent color áp dụng cho: nút "Bắt đầu", nút "Nộp bài", thanh tiến trình (progress bar), badge domain.
+- Nếu `logoUrl` null và `accentColor` null → giữ nguyên giao diện mặc định Brain Gym.
+
+#### FR-2.3 CandidateResult cũng có branding
+
+- Trang `/assess/:token/result` dùng cùng branding context.
+
+---
+
+### FR-3 — Export PDF per-candidate `[P1]` ← US-P3-3
+
+#### FR-3.1 Endpoint
+
+```
+GET /organizations/:orgId/assessments/:aid/candidates/:inviteId/pdf
+Authorization: JWT + OrgRole(OWNER, ADMIN, MANAGER, RECRUITER)
+Response: application/pdf; filename="candidate-{inviteId}.pdf"
+```
+
+#### FR-3.2 Nội dung PDF
+
+| Section | Nội dung |
+|---|---|
+| **Header** | Logo org + tên org; tên assessment; ngày xuất |
+| **Ứng viên** | Tên (hoặc "—" nếu đã anonymized), email (hoặc "***@***.***"), ngày submit |
+| **Kết quả** | Điểm tổng (%), Pass/Fail badge, thời gian làm bài |
+| **Domain breakdown** | Bảng điểm theo domain (từ `domainScores` JSON) |
+| **Integrity** | Integrity Score (từ P2), số tab-switch, có vi phạm fullscreen không |
+| **Footer** | "Tài liệu bảo mật — chỉ dành cho mục đích nội bộ" + timestamp |
+
+#### FR-3.3 Nút export trong UI
+
+- [AssessmentResults.tsx](../../src/pages/org/AssessmentResults.tsx): thêm nút "Export PDF" trong drawer chi tiết của từng ứng viên.
+- Click → gọi endpoint, browser download file.
+
+#### FR-3.4 Trạng thái chưa submit
+
+- Nếu `status != SUBMITTED` → trả `400 Bad Request`: "Ứng viên chưa hoàn thành bài thi".
+
+---
+
+### FR-4 — Reminder email cron `[P2]`
+
+#### FR-4.1 Cron job
+
+- Chạy mỗi giờ (cron expression: `0 * * * *`).
+- Query `CandidateInvite` có `status = INVITED` và `expiresAt` trong khoảng (now + 23h, now + 25h).
+- Gửi 1 email reminder / invite, **không gửi lại** (thêm field `reminderSentAt DateTime?` để idempotent).
+
+#### FR-4.2 Cấu hình per-assessment
+
+- Thêm field `sendReminderEmail Boolean @default(true)` vào `Assessment`.
+- Nếu false → cron bỏ qua invite thuộc assessment này.
+
+---
+
+### FR-5 — Retention policy & anonymization `[P1]` ← US-P3-4
+
+#### FR-5.1 Cấu hình retention per-org
+
+Thêm field vào `Organization`:
+```prisma
+retentionDays Int @default(365) @map("retention_days")
+```
+- Min 30, max 3650 (10 năm). Validate trong DTO.
+- UI cấu hình: OrgSettings → tab "Tuân thủ" → input "Lưu trữ dữ liệu ứng viên (ngày)".
+
+#### FR-5.2 Anonymization cron
+
+- Chạy mỗi ngày lúc 02:00 UTC (cron: `0 2 * * *`).
+- Query `CandidateInvite` có `submittedAt < now() - retentionDays days` và `anonymizedAt IS NULL`.
+- Anonymize: `candidateEmail = 'anonymized@example.com'`, `candidateName = null`, `ipAddress = null`.
+- Set `anonymizedAt = now()`.
+- **Giữ lại**: score, domainScores, integrityScore, stage, rating, timestamps — để analytics aggregate còn dùng được.
+- Nếu `status = INVITED` (chưa làm): không anonymize (không có `submittedAt`); bản ghi expire tự nhiên.
+
+Thêm field vào `CandidateInvite`:
+```prisma
+anonymizedAt DateTime? @map("anonymized_at")
+```
+
+#### FR-5.3 Endpoint xóa theo yêu cầu ứng viên
+
+```
+DELETE /organizations/:orgId/assessments/:aid/candidates/:inviteId/pii
+Authorization: JWT + OrgRole(OWNER, ADMIN)
+```
+- Thực hiện anonymization ngay lập tức (không chờ cron).
+- Trả `200 { anonymizedAt }`.
+- Ghi audit log action `CANDIDATE_PII_DELETED`.
+
+#### FR-5.4 Hiển thị trạng thái anonymized trong UI
+
+- [AssessmentResults.tsx](../../src/pages/org/AssessmentResults.tsx): nếu `anonymizedAt` có giá trị → hiển thị badge "Đã ẩn danh", email hiển thị `***@***.***`.
+- Nút "Export PDF" vẫn có thể nhấn; PDF sẽ in email/tên dưới dạng đã ẩn danh.
+
+---
+
+### FR-6 — Audit log cho assessment `[P1]` ← US-P3-5
+
+#### FR-6.1 Các thao tác cần ghi audit
+
+Tái dùng model `AuditLog` hiện có ([schema.prisma:781](../../backend/prisma/schema.prisma)). Ghi audit với `targetType = 'Assessment'` hoặc `'CandidateInvite'`:
+
+| Action | Trigger |
+|---|---|
+| `ASSESSMENT_CREATED` | Tạo assessment |
+| `ASSESSMENT_UPDATED` | Sửa cấu hình assessment |
+| `ASSESSMENT_STATUS_CHANGED` | Activate / Close / Archive |
+| `CANDIDATE_INVITED` | Tạo CandidateInvite (ghi email vào metadata) |
+| `CANDIDATE_STAGE_UPDATED` | Đổi stage (APPLIED → SHORTLISTED, REJECTED, HIRED) |
+| `CANDIDATE_DECISION_SET` | Recruiter ghi rating/note |
+| `CANDIDATE_PII_DELETED` | Anonymize PII theo yêu cầu (FR-5.3) |
+| `PDF_EXPORTED` | Recruiter export PDF (ghi inviteId) |
+
+#### FR-6.2 Hiển thị audit log
+
+- [OrgSettings.tsx](../../src/pages/org/OrgSettings.tsx) hoặc trang riêng `/org/:slug/audit-log`: tab/section "Lịch sử thao tác".
+- Filter theo: loại action, thời gian (date range), người thực hiện.
+- Endpoint: tái dùng hoặc mở rộng API audit hiện có, filter thêm theo `targetType IN ('Assessment', 'CandidateInvite')`.
+
+#### FR-6.3 Không audit thao tác đọc
+
+- `GET` (xem danh sách, xem kết quả) không ghi audit — chỉ ghi thao tác ghi/quyết định.
+
+---
+
+## 4. Yêu cầu phi chức năng
+
+| ID | Yêu cầu |
+|---|---|
+| NFR-1 (Hiệu năng PDF) | PDF generation < 3s cho report 1 trang; endpoint chặn đồng bộ (không cần job queue ở P3). |
+| NFR-2 (Email delivery) | Email gửi trong BullMQ job (không block request); timeout 10s/job; retry 3 lần với backoff. |
+| NFR-3 (Anonymization idempotency) | Cron có thể chạy lại nhiều lần mà không double-anonymize (guard bằng `anonymizedAt IS NULL`). |
+| NFR-4 (Audit immutability) | `AuditLog` chỉ INSERT, không UPDATE/DELETE. Không cần bảo vệ thêm ở P3. |
+| NFR-5 (Branding graceful degradation) | Nếu `logoUrl` không tải được (404/timeout) → template dùng org name text thay thế, không crash email. |
+| NFR-6 (Security PDF) | Endpoint PDF phải qua `JwtAuthGuard + OrgRoleGuard`; file không được cache public. |
+| NFR-7 (GDPR minimal data in logs) | Audit log `metadata` không được lưu full email của ứng viên; chỉ lưu `inviteId` và `assessmentId`. |
+| NFR-8 (A11y) | Trang CandidateExam với branding org vẫn phải đạt Lighthouse a11y ≥ 95 (contrast check với `accentColor`). |
+
+---
+
+## 5. Thay đổi schema Prisma
+
+### 5.1. `Organization` — thêm fields
+
+```prisma
+model Organization {
+  // ... fields hiện có ...
+  retentionDays     Int     @default(365)  @map("retention_days")
+  sendResultEmail   Boolean @default(false) @map("send_result_email") // nếu muốn per-org default
+}
+```
+
+> `logoUrl` và `accentColor` đã có — không thêm mới.
+
+### 5.2. `Assessment` — thêm fields
+
+```prisma
+model Assessment {
+  // ... fields hiện có ...
+  sendResultEmail   Boolean @default(false) @map("send_result_email")
+  sendReminderEmail Boolean @default(true)  @map("send_reminder_email")
+}
+```
+
+### 5.3. `CandidateInvite` — thêm fields
+
+```prisma
+model CandidateInvite {
+  // ... fields hiện có ...
+  reminderSentAt DateTime? @map("reminder_sent_at")
+  anonymizedAt   DateTime? @map("anonymized_at")
+}
+```
+
+### 5.4. Migration
+
+Một migration nhỏ:
+```
+npx prisma migrate dev --name p3_branding_email_compliance
+```
+Không phá vỡ schema hiện tại (tất cả là optional hoặc có default).
+
+---
+
+## 6. Thiết kế API
+
+### 6.1. Branding trong response public
+
+**Mở rộng** `GET /assessments/take/:token` (đã có):
+```jsonc
+// Response hiện tại + thêm:
+{
+  "id": "...",
+  "title": "Senior Backend Engineer — Technical Screen",
+  // ...
+  "branding": {
+    "orgName": "Acme Corp",
+    "logoUrl": "https://cdn.example.com/acme-logo.png",
+    "accentColor": "#1a56db"
+  }
+}
+```
+
+### 6.2. PDF export
+
+```
+GET /organizations/:orgId/assessments/:aid/candidates/:inviteId/pdf
+Headers:
+  Authorization: Bearer <token>
+Response:
+  Content-Type: application/pdf
+  Content-Disposition: attachment; filename="result-{inviteId}.pdf"
+  Body: <binary PDF>
+```
+
+Lỗi:
+- `403` — không có quyền.
+- `400` — ứng viên chưa submit.
+- `404` — invite không tồn tại trong assessment/org này.
+
+### 6.3. Anonymize PII
+
+```
+DELETE /organizations/:orgId/assessments/:aid/candidates/:inviteId/pii
+Headers:
+  Authorization: Bearer <token>   (OWNER or ADMIN)
+Response 200:
+{
+  "inviteId": "...",
+  "anonymizedAt": "2026-06-05T10:00:00Z"
+}
+```
+
+### 6.4. Audit log (tái dùng pattern hiện có)
+
+```
+GET /organizations/:orgId/audit-logs?targetType=Assessment,CandidateInvite&from=2026-01-01&to=2026-06-30&page=1&limit=50
+Headers:
+  Authorization: Bearer <token>   (OWNER or ADMIN)
+Response:
+{
+  "data": [
+    { "id": "...", "action": "CANDIDATE_INVITED", "targetType": "CandidateInvite", "targetId": "...", "metadata": { "assessmentId": "..." }, "createdAt": "...", "user": { "id": "...", "displayName": "..." } }
+  ],
+  "total": 120,
+  "page": 1,
+  "limit": 50
+}
+```
+
+---
+
+## 7. Ảnh hưởng các file hiện có
+
+### 7.1. Backend
+
+| File | Thay đổi |
+|---|---|
+| `backend/prisma/schema.prisma` | Thêm fields `retentionDays`, `sendResultEmail`, `sendReminderEmail`, `reminderSentAt`, `anonymizedAt` |
+| `backend/src/mail/mail.service.ts` | Refactor `sendAssessmentInvite()` nhận thêm `branding` object; thêm `sendAssessmentReminder()`, `sendAssessmentResult()` |
+| `backend/src/assessments/candidate.controller.ts` | `GET /take/:token` — include branding trong response |
+| `backend/src/assessments/candidate.service.ts` | `submitAttempt()` — trigger result email nếu `assessment.sendResultEmail` |
+| `backend/src/assessments/assessments.controller.ts` | Thêm `GET .../candidates/:inviteId/pdf`, `DELETE .../candidates/:inviteId/pii` |
+| `backend/src/assessments/assessments.service.ts` | Logic generate PDF, logic anonymize PII, ghi audit log |
+| `backend/src/assessments/dto/create-assessment.dto.ts` | Thêm `sendResultEmail`, `sendReminderEmail` |
+| `backend/src/organizations/dto/update-org.dto.ts` | Thêm `retentionDays` (validate min 30) |
+
+### 7.2. Backend — files mới
+
+| File | Nội dung |
+|---|---|
+| `backend/src/assessments/pdf.service.ts` | Generate PDF từ invite data; inject `pdfkit` hoặc `puppeteer` |
+| `backend/src/assessments/mail-templates/assessment-invite.html` | Branded HTML template (Handlebars hoặc string interpolation) |
+| `backend/src/assessments/mail-templates/assessment-reminder.html` | Template nhắc hạn |
+| `backend/src/assessments/mail-templates/assessment-result.html` | Template kết quả |
+| `backend/src/cron/assessment-reminder.cron.ts` | BullMQ scheduled job hoặc NestJS `@Cron` — gửi reminder 24h |
+| `backend/src/cron/candidate-retention.cron.ts` | BullMQ scheduled job hoặc NestJS `@Cron` — anonymize PII |
+
+### 7.3. Frontend
+
+| File | Thay đổi |
+|---|---|
+| `src/pages/CandidateExam.tsx` | Đọc `branding` từ response, áp logo + accentColor lên header + UI elements |
+| `src/pages/CandidateResult.tsx` | Áp cùng branding context |
+| `src/pages/org/AssessmentResults.tsx` | Thêm nút "Export PDF" trong drawer chi tiết; badge "Đã ẩn danh"; action "Xóa PII" cho Admin |
+| `src/pages/org/OrgSettings.tsx` | Tab/section "Tuân thủ": input `retentionDays`; toggle `sendResultEmail` per-org default |
+| `src/pages/org/AssessmentBuilder.tsx` | Thêm toggle `sendResultEmail`, `sendReminderEmail` trong cài đặt assessment |
+
+### 7.4. Frontend — files mới
+
+| File | Nội dung |
+|---|---|
+| `src/pages/org/OrgAuditLog.tsx` | Trang audit log với filter và bảng sự kiện |
+| `src/services/compliance.ts` | API client: PDF export, delete PII, audit log query |
+
+---
+
+## 8. Kế hoạch triển khai theo giai đoạn
+
+| Phase | Nội dung | FR bao phủ |
+|---|---|---|
+| **P1 (MVP)** | Branded email templates (invite) · Branding trên CandidateExam · PDF export · Retention anonymization cron · Audit log 8 actions | FR-1.1–1.2 (invite only), FR-2, FR-3, FR-5, FR-6 |
+| **P2** | Reminder email cron · Result email · Cấu hình per-assessment · Endpoint xóa PII · Audit log UI | FR-1.3, FR-1.4 (result), FR-4, FR-5.3–5.4, FR-6.2 |
+
+---
+
+## 9. Tiêu chí chấp nhận (Acceptance Criteria)
+
+### AC-1 — Branded invite email (FR-1, FR-2)
+- [ ] Tạo `CandidateInvite` cho org có `logoUrl = "https://example.com/logo.png"` và `accentColor = "#1a56db"` → email gửi (Mailtrap) có `<img src="https://example.com/logo.png">` và nút CTA màu `#1a56db`.
+- [ ] Org không có `logoUrl` → email hiển thị tên org dạng text, không có broken image.
+- [ ] Trang `/assess/:token` load branding của org: logo header, accent color trên nút "Bắt đầu làm bài".
+
+### AC-2 — PDF export (FR-3)
+- [ ] Recruiter nhấn "Export PDF" với invite đã SUBMITTED → tải về file `.pdf` hợp lệ mở được.
+- [ ] PDF chứa: tên assessment, điểm tổng, pass/fail, domain breakdown, integrity score, timestamp.
+- [ ] Invite `status = INVITED` (chưa làm) → nút disable hoặc gọi API trả `400`.
+- [ ] User không phải OWNER/ADMIN/MANAGER/RECRUITER gọi endpoint → `403`.
+
+### AC-3 — Anonymization (FR-5)
+- [ ] Set `retentionDays = 30` cho org. Sau khi fake `submittedAt` là 31 ngày trước và chạy cron thủ công → `candidateEmail = 'anonymized@example.com'`, `candidateName = null`, `ipAddress = null`, `anonymizedAt != null`.
+- [ ] Score, domainScores, integrityScore, stage giữ nguyên sau anonymization.
+- [ ] Cron chạy lại → không thay đổi gì (idempotent).
+- [ ] Endpoint `DELETE .../pii` gọi bởi Admin → anonymize ngay, không chờ cron.
+
+### AC-4 — Audit log (FR-6)
+- [ ] Tạo assessment → xuất hiện `ASSESSMENT_CREATED` trong audit log với đúng `targetId`.
+- [ ] Đổi stage ứng viên → xuất hiện `CANDIDATE_STAGE_UPDATED`.
+- [ ] Export PDF → xuất hiện `PDF_EXPORTED`.
+- [ ] `GET` danh sách kết quả → **không** xuất hiện bất kỳ log nào.
+- [ ] Audit log `metadata` không chứa full email ứng viên.
+
+### AC-5 — Branding graceful degradation (NFR-5, NFR-8)
+- [ ] `logoUrl` trả 404 → email không crash, hiển thị orgName dạng text.
+- [ ] `accentColor = "#000000"` (màu tối) → Lighthouse a11y vẫn ≥ 90 (text trên nền dark button đủ contrast).
+
+---
+
+## 10. Rủi ro & vấn đề mở
+
+| # | Rủi ro | Hướng xử lý |
+|---|---|---|
+| R-1 | PDF library trong Docker: `puppeteer` cần Chromium — image có thể phình to | Dùng `pdfkit` (pure Node) cho MVP; migrate sang puppeteer nếu cần layout phức tạp. Cần confirm với DevOps trước khi chọn. |
+| R-2 | Email branding: inline CSS bị mail client cắt (Gmail cắt style > 102KB) | Dùng inline styles trực tiếp, không import stylesheet ngoài. Template phải nhẹ < 50KB. |
+| R-3 | Retention cron quét toàn bộ table lớn mỗi ngày | Index `(submitted_at, anonymized_at)` để scan hiệu quả; xử lý theo batch 500 rows/lần. |
+| R-4 | Org không upload logo → branding không khác gì Brain Gym mặc định | Thêm hướng dẫn trong OrgSettings + reminder "Chưa cấu hình logo — email sẽ hiển thị tên org". |
+| R-5 | Ứng viên EU yêu cầu xóa dữ liệu (GDPR Article 17) nhưng không có tài khoản | Documented workaround: ứng viên gửi email → Admin org trigger `DELETE .../pii` endpoint. Cần hướng dẫn trong help center. |
+| R-6 | `accentColor` người dùng nhập tạo contrast không đủ a11y | Validate hex format trong OrgSettings; hiển thị preview + cảnh báo nếu contrast < WCAG AA với màu trắng. |
+
+---
+
+## 11. Liên kết tài liệu
+
+- **Enterprise plan tổng quan**: [enterprise-entrance-exam-plan.md](../enterprise-entrance-exam-plan.md)
+- **Schema Prisma**: [backend/prisma/schema.prisma](../../backend/prisma/schema.prisma)
+- **Mail service**: [backend/src/mail/mail.service.ts](../../backend/src/mail/mail.service.ts)
+- **Candidate controller**: [backend/src/assessments/candidate.controller.ts](../../backend/src/assessments/candidate.controller.ts)
+- **AssessmentResults FE**: [src/pages/org/AssessmentResults.tsx](../../src/pages/org/AssessmentResults.tsx)
+- **CandidateExam FE**: [src/pages/CandidateExam.tsx](../../src/pages/CandidateExam.tsx)
+- **A11y baseline**: [docs/a11y-baseline.md](../a11y-baseline.md)
+- **SRS P0 reference (Smart Builder)**: [docs/specs/smart-exam-builder-srs.md](./smart-exam-builder-srs.md)
+
+---
+
+*Tài liệu này ở trạng thái Draft để review. Sau khi chốt D1–D5 (§2.4) và AC được team approve, sẽ chuyển sang thiết kế chi tiết và lập kế hoạch sprint.*


### PR DESCRIPTION
## Summary

Added Software Requirements Specifications (SRS) for all 4 phases of the Enterprise Entrance Exam feature:

- **P0 — Smart Assessment Builder**: BLUEPRINT mode (auto-build by domain %) and POOL mode (per-candidate random draw)
- **P1 — Recruiting Workflow (ATS-lite)**: RECRUITER role, JobRole, pipeline stages (APPLIED→HIRED/REJECTED), percentile ranking, bulk CSV import
- **P2 — Proctoring & Integrity**: OTP verification, fullscreen enforcement, event logging (TAB_SWITCH, FULLSCREEN_EXIT, COPY, PASTE), integrity scoring (0–100)
- **P3 — Branding, Email & Compliance**: branded email templates, PDF export, GDPR retention/anonymization (PII masking), audit logs

## Details

Each SRS includes:
- **Functional Requirements (FR)** — detailed feature specs with examples
- **Non-Functional Requirements (NFR)** — performance, security, scaling
- **Acceptance Criteria (AC)** — testable definitions of done
- **Schema changes** — Prisma model additions with minimal migration
- **API endpoints** — request/response contracts
- **Frontend components** — pages and UI changes
- **Known issues & limitations** — documented gaps (e.g., OTP multi-pod TODO, iOS fullscreen API)

## Implementation Status

- **P0 & P1 & P2**: Already implemented (schema, backend service, frontend components exist)
- **P3**: Ready for implementation (design decided, dependencies clear)

This documentation consolidates the scattered implementation into formal SRS format for team alignment and future reference.

## Test Plan

- [ ] Review AC in each SRS against current implementation
- [ ] Verify schema/API/frontend match documented contracts
- [ ] Identify any gaps in tests or edge cases

🤖 Generated with Claude Code