### PR TITLE
fix: persist local LLM apiKey to survive page reloads (hotfix)

### DIFF
--- a/src/services/__tests__/local-llm.test.ts
+++ b/src/services/__tests__/local-llm.test.ts
@@ -206,7 +206,7 @@ describe("Local LLM Feature", () => {
       expect(updated?.apiKey).toBe("secret");
     });
 
-    it("should never write the apiKey to localStorage in clear text", () => {
+    it("should persist the apiKey so it survives a reload", () => {
       const saved = localLlmConfigStorage.save({
         dialect: "openai",
         baseUrl: "http://localhost:11434/v1",
@@ -214,12 +214,12 @@ describe("Local LLM Feature", () => {
         apiKey: "super-secret-key",
       });
 
-      // The raw persisted blob must not contain the secret…
+      // The key is persisted to localStorage so it survives a page reload —
+      // otherwise the next generation request would fail with 401.
       const raw = localStorage.getItem("braingym:local-llm-configs") ?? "";
-      expect(raw).not.toContain("super-secret-key");
-      expect(raw).not.toContain("apiKey");
+      expect(raw).toContain("super-secret-key");
 
-      // …but it remains usable in-session via the in-memory cache.
+      // A fresh read (simulating a reload) still yields the key.
       expect(localLlmConfigStorage.getById(saved.id)?.apiKey).toBe(
         "super-secret-key",
       );

--- a/src/services/local-llm/config-storage.ts
+++ b/src/services/local-llm/config-storage.ts
@@ -14,10 +14,13 @@ export interface StoredLocalLlmConfig {
 }
 
 /**
- * Shape actually written to localStorage. The apiKey is deliberately NOT
- * persisted (see `apiKeyCache`) to avoid storing a secret in clear text.
+ * Shape written to localStorage. The apiKey IS persisted (in clear text) so it
+ * survives page reloads — otherwise the key is lost on refresh and the next
+ * generation request fails with 401. This is the same exposure level as the
+ * auth JWT the app already keeps in localStorage; do not store high-value
+ * secrets in a local LLM profile.
  */
-type PersistedConfig = Omit<StoredLocalLlmConfig, "apiKey">;
+type PersistedConfig = StoredLocalLlmConfig;
 
 interface ConfigStore {
   configs: PersistedConfig[];
@@ -33,14 +36,6 @@ export type LocalLlmConfigInput = Omit<
 };
 
 const EMPTY_STORE: ConfigStore = { configs: [], activeId: null };
-
-/**
- * Session-scoped, in-memory store for API keys, keyed by config id. Keys are
- * never written to localStorage, so they are cleared on reload — for endpoints
- * that need a key the user re-enters it per session (most local servers need
- * none). This is what keeps the secret out of clear-text persistent storage.
- */
-const apiKeyCache = new Map<string, string>();
 
 function generateId(): string {
   if (typeof crypto !== "undefined") {
@@ -59,23 +54,9 @@ function generateId(): string {
   return `cfg-${Date.now()}-${performance.now().toString(36).replace(".", "")}`;
 }
 
-/** Attach the session-cached apiKey (if any) to a persisted config. */
-function hydrate(config: PersistedConfig): StoredLocalLlmConfig {
-  const apiKey = apiKeyCache.get(config.id);
-  return apiKey ? { ...config, apiKey } : { ...config };
-}
-
-/**
- * Drop the apiKey before persisting. If a key is present (e.g. legacy data or
- * an upgraded store written by an earlier version) it is moved into the
- * in-memory cache so it still works for the current session.
- */
-function toPersisted(
-  config: PersistedConfig & { apiKey?: string },
-): PersistedConfig {
-  const { apiKey, ...rest } = config;
-  if (apiKey) apiKeyCache.set(rest.id, apiKey);
-  return rest;
+/** Return a defensive copy of a stored config. */
+function clone(config: PersistedConfig): StoredLocalLlmConfig {
+  return { ...config };
 }
 
 /**
@@ -94,13 +75,12 @@ function migrateLegacy(): ConfigStore | null {
     if (!legacy?.modelId || !legacy?.baseUrl) return null;
 
     const id = generateId();
-    if (legacy.apiKey) apiKeyCache.set(id, legacy.apiKey);
-
     const migrated: PersistedConfig = {
       id,
       dialect: legacy.dialect,
       baseUrl: legacy.baseUrl,
       modelId: legacy.modelId,
+      ...(legacy.apiKey ? { apiKey: legacy.apiKey } : {}),
       savedAt: legacy.savedAt ?? new Date().toISOString(),
     };
     const store: ConfigStore = { configs: [migrated], activeId: id };
@@ -119,15 +99,13 @@ function read(): ConfigStore {
       return migrateLegacy() ?? { ...EMPTY_STORE };
     }
     const parsed = JSON.parse(raw) as {
-      configs?: (PersistedConfig & { apiKey?: string })[];
+      configs?: PersistedConfig[];
       activeId?: string | null;
     };
     if (!parsed || !Array.isArray(parsed.configs)) return { ...EMPTY_STORE };
-    // Defensively strip any persisted apiKey (and move it to the cache).
-    const configs = parsed.configs.map(toPersisted);
     return {
-      configs,
-      activeId: parsed.activeId ?? configs[0]?.id ?? null,
+      configs: parsed.configs,
+      activeId: parsed.activeId ?? parsed.configs[0]?.id ?? null,
     };
   } catch {
     return { ...EMPTY_STORE };
@@ -135,12 +113,7 @@ function read(): ConfigStore {
 }
 
 function write(store: ConfigStore): void {
-  // Re-strip on the way out so a secret can never reach localStorage.
-  const safe: ConfigStore = {
-    configs: store.configs.map(toPersisted),
-    activeId: store.activeId,
-  };
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(safe));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
 }
 
 /**
@@ -162,7 +135,7 @@ function isSameProfile(
 export const localLlmConfigStorage = {
   /** All saved local LLM profiles, newest first. */
   list(): StoredLocalLlmConfig[] {
-    return read().configs.map(hydrate);
+    return read().configs.map(clone);
   },
 
   /** The currently active profile, or null if none are saved. */
@@ -170,20 +143,19 @@ export const localLlmConfigStorage = {
     const { configs, activeId } = read();
     if (configs.length === 0) return null;
     const found = configs.find((c) => c.id === activeId) ?? configs[0];
-    return hydrate(found);
+    return clone(found);
   },
 
   getById(id: string): StoredLocalLlmConfig | null {
     const found = read().configs.find((c) => c.id === id);
-    return found ? hydrate(found) : null;
+    return found ? clone(found) : null;
   },
 
   /**
    * Add a new profile or update an existing one (matched by id, otherwise by
    * dialect + baseUrl + modelId). The saved profile becomes active.
-   * When updating, the optional `label` omitted from the input keeps its
-   * existing value. The apiKey is held in memory for the session only and is
-   * preserved across updates that omit it. Returns the saved profile.
+   * When updating, an omitted `label` or `apiKey` keeps its existing value; an
+   * explicit empty-string `apiKey` clears it. Returns the saved profile.
    */
   save(input: LocalLlmConfigInput): StoredLocalLlmConfig {
     const store = read();
@@ -197,21 +169,20 @@ export const localLlmConfigStorage = {
 
     const id = input.id ?? existing?.id ?? generateId();
 
+    // Resolve the key: a provided non-empty key replaces it, an explicit empty
+    // string clears it, and an omitted key keeps the existing one.
+    const apiKey =
+      input.apiKey !== undefined ? input.apiKey || undefined : existing?.apiKey;
+
     const saved: PersistedConfig = {
       id,
       label: input.label ?? existing?.label,
       dialect: input.dialect,
       baseUrl: input.baseUrl,
       modelId: input.modelId,
+      ...(apiKey ? { apiKey } : {}),
       savedAt: now,
     };
-
-    // Update the in-memory key cache: a provided non-empty key replaces it, an
-    // explicit empty string clears it, and an omitted key is left untouched.
-    if (input.apiKey !== undefined) {
-      if (input.apiKey) apiKeyCache.set(id, input.apiKey);
-      else apiKeyCache.delete(id);
-    }
 
     const configs =
       existingIndex >= 0
@@ -219,7 +190,7 @@ export const localLlmConfigStorage = {
         : [saved, ...store.configs];
 
     write({ configs, activeId: id });
-    return hydrate(saved);
+    return clone(saved);
   },
 
   setActive(id: string): void {
@@ -234,13 +205,11 @@ export const localLlmConfigStorage = {
     const configs = store.configs.filter((c) => c.id !== id);
     const activeId =
       store.activeId === id ? (configs[0]?.id ?? null) : store.activeId;
-    apiKeyCache.delete(id);
     write({ configs, activeId });
   },
 
   /** Remove every saved profile. */
   clear(): void {
-    apiKeyCache.clear();
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(LEGACY_STORAGE_KEY);
   },


### PR DESCRIPTION
## Summary

- The local LLM `apiKey` was stored only in a session-scoped in-memory `Map` that was wiped on every page reload
- After a reload, all generation requests were sent without the key → **401 Unauthorized**
- `apiKey` is now persisted to `localStorage` alongside the rest of the config, so it survives reloads

## What changed

**`src/services/local-llm/config-storage.ts`**
- Removed `apiKeyCache` (in-memory `Map`), `hydrate()`, and `toPersisted()` — the whole session-only key dance
- `PersistedConfig` is now just `StoredLocalLlmConfig` (apiKey included)
- `write()` serializes the full config including `apiKey` directly to localStorage
- `save()` key-resolution logic preserved: omit = keep existing, `""` = clear, non-empty string = replace

**`src/services/__tests__/local-llm.test.ts`**
- Updated the test that previously asserted `apiKey` must never be in localStorage; it now asserts the opposite

## Reviewer notes

The `apiKey` is stored in clear text in localStorage — the same exposure level as the auth JWT the app already keeps there. This is acceptable for local LLM endpoints (typically `localhost`), but users should not store high-value production secrets in a local LLM profile.

## Test plan

- [x] All 25 existing unit tests pass (`npx vitest run src/services/__tests__/local-llm.test.ts`)
- [ ] Manually: configure a local LLM with an API key, generate questions, reload the page, generate again — should not get 401