### PR TITLE
Potential fix for code scanning alert no. 19: Server-side request forgery

### DIFF
--- a/backend/src/ai-question-bank/ingestion/ingestion.service.ts
+++ b/backend/src/ai-question-bank/ingestion/ingestion.service.ts
@@ -139,7 +139,8 @@ export class IngestionService {
       normalized === '::' || // unspecified
       normalized.startsWith('fe80:') || // link-local
       normalized.startsWith('fc') || // unique local fc00::/7
-      normalized.startsWith('fd')
+      normalized.startsWith('fd') || // unique local fc00::/7
+      normalized.startsWith('::ffff:') // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1)
     );
   }
 
@@ -169,7 +170,9 @@ export class IngestionService {
     }
 
     if (this.isPrivateOrLocalIp(hostname)) {
-      throw new BadRequestException('Private or local network URLs are not allowed');
+      throw new BadRequestException(
+        'Private or local network URLs are not allowed',
+      );
     }
 
     return parsed.toString();
@@ -180,6 +183,7 @@ export class IngestionService {
     const response = await fetch(safeUrl, {
       headers: { 'User-Agent': 'BrainGym/1.0 (study material fetcher)' },
       signal: AbortSignal.timeout(15000),
+      redirect: 'error', // prevent redirect chains bypassing SSRF validation
     });
     if (!response.ok)
       throw new BadRequestException(

--- a/backend/src/ai-question-bank/ingestion/ingestion.service.ts
+++ b/backend/src/ai-question-bank/ingestion/ingestion.service.ts
@@ -181,10 +181,9 @@ export class IngestionService {
   private async fetchUrl(url: string): Promise<string> {
     // validateAndNormalizeExternalUrl enforces: https/http only, no private/loopback
     // IPs (IPv4 + IPv4-mapped IPv6), no internal hostnames, and redirect:'error'
-    // prevents redirect-chain bypass. CodeQL cannot model the custom sanitizer,
-    // so the alert is suppressed here after manual review.
-    // lgtm[js/server-side-request-forgery]
+    // prevents redirect-chain bypass. CodeQL cannot model the custom sanitizer.
     const safeUrl = this.validateAndNormalizeExternalUrl(url);
+    // lgtm[js/server-side-request-forgery]
     const response = await fetch(safeUrl, {
       headers: { 'User-Agent': 'BrainGym/1.0 (study material fetcher)' },
       signal: AbortSignal.timeout(15000),

--- a/backend/src/ai-question-bank/ingestion/ingestion.service.ts
+++ b/backend/src/ai-question-bank/ingestion/ingestion.service.ts
@@ -179,6 +179,11 @@ export class IngestionService {
   }
 
   private async fetchUrl(url: string): Promise<string> {
+    // validateAndNormalizeExternalUrl enforces: https/http only, no private/loopback
+    // IPs (IPv4 + IPv4-mapped IPv6), no internal hostnames, and redirect:'error'
+    // prevents redirect-chain bypass. CodeQL cannot model the custom sanitizer,
+    // so the alert is suppressed here after manual review.
+    // lgtm[js/server-side-request-forgery]
     const safeUrl = this.validateAndNormalizeExternalUrl(url);
     const response = await fetch(safeUrl, {
       headers: { 'User-Agent': 'BrainGym/1.0 (study material fetcher)' },

--- a/backend/src/ai-question-bank/ingestion/ingestion.service.ts
+++ b/backend/src/ai-question-bank/ingestion/ingestion.service.ts
@@ -8,6 +8,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { MaterialContentType } from '@prisma/client';
 import { UploadMaterialDto } from '../dto/upload-material.dto';
 import { chunkText } from './chunker';
+import { isIP } from 'node:net';
 
 const MAX_TEXT_LENGTH = 100_000; // ~25k tokens
 
@@ -117,8 +118,66 @@ export class IngestionService {
     return chunks.map((c: { content: string }) => c.content);
   }
 
+  private isPrivateOrLocalIp(host: string): boolean {
+    const ipVersion = isIP(host);
+    if (!ipVersion) return false;
+
+    if (ipVersion === 4) {
+      const [a, b] = host.split('.').map((n) => Number(n));
+      if (a === 10) return true; // 10.0.0.0/8
+      if (a === 127) return true; // 127.0.0.0/8 (loopback)
+      if (a === 169 && b === 254) return true; // 169.254.0.0/16 (link-local)
+      if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+      if (a === 192 && b === 168) return true; // 192.168.0.0/16
+      if (a === 0) return true; // 0.0.0.0/8
+      return false;
+    }
+
+    const normalized = host.toLowerCase();
+    return (
+      normalized === '::1' || // loopback
+      normalized === '::' || // unspecified
+      normalized.startsWith('fe80:') || // link-local
+      normalized.startsWith('fc') || // unique local fc00::/7
+      normalized.startsWith('fd')
+    );
+  }
+
+  private validateAndNormalizeExternalUrl(rawUrl: string): string {
+    let parsed: URL;
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      throw new BadRequestException('Invalid sourceUrl');
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new BadRequestException('Only HTTP/HTTPS URLs are allowed');
+    }
+
+    const hostname = parsed.hostname.toLowerCase();
+    if (!hostname) {
+      throw new BadRequestException('Invalid sourceUrl hostname');
+    }
+
+    if (
+      hostname === 'localhost' ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.internal')
+    ) {
+      throw new BadRequestException('URL hostname is not allowed');
+    }
+
+    if (this.isPrivateOrLocalIp(hostname)) {
+      throw new BadRequestException('Private or local network URLs are not allowed');
+    }
+
+    return parsed.toString();
+  }
+
   private async fetchUrl(url: string): Promise<string> {
-    const response = await fetch(url, {
+    const safeUrl = this.validateAndNormalizeExternalUrl(url);
+    const response = await fetch(safeUrl, {
       headers: { 'User-Agent': 'BrainGym/1.0 (study material fetcher)' },
       signal: AbortSignal.timeout(15000),
     });

--- a/backend/src/ai-question-bank/ingestion/ingestion.service.ts
+++ b/backend/src/ai-question-bank/ingestion/ingestion.service.ts
@@ -181,9 +181,8 @@ export class IngestionService {
   private async fetchUrl(url: string): Promise<string> {
     // validateAndNormalizeExternalUrl enforces: https/http only, no private/loopback
     // IPs (IPv4 + IPv4-mapped IPv6), no internal hostnames, and redirect:'error'
-    // prevents redirect-chain bypass. CodeQL cannot model the custom sanitizer.
+    // prevents redirect-chain bypass.
     const safeUrl = this.validateAndNormalizeExternalUrl(url);
-    // lgtm[js/server-side-request-forgery]
     const response = await fetch(safeUrl, {
       headers: { 'User-Agent': 'BrainGym/1.0 (study material fetcher)' },
       signal: AbortSignal.timeout(15000),


### PR DESCRIPTION
Potential fix for [https://github.com/thanhpt-25/brain-gym/security/code-scanning/19](https://github.com/thanhpt-25/brain-gym/security/code-scanning/19)

To fix this without changing intended functionality (fetching user-provided public URLs), validate and normalize the URL server-side before making the request, and reject dangerous targets.

Best approach in this code:
- In `backend/src/ai-question-bank/ingestion/ingestion.service.ts`, add a private validator method (e.g., `validateAndNormalizeExternalUrl`) used by `fetchUrl`.
- Enforce:
  - only `http:` / `https:`
  - hostname must exist
  - block localhost and loopback/link-local/private/internal IP ranges (`127.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `::1`, `fc00::/7`, `fe80::/10`, etc.)
  - block obvious internal hostnames (e.g., `localhost`, `.local`, `.internal`)
- Use the validated URL (`parsed.toString()`) in `fetch`.
- Catch URL parsing/validation errors and return `BadRequestException`.

This single change in the ingestion service addresses both alert variants because both flows converge on the same sink (`fetch(url, ...)`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
