### PR TITLE
feat(ingestion): Markitdown pipeline — PDF/DOCX/PPTX/XLSX → Markdown before AI generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,53 @@ jobs:
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
 
+  # Build and push Markitdown Lambda container image to ECR, then update function
+  build-push-lambda:
+    name: Build & Push Markitdown Lambda
+    needs: setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: ${{ needs.setup.outputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        run: |
+          aws ecr get-login-password --region ${{ env.AWS_REGION }} | \
+            docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Markitdown image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./lambda/markitdown
+          file: ./lambda/markitdown/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/braingym-markitdown:${{ needs.setup.outputs.image-tag }}
+            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/braingym-markitdown:latest
+          cache-from: type=gha,scope=markitdown
+          cache-to: type=gha,mode=max,scope=markitdown
+
+      - name: Update Lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name braingym-${{ needs.setup.outputs.environment }}-markitdown \
+            --image-uri ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/braingym-markitdown:${{ needs.setup.outputs.image-tag }} \
+            --no-cli-pager
+
+          echo "✓ Markitdown Lambda updated"
+
   # Run database migrations
   migrate-db:
     name: Migrate Database
@@ -178,7 +225,7 @@ jobs:
   # Deploy backend to ECS
   deploy-backend:
     name: Deploy Backend
-    needs: [setup, migrate-db]
+    needs: [setup, migrate-db, build-push-lambda]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,11 @@ jobs:
         with:
           context: ./lambda/markitdown
           file: ./lambda/markitdown/Dockerfile
-          push: true
+          # AWS Lambda rejects OCI image indexes with SLSA/SBOM attestations
+          # ("image manifest ... media type ... is not supported"). Disable
+          # provenance and force Docker v2s2 media types instead of OCI.
+          provenance: false
+          outputs: type=image,oci-mediatypes=false,push=true
           tags: |
             ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/braingym-markitdown:${{ needs.setup.outputs.image-tag }}
             ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/braingym-markitdown:latest

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
+        "@aws-sdk/client-lambda": "^3.1063.0",
         "@aws-sdk/client-s3": "^3.1055.0",
         "@aws-sdk/s3-request-presigner": "^3.1055.0",
         "@bull-board/api": "^7.0.0",
@@ -298,6 +299,27 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1063.0.tgz",
+      "integrity": "sha512-xn2c+C2/le5Iya243PVsH+s4yhs0Oo5wK+CopVJfhZ2uH6WNEWre+wQ6D/q8FkFZaaPP/cwejVBVUEaMsD98Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/credential-provider-node": "^3.972.52",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1055.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1055.0.tgz",
@@ -328,17 +350,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.974.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.18.tgz",
+      "integrity": "sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.11",
+        "@aws-sdk/xml-builder": "^3.972.28",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -360,15 +382,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.44.tgz",
+      "integrity": "sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -376,17 +398,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.46.tgz",
+      "integrity": "sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -394,23 +416,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.50.tgz",
+      "integrity": "sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/credential-provider-env": "^3.972.44",
+        "@aws-sdk/credential-provider-http": "^3.972.46",
+        "@aws-sdk/credential-provider-login": "^3.972.49",
+        "@aws-sdk/credential-provider-process": "^3.972.44",
+        "@aws-sdk/credential-provider-sso": "^3.972.49",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.49",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -418,16 +440,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.44.tgz",
-      "integrity": "sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.49.tgz",
+      "integrity": "sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -435,21 +457,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.52.tgz",
+      "integrity": "sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.44",
+        "@aws-sdk/credential-provider-http": "^3.972.46",
+        "@aws-sdk/credential-provider-ini": "^3.972.50",
+        "@aws-sdk/credential-provider-process": "^3.972.44",
+        "@aws-sdk/credential-provider-sso": "^3.972.49",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.49",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -457,15 +479,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.44.tgz",
+      "integrity": "sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -473,17 +495,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.49.tgz",
+      "integrity": "sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/token-providers": "3.1063.0",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -491,16 +513,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.49.tgz",
+      "integrity": "sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -604,20 +626,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "version": "3.997.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.17.tgz",
+      "integrity": "sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.32",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -642,14 +664,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.29.tgz",
-      "integrity": "sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==",
+      "version": "3.996.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.32.tgz",
+      "integrity": "sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -657,16 +679,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1063.0.tgz",
+      "integrity": "sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -674,12 +696,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.11.tgz",
+      "integrity": "sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -699,12 +721,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
-      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.28.tgz",
+      "integrity": "sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -4267,13 +4289,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
-      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4281,13 +4303,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.5.tgz",
-      "integrity": "sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4295,13 +4317,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
-      "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4321,13 +4343,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
-      "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4335,13 +4357,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
-      "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4349,9 +4371,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "seed": "npm run seed"
   },
   "dependencies": {
+    "@aws-sdk/client-lambda": "^3.1063.0",
     "@aws-sdk/client-s3": "^3.1055.0",
     "@aws-sdk/s3-request-presigner": "^3.1055.0",
     "@bull-board/api": "^7.0.0",

--- a/backend/prisma/migrations/20260714000001_add_docx_pptx_xlsx_content_types/migration.sql
+++ b/backend/prisma/migrations/20260714000001_add_docx_pptx_xlsx_content_types/migration.sql
@@ -1,0 +1,5 @@
+-- Add DOCX, PPTX, XLSX to MaterialContentType enum
+-- PostgreSQL requires ALTER TYPE for enum additions
+ALTER TYPE "MaterialContentType" ADD VALUE IF NOT EXISTS 'DOCX';
+ALTER TYPE "MaterialContentType" ADD VALUE IF NOT EXISTS 'PPTX';
+ALTER TYPE "MaterialContentType" ADD VALUE IF NOT EXISTS 'XLSX';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -151,6 +151,9 @@ enum MaterialContentType {
   PDF
   URL
   TEXT
+  DOCX
+  PPTX
+  XLSX
 }
 
 // ==================== ENTERPRISE ENUMS ====================

--- a/backend/src/ai-question-bank/ai-question-bank.controller.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.controller.ts
@@ -137,6 +137,15 @@ export class AiQuestionBankController {
     return this.ingestion.getMaterial(req.user.id, id);
   }
 
+  @Get('materials/:id/chunks')
+  @ApiOperation({ summary: 'Return ordered text chunks for a material (used by local LLM generation)' })
+  async getMaterialChunks(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
+    // Ownership check via getMaterial — throws 403/404 if not allowed.
+    await this.ingestion.getMaterial(req.user.id, id);
+    const chunks = await this.ingestion.getChunksForMaterial(id);
+    return { chunks };
+  }
+
   @Delete('materials/:id')
   @ApiOperation({ summary: 'Delete a study material' })
   deleteMaterial(@Req() req: AuthenticatedRequest, @Param('id') id: string) {

--- a/backend/src/ai-question-bank/ai-question-bank.controller.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.controller.ts
@@ -97,16 +97,38 @@ export class AiQuestionBankController {
     return this.ingestion.uploadMaterial(req.user.id, dto);
   }
 
-  @Post('materials/pdf')
-  @ApiOperation({ summary: 'Upload a PDF study material' })
+  @Post('materials/file')
+  @ApiOperation({ summary: 'Upload a file study material (PDF, DOCX, PPTX, XLSX)' })
   @ApiConsumes('multipart/form-data')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(FileInterceptor('file', {
+    fileFilter: (_req, file, cb) => {
+      const allowed = /\.(pdf|docx|pptx|xlsx)$/i;
+      cb(null, allowed.test(file.originalname));
+    },
+  }))
+  uploadFileMaterial(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: UploadMaterialDto,
+    @UploadedFile() file: { buffer: Buffer; originalname: string } | undefined,
+  ) {
+    return this.ingestion.uploadMaterial(req.user.id, dto, file?.buffer, file?.originalname);
+  }
+
+  /** @deprecated Use /materials/file instead */
+  @Post('materials/pdf')
+  @ApiOperation({ summary: '[Deprecated] Use /materials/file' })
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(FileInterceptor('file', {
+    fileFilter: (_req, file, cb) => {
+      cb(null, /\.pdf$/i.test(file.originalname));
+    },
+  }))
   uploadPdfMaterial(
     @Req() req: AuthenticatedRequest,
     @Body() dto: UploadMaterialDto,
     @UploadedFile() file: { buffer: Buffer; originalname: string } | undefined,
   ) {
-    return this.ingestion.uploadMaterial(req.user.id, dto, file?.buffer);
+    return this.ingestion.uploadMaterial(req.user.id, dto, file?.buffer, file?.originalname);
   }
 
   @Get('materials/:id')

--- a/backend/src/ai-question-bank/ai-question-bank.module.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.module.ts
@@ -7,7 +7,9 @@ import { AiQuestionBankController } from './ai-question-bank.controller';
 import { AiQuestionBankService } from './ai-question-bank.service';
 import { EncryptionService } from './crypto/encryption.service';
 import { IngestionService } from './ingestion/ingestion.service';
+import { S3UploadService } from './ingestion/s3-upload.service';
 import { AI_GEN_QUEUE } from '../queues/ai-gen/ai-gen.job.interface';
+import { MATERIAL_CONVERSION_QUEUE } from '../queues/material-conversion/material-conversion.job.interface';
 import { LlmUsageModule } from './llm-usage/llm-usage.module';
 import { EmbeddingModule } from './embedding/embedding.module';
 import { DdsModule } from './dds/dds.module';
@@ -19,10 +21,11 @@ import { DdsModule } from './dds/dds.module';
     LlmUsageModule,
     EmbeddingModule,
     DdsModule,
-    MulterModule.register({ limits: { fileSize: 20 * 1024 * 1024 } }),
+    MulterModule.register({ limits: { fileSize: 50 * 1024 * 1024 } }),
     BullModule.registerQueue({ name: AI_GEN_QUEUE }),
+    BullModule.registerQueue({ name: MATERIAL_CONVERSION_QUEUE }),
   ],
   controllers: [AiQuestionBankController],
-  providers: [AiQuestionBankService, EncryptionService, IngestionService],
+  providers: [AiQuestionBankService, EncryptionService, IngestionService, S3UploadService],
 })
 export class AiQuestionBankModule {}

--- a/backend/src/ai-question-bank/ingestion/ingestion.service.ts
+++ b/backend/src/ai-question-bank/ingestion/ingestion.service.ts
@@ -3,79 +3,199 @@ import {
   BadRequestException,
   NotFoundException,
   ForbiddenException,
+  Logger,
 } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
 import { PrismaService } from '../../prisma/prisma.service';
 import { MaterialContentType } from '@prisma/client';
 import { UploadMaterialDto } from '../dto/upload-material.dto';
 import { chunkText } from './chunker';
+import { S3UploadService } from './s3-upload.service';
+import {
+  MATERIAL_CONVERSION_QUEUE,
+  MaterialConversionJobData,
+} from '../../queues/material-conversion/material-conversion.job.interface';
 
 const MAX_TEXT_LENGTH = 100_000; // ~25k tokens
+// Warn when embedding file in Redis job payload (local dev only). 10 MB base64 ≈ 13.3 MB in Redis.
+const LOCAL_BUFFER_WARN_BYTES = 10 * 1024 * 1024;
+
+const FILE_CONTENT_TYPES = new Set<MaterialContentType>([
+  MaterialContentType.PDF,
+  MaterialContentType.DOCX,
+  MaterialContentType.PPTX,
+  MaterialContentType.XLSX,
+]);
 
 @Injectable()
 export class IngestionService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(IngestionService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly s3Upload: S3UploadService,
+    @InjectQueue(MATERIAL_CONVERSION_QUEUE)
+    private readonly conversionQueue: Queue<MaterialConversionJobData>,
+  ) {}
 
   async uploadMaterial(
     userId: string,
     dto: UploadMaterialDto,
     fileBuffer?: Buffer,
+    originalFilename?: string,
   ) {
-    let rawText: string;
-
     if (dto.contentType === MaterialContentType.TEXT) {
-      if (!dto.textContent)
-        throw new BadRequestException('textContent is required for TEXT type');
-      if (dto.textContent.length > MAX_TEXT_LENGTH) {
-        throw new BadRequestException(
-          `Text content exceeds maximum length of ${MAX_TEXT_LENGTH} characters`,
-        );
-      }
-      rawText = dto.textContent;
-    } else if (dto.contentType === MaterialContentType.URL) {
-      if (!dto.sourceUrl)
-        throw new BadRequestException('sourceUrl is required for URL type');
-      rawText = await this.fetchUrl(dto.sourceUrl);
-    } else if (dto.contentType === MaterialContentType.PDF) {
-      if (!fileBuffer)
-        throw new BadRequestException('A PDF file is required for PDF type');
-      rawText = await this.parsePdf(fileBuffer);
-    } else {
-      throw new BadRequestException('Unsupported content type');
+      return this.uploadTextMaterial(userId, dto);
     }
 
-    // Create the SourceMaterial record
+    if (dto.contentType === MaterialContentType.URL) {
+      return this.uploadUrlMaterial(userId, dto);
+    }
+
+    if (FILE_CONTENT_TYPES.has(dto.contentType)) {
+      if (!fileBuffer || !originalFilename) {
+        throw new BadRequestException('A file is required for this content type');
+      }
+      return this.queueFileMaterial(userId, dto, fileBuffer, originalFilename);
+    }
+
+    throw new BadRequestException('Unsupported content type');
+  }
+
+  private async uploadTextMaterial(userId: string, dto: UploadMaterialDto) {
+    if (!dto.textContent)
+      throw new BadRequestException('textContent is required for TEXT type');
+    if (dto.textContent.length > MAX_TEXT_LENGTH) {
+      throw new BadRequestException(
+        `Text content exceeds maximum length of ${MAX_TEXT_LENGTH} characters`,
+      );
+    }
+
     const material = await this.prisma.sourceMaterial.create({
       data: {
         userId,
         certificationId: dto.certificationId || null,
         title: dto.title,
         contentType: dto.contentType,
-        sourceUrl: dto.sourceUrl || null,
         status: 'processing',
       },
     });
 
-    // Chunk and store
+    const chunks = chunkText(dto.textContent);
+    await this.prisma.sourceChunk.createMany({
+      data: chunks.map((c) => ({
+        materialId: material.id,
+        content: c.content,
+        chunkIndex: c.chunkIndex,
+        pageNumber: c.pageNumber ?? null,
+        sectionTitle: c.sectionTitle ?? null,
+        tokenCount: c.tokenCount,
+      })),
+    });
+
+    return this.prisma.sourceMaterial.update({
+      where: { id: material.id },
+      data: { chunkCount: chunks.length, status: 'ready' },
+      include: { _count: { select: { chunks: true } } },
+    });
+  }
+
+  private async uploadUrlMaterial(userId: string, dto: UploadMaterialDto) {
+    if (!dto.sourceUrl)
+      throw new BadRequestException('sourceUrl is required for URL type');
+
+    const rawText = await this.fetchUrl(dto.sourceUrl);
+
+    const material = await this.prisma.sourceMaterial.create({
+      data: {
+        userId,
+        certificationId: dto.certificationId || null,
+        title: dto.title,
+        contentType: dto.contentType,
+        sourceUrl: dto.sourceUrl,
+        status: 'processing',
+      },
+    });
+
     const chunks = chunkText(rawText);
     await this.prisma.sourceChunk.createMany({
       data: chunks.map((c) => ({
         materialId: material.id,
         content: c.content,
         chunkIndex: c.chunkIndex,
-        pageNumber: c.pageNumber || null,
-        sectionTitle: c.sectionTitle || null,
+        pageNumber: c.pageNumber ?? null,
+        sectionTitle: c.sectionTitle ?? null,
         tokenCount: c.tokenCount,
       })),
     });
 
-    // Update chunk count and status
-    const updated = await this.prisma.sourceMaterial.update({
+    return this.prisma.sourceMaterial.update({
       where: { id: material.id },
       data: { chunkCount: chunks.length, status: 'ready' },
       include: { _count: { select: { chunks: true } } },
     });
+  }
 
-    return updated;
+  private async queueFileMaterial(
+    userId: string,
+    dto: UploadMaterialDto,
+    fileBuffer: Buffer,
+    originalFilename: string,
+  ) {
+    // Create the record first so we have a materialId for the job.
+    const material = await this.prisma.sourceMaterial.create({
+      data: {
+        userId,
+        certificationId: dto.certificationId || null,
+        title: dto.title,
+        contentType: dto.contentType,
+        originalFilename,
+        status: 'processing',
+      },
+      include: { _count: { select: { chunks: true } } },
+    });
+
+    // If staging or queueing fails, mark the material as failed so it doesn't
+    // stay stuck in 'processing' forever (Fix #1).
+    try {
+      const jobData: MaterialConversionJobData = {
+        materialId: material.id,
+        filename: originalFilename,
+      };
+
+      const useS3 = !!process.env.AWS_S3_MATERIALS_TMP_BUCKET;
+      if (useS3) {
+        const { bucket, key } = await this.s3Upload.uploadToTemp(
+          fileBuffer,
+          originalFilename,
+        );
+        jobData.s3Bucket = bucket;
+        jobData.s3Key = key;
+      } else {
+        // Local dev: embed buffer in job payload (Fix #4 — warn on large files).
+        if (fileBuffer.length > LOCAL_BUFFER_WARN_BYTES) {
+          this.logger.warn(
+            `Large file embedded in Redis job payload (${Math.round(fileBuffer.length / 1024 / 1024)}MB). ` +
+              'Set AWS_S3_MATERIALS_TMP_BUCKET to use S3 staging instead.',
+          );
+        }
+        jobData.bufferBase64 = fileBuffer.toString('base64');
+      }
+
+      await this.conversionQueue.add('convert', jobData);
+    } catch (err) {
+      this.logger.error(
+        `Failed to stage/queue material ${material.id}: ${err}`,
+      );
+      await this.prisma.sourceMaterial.update({
+        where: { id: material.id },
+        data: { status: 'failed' },
+      });
+      throw err;
+    }
+
+    return material;
   }
 
   async getMaterials(userId: string, certificationId?: string) {
@@ -127,24 +247,9 @@ export class IngestionService {
         `Failed to fetch URL: ${response.statusText}`,
       );
     const html = await response.text();
-    // Strip HTML tags
     return html
       .replace(/<[^>]+>/g, ' ')
       .replace(/\s{2,}/g, ' ')
       .trim();
-  }
-
-  private async parsePdf(buffer: Buffer): Promise<string> {
-    // Dynamic import to avoid hard dependency at module load
-    const pdfParse = await import('pdf-parse')
-      .then((m) => m.default || m)
-      .catch(() => null);
-    if (!pdfParse) {
-      throw new BadRequestException(
-        'PDF parsing is not available. Please use TEXT type instead.',
-      );
-    }
-    const data = await pdfParse(buffer);
-    return data.text;
   }
 }

--- a/backend/src/ai-question-bank/ingestion/ingestion.service.ts
+++ b/backend/src/ai-question-bank/ingestion/ingestion.service.ts
@@ -183,7 +183,14 @@ export class IngestionService {
         jobData.bufferBase64 = fileBuffer.toString('base64');
       }
 
-      await this.conversionQueue.add('convert', jobData);
+      // removeOnComplete: true — the job payload may contain a large base64
+      // buffer (local dev) or S3 coords (production). Once the processor has
+      // finished there is no reason to keep the job in Redis; the result is
+      // persisted as SourceChunk rows in Postgres.
+      await this.conversionQueue.add('convert', jobData, {
+        removeOnComplete: true,
+        removeOnFail: { count: 10 }, // keep a small window of failures for debugging
+      });
     } catch (err) {
       this.logger.error(
         `Failed to stage/queue material ${material.id}: ${err}`,
@@ -205,7 +212,10 @@ export class IngestionService {
         ...(certificationId ? { certificationId } : {}),
       },
       orderBy: { createdAt: 'desc' },
-      include: { _count: { select: { chunks: true } } },
+      include: {
+        _count: { select: { chunks: true } },
+        certification: { select: { code: true } },
+      },
     });
   }
 

--- a/backend/src/ai-question-bank/ingestion/s3-upload.service.ts
+++ b/backend/src/ai-question-bank/ingestion/s3-upload.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class S3UploadService {
+  private readonly logger = new Logger(S3UploadService.name);
+  private readonly s3 = new S3Client({ region: process.env.AWS_REGION ?? 'us-east-1' });
+  readonly bucket = process.env.AWS_S3_MATERIALS_TMP_BUCKET ?? '';
+
+  async uploadToTemp(buffer: Buffer, filename: string): Promise<{ bucket: string; key: string }> {
+    const key = `uploads/${uuidv4()}/${filename}`;
+    await this.s3.send(new PutObjectCommand({ Bucket: this.bucket, Key: key, Body: buffer }));
+    return { bucket: this.bucket, key };
+  }
+
+  async deleteTemp(bucket: string, key: string): Promise<void> {
+    try {
+      await this.s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    } catch (err) {
+      this.logger.warn(`Failed to delete temp s3://${bucket}/${key}: ${err}`);
+    }
+  }
+}

--- a/backend/src/queues/material-conversion/material-conversion.job.interface.ts
+++ b/backend/src/queues/material-conversion/material-conversion.job.interface.ts
@@ -1,0 +1,11 @@
+export const MATERIAL_CONVERSION_QUEUE = 'material-conversion';
+
+export interface MaterialConversionJobData {
+  materialId: string;
+  filename: string;
+  // Production: Lambda reads from S3
+  s3Bucket?: string;
+  s3Key?: string;
+  // Local dev: buffer embedded as base64 (no S3 needed)
+  bufferBase64?: string;
+}

--- a/backend/src/queues/material-conversion/material-conversion.processor.ts
+++ b/backend/src/queues/material-conversion/material-conversion.processor.ts
@@ -1,0 +1,185 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import {
+  LambdaClient,
+  InvokeCommand,
+  InvocationType,
+} from '@aws-sdk/client-lambda';
+import { PrismaService } from '../../prisma/prisma.service';
+import { S3UploadService } from '../../ai-question-bank/ingestion/s3-upload.service';
+import { chunkText } from '../../ai-question-bank/ingestion/chunker';
+import {
+  MATERIAL_CONVERSION_QUEUE,
+  MaterialConversionJobData,
+} from './material-conversion.job.interface';
+
+@Processor(MATERIAL_CONVERSION_QUEUE, { concurrency: 2 })
+export class MaterialConversionProcessor extends WorkerHost {
+  private readonly logger = new Logger(MaterialConversionProcessor.name);
+  private readonly lambdaClient = new LambdaClient({
+    region: process.env.AWS_REGION ?? 'us-east-1',
+  });
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly s3Upload: S3UploadService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<MaterialConversionJobData>): Promise<void> {
+    const { materialId, filename, s3Bucket, s3Key, bufferBase64 } = job.data;
+    this.logger.log(`Converting material ${materialId} (${filename})`);
+
+    try {
+      const markdown = await this.convertToMarkdown(
+        filename,
+        s3Bucket,
+        s3Key,
+        bufferBase64,
+      );
+
+      // Fix #5: Treat empty markdown as a conversion failure rather than
+      // creating a ready material with 0 chunks that produces no AI context.
+      if (!markdown || markdown.trim().length === 0) {
+        throw new Error(
+          `Markitdown returned empty content for "${filename}". ` +
+            'The file may be corrupt, password-protected, or an unsupported format.',
+        );
+      }
+
+      const chunks = chunkText(markdown);
+      await this.prisma.sourceChunk.createMany({
+        data: chunks.map((c) => ({
+          materialId,
+          content: c.content,
+          chunkIndex: c.chunkIndex,
+          pageNumber: c.pageNumber ?? null,
+          sectionTitle: c.sectionTitle ?? null,
+          tokenCount: c.tokenCount,
+        })),
+      });
+
+      await this.prisma.sourceMaterial.update({
+        where: { id: materialId },
+        data: { status: 'ready', chunkCount: chunks.length },
+      });
+
+      this.logger.log(
+        `Material ${materialId} ready — ${chunks.length} chunks`,
+      );
+    } catch (err) {
+      this.logger.error(`Failed to convert material ${materialId}: ${err}`);
+      await this.prisma.sourceMaterial.update({
+        where: { id: materialId },
+        data: { status: 'failed' },
+      });
+      throw err;
+    } finally {
+      // Fix #3: Always clean up the S3 temp object, even on conversion failure.
+      // The 24h lifecycle rule is a safety net, but eager cleanup avoids leaked
+      // objects accumulating across BullMQ retries (default: 3 attempts).
+      if (s3Bucket && s3Key) {
+        await this.s3Upload.deleteTemp(s3Bucket, s3Key);
+      }
+    }
+  }
+
+  private async convertToMarkdown(
+    filename: string,
+    s3Bucket?: string,
+    s3Key?: string,
+    bufferBase64?: string,
+  ): Promise<string> {
+    const localUrl = process.env.MARKITDOWN_LOCAL_URL;
+
+    if (localUrl) {
+      return this.convertViaLocalServer(
+        localUrl,
+        filename,
+        s3Bucket,
+        s3Key,
+        bufferBase64,
+      );
+    }
+
+    const lambdaArn = process.env.AWS_MARKITDOWN_LAMBDA_ARN;
+    if (!lambdaArn) {
+      throw new Error(
+        'MARKITDOWN_LOCAL_URL or AWS_MARKITDOWN_LAMBDA_ARN must be set',
+      );
+    }
+
+    // Fix #2: Validate S3 coords are present before invoking Lambda.
+    // In production the job is always populated with s3Bucket/s3Key, but guard
+    // explicitly to surface misconfiguration as a clear error rather than a
+    // runtime crash on the non-null assertion.
+    if (!s3Bucket || !s3Key) {
+      throw new Error(
+        `Lambda conversion requires s3Bucket and s3Key in job data, ` +
+          `but got s3Bucket=${s3Bucket}, s3Key=${s3Key}. ` +
+          'Ensure AWS_S3_MATERIALS_TMP_BUCKET is set.',
+      );
+    }
+
+    return this.convertViaLambda(lambdaArn, s3Bucket, s3Key, filename);
+  }
+
+  private async convertViaLambda(
+    lambdaArn: string,
+    bucket: string,
+    key: string,
+    filename: string,
+  ): Promise<string> {
+    const payload = JSON.stringify({ bucket, key, filename });
+    const response = await this.lambdaClient.send(
+      new InvokeCommand({
+        FunctionName: lambdaArn,
+        InvocationType: InvocationType.RequestResponse,
+        Payload: Buffer.from(payload),
+      }),
+    );
+
+    if (response.FunctionError) {
+      const errorBody = Buffer.from(response.Payload!).toString('utf-8');
+      throw new Error(`Lambda error: ${errorBody}`);
+    }
+
+    const result = JSON.parse(Buffer.from(response.Payload!).toString('utf-8'));
+    return result.markdown as string;
+  }
+
+  private async convertViaLocalServer(
+    baseUrl: string,
+    filename: string,
+    s3Bucket?: string,
+    s3Key?: string,
+    bufferBase64?: string,
+  ): Promise<string> {
+    let fileBuffer: Buffer;
+
+    if (bufferBase64) {
+      fileBuffer = Buffer.from(bufferBase64, 'base64');
+    } else if (s3Bucket && s3Key) {
+      const { GetObjectCommand, S3Client } = await import('@aws-sdk/client-s3');
+      const s3 = new S3Client({ region: process.env.AWS_REGION ?? 'us-east-1' });
+      const obj = await s3.send(new GetObjectCommand({ Bucket: s3Bucket, Key: s3Key }));
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of obj.Body as any) chunks.push(chunk);
+      fileBuffer = Buffer.concat(chunks);
+    } else {
+      throw new Error('No file source for local conversion');
+    }
+
+    // Use Node 18+ built-in FormData + Blob
+    const form = new FormData();
+    form.append('file', new Blob([new Uint8Array(fileBuffer)]), filename);
+    form.append('filename', filename);
+
+    const res = await fetch(`${baseUrl}/convert`, { method: 'POST', body: form });
+    if (!res.ok) throw new Error(`Markitdown local server error: ${res.statusText}`);
+    const json = (await res.json()) as { markdown: string };
+    return json.markdown;
+  }
+}

--- a/backend/src/queues/queues.module.ts
+++ b/backend/src/queues/queues.module.ts
@@ -10,7 +10,10 @@ import { AI_GEN_QUEUE } from './ai-gen/ai-gen.job.interface';
 import { SCENARIO_GENERATION_QUEUE } from './scenario-generation/scenario-generation.job.interface';
 import { DIGEST_GENERATION_QUEUE } from './digest-generation/digest-generation.job.interface';
 import { COACH_SESSION_MONITORING_QUEUE } from './coach-session-monitoring/coach-session-monitoring.job.interface';
+import { MATERIAL_CONVERSION_QUEUE } from './material-conversion/material-conversion.job.interface';
+import { MaterialConversionProcessor } from './material-conversion/material-conversion.processor';
 import { IngestionService } from '../ai-question-bank/ingestion/ingestion.service';
+import { S3UploadService } from '../ai-question-bank/ingestion/s3-upload.service';
 import { EncryptionService } from '../ai-question-bank/crypto/encryption.service';
 import { DigestGenerationProcessor } from '../mail/digest/digest-generation.processor';
 import { DigestModule } from '../mail/digest/digest.module';
@@ -37,6 +40,7 @@ import { TrainingModule } from '../training/training.module';
     BullModule.registerQueue({ name: SCENARIO_GENERATION_QUEUE }),
     BullModule.registerQueue({ name: DIGEST_GENERATION_QUEUE }),
     BullModule.registerQueue({ name: COACH_SESSION_MONITORING_QUEUE }),
+    BullModule.registerQueue({ name: MATERIAL_CONVERSION_QUEUE }),
     BullModule.registerQueue({ name: 'burnout-detection' }),
     BullBoardModule.forRoot({
       route: '/admin/queues',
@@ -59,6 +63,10 @@ import { TrainingModule } from '../training/training.module';
       adapter: BullMQAdapter,
     }),
     BullBoardModule.forFeature({
+      name: MATERIAL_CONVERSION_QUEUE,
+      adapter: BullMQAdapter,
+    }),
+    BullBoardModule.forFeature({
       name: 'burnout-detection',
       adapter: BullMQAdapter,
     }),
@@ -71,7 +79,9 @@ import { TrainingModule } from '../training/training.module';
     AiGenProcessor,
     DigestGenerationProcessor,
     BurnoutProcessor,
+    MaterialConversionProcessor,
     IngestionService,
+    S3UploadService,
     EncryptionService,
   ],
   exports: [BullModule],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,14 @@ services:
       PORT: ${PORT:-3000}
       NODE_ENV: ${NODE_ENV:-production}
       LLM_KEY_ENCRYPTION_SECRET: "${LLM_KEY_ENCRYPTION_SECRET:-braingym-llm-encryption-secret-change-in-production}"
+      MARKITDOWN_LOCAL_URL: "http://markitdown:8001"
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
+      markitdown:
+        condition: service_started
     expose:
       - "3000"
 
@@ -64,6 +67,14 @@ services:
     container_name: braingym-frontend
     expose:
       - "80"
+
+  markitdown:
+    build:
+      context: ./lambda/markitdown
+      dockerfile: Dockerfile.local
+    container_name: braingym-markitdown
+    expose:
+      - "8001"
 
   nginx:
     image: nginx:stable-alpine

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -61,6 +61,8 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "AWS_REGION", value = var.aws_region },
         { name = "AWS_S3_AVATARS_BUCKET", value = aws_s3_bucket.avatars.bucket },
         { name = "AWS_AVATARS_CDN_BASE_URL", value = "https://${var.domain_name}" },
+        { name = "AWS_S3_MATERIALS_TMP_BUCKET", value = aws_s3_bucket.materials_tmp.bucket },
+        { name = "AWS_MARKITDOWN_LAMBDA_ARN", value = aws_lambda_function.markitdown.arn },
         { name = "DDS_SHADOW_MODE", value = var.dds_shadow_mode },
       ]
 

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -195,6 +195,15 @@ resource "aws_iam_role_policy" "github_deploy" {
         Resource = "*"
       },
       {
+        Sid    = "Lambda"
+        Effect = "Allow"
+        Action = [
+          "lambda:UpdateFunctionCode",
+          "lambda:GetFunction"
+        ]
+        Resource = aws_lambda_function.markitdown.arn
+      },
+      {
         Sid    = "PassRole"
         Effect = "Allow"
         Action = "iam:PassRole"

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -83,6 +83,33 @@ resource "aws_iam_role_policy" "ecs_task_avatars" {
   })
 }
 
+# Allow the ECS task to stage uploaded files and invoke the Markitdown Lambda.
+resource "aws_iam_role_policy" "ecs_task_markitdown" {
+  name = "markitdown-pipeline"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "MaterialsTmpBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${aws_s3_bucket.materials_tmp.arn}/*"
+      },
+      {
+        Sid      = "InvokeMarkitdownLambda"
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = aws_lambda_function.markitdown.arn
+      }
+    ]
+  })
+}
+
 # ─────────────────────────────────────────────
 # GitHub Actions Deploy Role (OIDC)
 # Assumed by GitHub Actions via OIDC — no static

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,0 +1,130 @@
+# ─────────────────────────────────────────────
+# ECR Repository — Markitdown Lambda container image
+# ─────────────────────────────────────────────
+resource "aws_ecr_repository" "markitdown" {
+  name                 = "${var.app_name}-markitdown"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.app_name}-markitdown"
+  })
+}
+
+resource "aws_ecr_lifecycle_policy" "markitdown" {
+  repository = aws_ecr_repository.markitdown.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 5 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 5
+      }
+      action = { type = "expire" }
+    }]
+  })
+}
+
+# ─────────────────────────────────────────────
+# IAM Role — Lambda execution role
+# ─────────────────────────────────────────────
+resource "aws_iam_role" "lambda_markitdown" {
+  name = "${var.app_name}-${var.environment}-lambda-markitdown"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.common_tags, {
+    Name = "${var.app_name}-${var.environment}-lambda-markitdown"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_markitdown_basic" {
+  role       = aws_iam_role.lambda_markitdown.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "lambda_markitdown_s3" {
+  name = "read-materials-tmp"
+  role = aws_iam_role.lambda_markitdown.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "ReadMaterialsTmp"
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = "${aws_s3_bucket.materials_tmp.arn}/*"
+    }]
+  })
+}
+
+# ─────────────────────────────────────────────
+# CloudWatch Log Group
+# ─────────────────────────────────────────────
+resource "aws_cloudwatch_log_group" "lambda_markitdown" {
+  name              = "/aws/lambda/${var.app_name}-${var.environment}-markitdown"
+  retention_in_days = 14
+
+  tags = var.common_tags
+}
+
+# ─────────────────────────────────────────────
+# Lambda Function — Markitdown converter
+# Image is bootstrapped as :latest here; CI/CD
+# updates the image URI on every deploy.
+# ─────────────────────────────────────────────
+resource "aws_lambda_function" "markitdown" {
+  function_name = "${var.app_name}-${var.environment}-markitdown"
+  role          = aws_iam_role.lambda_markitdown.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.markitdown.repository_url}:latest"
+
+  timeout     = 300  # 5 minutes — enough for large PPTX/PDF
+  memory_size = 1024
+
+  environment {
+    variables = {
+      AWS_REGION_NAME = var.aws_region
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.lambda_markitdown,
+    aws_iam_role_policy_attachment.lambda_markitdown_basic,
+  ]
+
+  tags = merge(var.common_tags, {
+    Name = "${var.app_name}-${var.environment}-markitdown"
+  })
+
+  lifecycle {
+    ignore_changes = [image_uri]
+  }
+}
+
+output "markitdown_lambda_arn" {
+  value       = aws_lambda_function.markitdown.arn
+  description = "Markitdown Lambda ARN — use as AWS_MARKITDOWN_LAMBDA_ARN env var"
+}
+
+output "markitdown_ecr_repository_url" {
+  value       = aws_ecr_repository.markitdown.repository_url
+  description = "ECR URL for the Markitdown Lambda image"
+}

--- a/infra/s3_materials.tf
+++ b/infra/s3_materials.tf
@@ -1,0 +1,48 @@
+# S3 Bucket — temporary staging area for uploaded study materials
+# Objects are deleted automatically after 24 h via lifecycle rule.
+# The ECS task uploads files here; the Lambda reads and converts them.
+resource "aws_s3_bucket" "materials_tmp" {
+  bucket = "${var.app_name}-${var.environment}-materials-tmp"
+
+  tags = merge(var.common_tags, {
+    Name = "${var.app_name}-${var.environment}-materials-tmp"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "materials_tmp" {
+  bucket = aws_s3_bucket.materials_tmp.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "materials_tmp" {
+  bucket = aws_s3_bucket.materials_tmp.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "materials_tmp" {
+  bucket = aws_s3_bucket.materials_tmp.id
+
+  rule {
+    id     = "auto-delete-after-24h"
+    status = "Enabled"
+
+    filter { prefix = "uploads/" }
+
+    expiration {
+      days = 1
+    }
+  }
+}
+
+output "s3_materials_tmp_bucket_name" {
+  value       = aws_s3_bucket.materials_tmp.bucket
+  description = "Materials temp bucket — use as AWS_S3_MATERIALS_TMP_BUCKET env var"
+}

--- a/lambda/markitdown/Dockerfile
+++ b/lambda/markitdown/Dockerfile
@@ -1,0 +1,15 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+# System dependencies note:
+# - PDF/DOCX/PPTX/XLSX converters are pure Python — no system binaries needed.
+# - Audio conversion (pydub) requires `ffmpeg`. We intentionally exclude the
+#   [audio-transcription] extra so ffmpeg is not needed here.
+# - If audio support is added in future, uncomment below and add the extra:
+#   RUN dnf install -y ffmpeg-free
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY handler.py .
+
+CMD ["handler.lambda_handler"]

--- a/lambda/markitdown/handler.py
+++ b/lambda/markitdown/handler.py
@@ -1,0 +1,37 @@
+import json
+import os
+import tempfile
+import boto3
+from markitdown import MarkItDown
+
+s3_client = boto3.client("s3")
+md = MarkItDown()
+
+# Formats supported by this Lambda (must match markitdown extras in requirements.txt).
+# Audio/video are excluded because they require the ffmpeg system binary.
+SUPPORTED_EXTENSIONS = {".pdf", ".docx", ".pptx", ".xlsx"}
+
+
+def lambda_handler(event, context):
+    bucket = event["bucket"]
+    key = event["key"]
+    filename = event.get("filename", key.split("/")[-1])
+
+    ext = os.path.splitext(filename)[1].lower()
+    if ext not in SUPPORTED_EXTENSIONS:
+        return {
+            "error": f"Unsupported file extension '{ext}'. Supported: {sorted(SUPPORTED_EXTENSIONS)}",
+            "markdown": "",
+        }
+
+    with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+        s3_client.download_fileobj(bucket, key, tmp)
+        tmp_path = tmp.name
+
+    try:
+        result = md.convert(tmp_path)
+        markdown = result.text_content or ""
+    finally:
+        os.unlink(tmp_path)
+
+    return {"markdown": markdown, "filename": filename}

--- a/lambda/markitdown/local_server.py
+++ b/lambda/markitdown/local_server.py
@@ -1,0 +1,42 @@
+"""
+Local development server — mimics the Lambda handler via HTTP.
+Run via Dockerfile.local (docker-compose service: markitdown).
+"""
+import os
+import tempfile
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from fastapi.responses import JSONResponse
+from markitdown import MarkItDown
+
+app = FastAPI()
+md = MarkItDown()
+
+# Must match SUPPORTED_EXTENSIONS in handler.py
+SUPPORTED_EXTENSIONS = {".pdf", ".docx", ".pptx", ".xlsx"}
+
+
+@app.post("/convert")
+async def convert(file: UploadFile = File(...), filename: str = Form(...)):
+    ext = os.path.splitext(filename)[1].lower()
+    if ext not in SUPPORTED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file extension '{ext}'. Supported: {sorted(SUPPORTED_EXTENSIONS)}",
+        )
+
+    content = await file.read()
+    with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+    try:
+        result = md.convert(tmp_path)
+        markdown = result.text_content or ""
+    finally:
+        os.unlink(tmp_path)
+
+    return JSONResponse({"markdown": markdown, "filename": filename})
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/lambda/markitdown/requirements.txt
+++ b/lambda/markitdown/requirements.txt
@@ -1,0 +1,15 @@
+# Targeted extras — only install what we actually convert.
+# DO NOT use markitdown[all]: it pulls in pydub + SpeechRecognition
+# which require the `ffmpeg` system binary (not available in Lambda by default).
+#
+# Supported formats and their extras:
+#   pdf   → pdfminer.six, pdfplumber   (pure Python, no system deps)
+#   docx  → mammoth, lxml              (pure Python, no system deps)
+#   pptx  → python-pptx                (pure Python, no system deps)
+#   xlsx  → pandas, openpyxl           (pure Python, no system deps)
+#
+# To add audio support in future, you must also:
+#   1. Add `markitdown[audio-transcription]` below
+#   2. Install ffmpeg in the Dockerfile:  RUN dnf install -y ffmpeg-free
+markitdown[pdf,docx,pptx,xlsx]>=0.1.0
+boto3>=1.34.0

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -12,6 +12,9 @@ server {
         proxy_cache_bypass $http_upgrade;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # Allow file uploads up to 50 MB (matches Multer limit in the backend).
+        client_max_body_size 50m;
     }
 
     # Swagger/Docs Proxy (NestJS)

--- a/src/components/ai-questions/GenerationForm.tsx
+++ b/src/components/ai-questions/GenerationForm.tsx
@@ -18,6 +18,7 @@ import {
   estimateTokens,
   generateQuestions,
   getJobStatus,
+  getMaterialChunks,
 } from "@/services/ai-questions";
 import {
   LlmProvider,
@@ -174,6 +175,17 @@ export default function GenerationForm({ onResult }: Props) {
       const domain =
         domainId !== "all" ? domains.find((d: any) => d.id === domainId) : null;
 
+      // If a study material is selected, fetch its chunks and inject as context.
+      let materialContext: string | undefined;
+      if (materialId) {
+        try {
+          const chunks = await getMaterialChunks(materialId);
+          if (chunks.length > 0) materialContext = chunks.join("\n\n");
+        } catch {
+          // Non-fatal: generate without material context if fetch fails.
+        }
+      }
+
       const params: LocalGenerationParams = {
         certificationName: cert?.name ?? certificationId,
         certificationCode: cert?.code ?? certificationId,
@@ -182,6 +194,7 @@ export default function GenerationForm({ onResult }: Props) {
         questionCount,
         questionType:
           questionType === "MIXED" ? undefined : (questionType as QuestionType),
+        materialContext,
       };
 
       const result = await generateLocalQuestions(selectedLocalConfig, params);
@@ -295,6 +308,7 @@ export default function GenerationForm({ onResult }: Props) {
           onValueChange={(v) => {
             setCertificationId(v);
             setDomainId("all");
+            setMaterialId(""); // clear stale selection — materials don't disappear but selection resets for the new cert
           }}
         >
           <SelectTrigger>
@@ -383,15 +397,13 @@ export default function GenerationForm({ onResult }: Props) {
         />
       </div>
 
-      {/* Source material — cloud only */}
-      {!isLocalSelected && (
-        <MaterialLibrary
-          certificationId={certificationId || undefined}
-          selectedId={materialId}
-          onSelect={(id) => setMaterialId(id ?? '')}
-          onSelectedProcessing={setMaterialProcessing}
-        />
-      )}
+      {/* Source material */}
+      <MaterialLibrary
+        certificationId={certificationId || undefined}
+        selectedId={materialId}
+        onSelect={(id) => setMaterialId(id ?? '')}
+        onSelectedProcessing={setMaterialProcessing}
+      />
 
       {/* Token estimate — cloud only */}
       {estimate && !isLocalSelected && (
@@ -415,6 +427,7 @@ export default function GenerationForm({ onResult }: Props) {
             <span>
               Generated in the browser — no cloud API calls, no quota usage.
               Questions go to <strong>Pending</strong> for admin review.
+              {materialId ? " Selected material will be injected as context." : ""}
             </span>
           </CardContent>
         </Card>

--- a/src/components/ai-questions/GenerationForm.tsx
+++ b/src/components/ai-questions/GenerationForm.tsx
@@ -58,6 +58,7 @@ export default function GenerationForm({ onResult }: Props) {
   const [certificationId, setCertificationId] = useState("");
   const [domainId, setDomainId] = useState("all");
   const [materialId, setMaterialId] = useState("");
+  const [materialProcessing, setMaterialProcessing] = useState(false);
   const [difficulty, setDifficulty] = useState<Difficulty>(Difficulty.MEDIUM);
   const [questionType, setQuestionType] = useState<QuestionType | "MIXED">(
     "MIXED",
@@ -225,7 +226,7 @@ export default function GenerationForm({ onResult }: Props) {
   const isLocalSelected = provider.startsWith(LOCAL_PREFIX);
   const hasLocalConfigs = localConfigs.length > 0;
   const isCloudGenerating = generateCloudMutation.isPending || !!pendingJobId;
-  const canGenerate = provider !== "" && certificationId !== "";
+  const canGenerate = provider !== "" && certificationId !== "" && !materialProcessing;
 
   return (
     <div className="space-y-5">
@@ -387,7 +388,8 @@ export default function GenerationForm({ onResult }: Props) {
         <MaterialLibrary
           certificationId={certificationId || undefined}
           selectedId={materialId}
-          onSelect={(id) => setMaterialId(materialId === id ? "" : id)}
+          onSelect={(id) => setMaterialId(id ?? '')}
+          onSelectedProcessing={setMaterialProcessing}
         />
       )}
 

--- a/src/components/ai-questions/MaterialLibrary.tsx
+++ b/src/components/ai-questions/MaterialLibrary.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { FileText, Link, Type, Trash2, Loader2, Plus, CheckCircle, AlertCircle } from 'lucide-react';
+import { FileText, Link, Type, Trash2, Loader2, Upload, Plus, CheckCircle, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -43,14 +43,21 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect,
   const queryClient = useQueryClient();
   const fileRef = useRef<HTMLInputElement>(null);
   const [adding, setAdding] = useState(false);
+  // 'file' mode pre-selects PDF and opens the form immediately with the file input visible.
+  const [addMode, setAddMode] = useState<'file' | 'text'>('text');
   const [contentType, setContentType] = useState<MaterialContentType>('TEXT');
   const [title, setTitle] = useState('');
   const [textContent, setTextContent] = useState('');
   const [sourceUrl, setSourceUrl] = useState('');
 
+  // Fetch ALL user materials regardless of selected cert — filtering by cert
+  // caused materials to vanish whenever the cert dropdown changed, which was
+  // confusing. certificationId is still passed at upload time for association,
+  // but the list is never filtered by it. A cert badge on each card shows which
+  // cert the material is tagged to.
   const { data: materials = [], isLoading } = useQuery({
-    queryKey: ['materials', certificationId],
-    queryFn: () => getMaterials(certificationId),
+    queryKey: ['materials'],
+    queryFn: () => getMaterials(undefined),
     // Poll every 4s when any material is still processing
     refetchInterval: (query) => {
       const list = query.state.data ?? [];
@@ -70,6 +77,7 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect,
     onSuccess: (material) => {
       queryClient.invalidateQueries({ queryKey: ['materials'] });
       setAdding(false);
+      setAddMode('text');
       setTitle(''); setTextContent(''); setSourceUrl('');
       if (material.status === 'processing') {
         toast.info('File uploaded — converting to markdown in background…');
@@ -109,9 +117,29 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect,
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">Source Materials</span>
         {!adding && (
-          <Button size="sm" variant="outline" onClick={() => setAdding(true)}>
-            <Plus className="h-3 w-3 mr-1" /> Add
-          </Button>
+          <div className="flex gap-1.5">
+            <Button
+              size="sm"
+              onClick={() => {
+                setAddMode('file');
+                setContentType('PDF');
+                setAdding(true);
+              }}
+            >
+              <Upload className="h-3 w-3 mr-1" /> Upload File
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setAddMode('text');
+                setContentType('TEXT');
+                setAdding(true);
+              }}
+            >
+              <Plus className="h-3 w-3 mr-1" /> Text / URL
+            </Button>
+          </div>
         )}
       </div>
 
@@ -119,48 +147,66 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect,
         <Card className="border-dashed">
           <CardContent className="pt-4 space-y-3">
             <Input placeholder="Material title" value={title} onChange={e => setTitle(e.target.value)} />
-            <Select value={contentType} onValueChange={v => { setContentType(v as MaterialContentType); if (fileRef.current) fileRef.current.value = ''; }}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="TEXT">Plain Text</SelectItem>
-                <SelectItem value="URL">Web URL</SelectItem>
-                <SelectItem value="PDF">PDF File</SelectItem>
-                <SelectItem value="DOCX">Word Document (.docx)</SelectItem>
-                <SelectItem value="PPTX">PowerPoint (.pptx)</SelectItem>
-                <SelectItem value="XLSX">Excel (.xlsx)</SelectItem>
-              </SelectContent>
-            </Select>
-            {contentType === 'TEXT' && (
-              <Textarea
-                placeholder="Paste your study notes here (max 100,000 chars)"
-                className="min-h-[120px] text-xs"
-                value={textContent}
-                maxLength={100000}
-                onChange={e => setTextContent(e.target.value)}
-              />
+
+            {/* File upload mode: show file-type selector + file picker immediately */}
+            {addMode === 'file' && (
+              <>
+                <Select value={contentType} onValueChange={v => { setContentType(v as MaterialContentType); if (fileRef.current) fileRef.current.value = ''; }}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="PDF">PDF (.pdf)</SelectItem>
+                    <SelectItem value="DOCX">Word Document (.docx)</SelectItem>
+                    <SelectItem value="PPTX">PowerPoint (.pptx)</SelectItem>
+                    <SelectItem value="XLSX">Excel (.xlsx)</SelectItem>
+                  </SelectContent>
+                </Select>
+                <div className="space-y-1">
+                  <input ref={fileRef} type="file" accept={getAcceptedExtensions(contentType)} className="text-sm w-full" />
+                  <p className="text-xs text-muted-foreground">File will be converted to Markdown automatically (may take up to 30 s for large files)</p>
+                </div>
+              </>
             )}
-            {contentType === 'URL' && (
-              <Input placeholder="https://docs.aws.amazon.com/..." value={sourceUrl} onChange={e => setSourceUrl(e.target.value)} />
+
+            {/* Text / URL mode: show type selector + relevant input */}
+            {addMode === 'text' && (
+              <>
+                <Select value={contentType} onValueChange={v => setContentType(v as MaterialContentType)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="TEXT">Plain Text</SelectItem>
+                    <SelectItem value="URL">Web URL</SelectItem>
+                  </SelectContent>
+                </Select>
+                {contentType === 'TEXT' && (
+                  <Textarea
+                    placeholder="Paste your study notes here (max 100,000 chars)"
+                    className="min-h-[120px] text-xs"
+                    value={textContent}
+                    maxLength={100000}
+                    onChange={e => setTextContent(e.target.value)}
+                  />
+                )}
+                {contentType === 'URL' && (
+                  <Input placeholder="https://docs.aws.amazon.com/..." value={sourceUrl} onChange={e => setSourceUrl(e.target.value)} />
+                )}
+              </>
             )}
-            {FILE_TYPES.includes(contentType) && (
-              <div className="space-y-1">
-                <input ref={fileRef} type="file" accept={getAcceptedExtensions(contentType)} className="text-sm" />
-                <p className="text-xs text-muted-foreground">File will be converted to Markdown automatically (may take a few seconds)</p>
-              </div>
-            )}
+
             <div className="flex gap-2">
               <Button size="sm" onClick={() => uploadMutation.mutate()} disabled={!title || uploadMutation.isPending}>
                 {uploadMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null}
-                Upload
+                {addMode === 'file' ? 'Upload' : 'Save'}
               </Button>
-              <Button size="sm" variant="ghost" onClick={() => setAdding(false)}>Cancel</Button>
+              <Button size="sm" variant="ghost" onClick={() => { setAdding(false); setAddMode('text'); }}>Cancel</Button>
             </div>
           </CardContent>
         </Card>
       )}
 
       {materials.length === 0 && !adding && (
-        <p className="text-xs text-muted-foreground text-center py-4">No materials yet. Add study notes, PDFs, Word docs, or URLs.</p>
+        <p className="text-xs text-muted-foreground text-center py-4">
+          No materials yet. Click <strong>Upload File</strong> to add a PDF, Word doc, PowerPoint, or Excel sheet, or <strong>Text / URL</strong> for pasted notes and links.
+        </p>
       )}
 
       {materials.map((m: any) => {
@@ -168,6 +214,9 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect,
         const isSelected = m.id === selectedId;
         const isProcessing = m.status === 'processing';
         const isFailed = m.status === 'failed';
+        // Cert mismatch: material was tagged to a different cert than currently selected.
+        // We still allow selection (material context is still useful) but show a hint.
+        const certMismatch = certificationId && m.certificationId && m.certificationId !== certificationId;
         return (
           <Card
             key={m.id}
@@ -181,6 +230,7 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect,
                   <p className="text-sm font-medium truncate">{m.title}</p>
                   <p className="text-xs text-muted-foreground">
                     {isProcessing ? 'Converting…' : isFailed ? 'Conversion failed' : `${m._count.chunks} chunks`}
+                    {certMismatch && <span className="ml-1 text-yellow-600" title={`Tagged to ${m.certification?.code ?? 'another cert'}`}>· {m.certification?.code ?? 'other cert'}</span>}
                   </p>
                 </div>
               </div>

--- a/src/components/ai-questions/MaterialLibrary.tsx
+++ b/src/components/ai-questions/MaterialLibrary.tsx
@@ -1,29 +1,45 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { FileText, Link, Type, Trash2, Loader2, Plus, CheckCircle, Clock } from 'lucide-react';
+import { FileText, Link, Type, Trash2, Loader2, Plus, CheckCircle, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { getMaterials, uploadTextMaterial, uploadPdfMaterial, deleteMaterial } from '@/services/ai-questions';
+import { getMaterials, uploadTextMaterial, uploadFileMaterial, deleteMaterial } from '@/services/ai-questions';
 import { MaterialContentType } from '@/types/api-types';
 import { toast } from 'sonner';
 
-const TYPE_ICONS = {
+const TYPE_ICONS: Record<string, typeof FileText> = {
   PDF: FileText,
+  DOCX: FileText,
+  PPTX: FileText,
+  XLSX: FileText,
   URL: Link,
   TEXT: Type,
 };
 
+const FILE_TYPES: MaterialContentType[] = ['PDF', 'DOCX', 'PPTX', 'XLSX'];
+
+function getAcceptedExtensions(contentType: MaterialContentType): string {
+  const map: Record<string, string> = {
+    PDF: '.pdf',
+    DOCX: '.docx',
+    PPTX: '.pptx',
+    XLSX: '.xlsx',
+  };
+  return map[contentType] ?? '';
+}
+
 interface Props {
   certificationId?: string;
   selectedId?: string;
-  onSelect?: (id: string) => void;
+  onSelect?: (id: string | undefined) => void;
+  onSelectedProcessing?: (isProcessing: boolean) => void;
 }
 
-export default function MaterialLibrary({ certificationId, selectedId, onSelect }: Props) {
+export default function MaterialLibrary({ certificationId, selectedId, onSelect, onSelectedProcessing }: Props) {
   const queryClient = useQueryClient();
   const fileRef = useRef<HTMLInputElement>(null);
   const [adding, setAdding] = useState(false);
@@ -35,30 +51,56 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect 
   const { data: materials = [], isLoading } = useQuery({
     queryKey: ['materials', certificationId],
     queryFn: () => getMaterials(certificationId),
+    // Poll every 4s when any material is still processing
+    refetchInterval: (query) => {
+      const list = query.state.data ?? [];
+      return list.some((m: any) => m.status === 'processing') ? 4000 : false;
+    },
   });
 
   const uploadMutation = useMutation({
     mutationFn: async () => {
-      if (contentType === 'PDF') {
+      if (FILE_TYPES.includes(contentType)) {
         const file = fileRef.current?.files?.[0];
-        if (!file) throw new Error('Select a PDF file');
-        return uploadPdfMaterial(file, title, certificationId);
+        if (!file) throw new Error('Select a file');
+        return uploadFileMaterial(file, title, contentType as any, certificationId);
       }
       return uploadTextMaterial({ title, contentType, certificationId, textContent, sourceUrl });
     },
-    onSuccess: () => {
+    onSuccess: (material) => {
       queryClient.invalidateQueries({ queryKey: ['materials'] });
       setAdding(false);
       setTitle(''); setTextContent(''); setSourceUrl('');
-      toast.success('Material uploaded and chunked');
+      if (material.status === 'processing') {
+        toast.info('File uploaded — converting to markdown in background…');
+      } else {
+        toast.success('Material uploaded and chunked');
+      }
     },
     onError: (e: any) => toast.error(e?.response?.data?.message || 'Upload failed'),
   });
 
   const deleteMutation = useMutation({
     mutationFn: deleteMaterial,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['materials'] }),
+    // Fix #7: Clear selection only after delete succeeds, so a failed delete
+    // doesn't leave the UI in a desynced state.
+    onSuccess: (_data, deletedId) => {
+      if (deletedId === selectedId) onSelect?.(undefined);
+      queryClient.invalidateQueries({ queryKey: ['materials'] });
+    },
   });
+
+  // Fix #6: Notify parent of processing state changes, including when selectedId
+  // becomes undefined (selection cleared while material was still processing).
+  useEffect(() => {
+    if (!onSelectedProcessing) return;
+    if (!selectedId) {
+      onSelectedProcessing(false);
+      return;
+    }
+    const selected = materials.find((m: any) => m.id === selectedId);
+    onSelectedProcessing(selected?.status === 'processing');
+  }, [materials, selectedId, onSelectedProcessing]);
 
   if (isLoading) return <div className="flex justify-center py-6"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>;
 
@@ -77,12 +119,15 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect 
         <Card className="border-dashed">
           <CardContent className="pt-4 space-y-3">
             <Input placeholder="Material title" value={title} onChange={e => setTitle(e.target.value)} />
-            <Select value={contentType} onValueChange={v => setContentType(v as MaterialContentType)}>
+            <Select value={contentType} onValueChange={v => { setContentType(v as MaterialContentType); if (fileRef.current) fileRef.current.value = ''; }}>
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="TEXT">Plain Text</SelectItem>
                 <SelectItem value="URL">Web URL</SelectItem>
                 <SelectItem value="PDF">PDF File</SelectItem>
+                <SelectItem value="DOCX">Word Document (.docx)</SelectItem>
+                <SelectItem value="PPTX">PowerPoint (.pptx)</SelectItem>
+                <SelectItem value="XLSX">Excel (.xlsx)</SelectItem>
               </SelectContent>
             </Select>
             {contentType === 'TEXT' && (
@@ -97,13 +142,16 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect 
             {contentType === 'URL' && (
               <Input placeholder="https://docs.aws.amazon.com/..." value={sourceUrl} onChange={e => setSourceUrl(e.target.value)} />
             )}
-            {contentType === 'PDF' && (
-              <input ref={fileRef} type="file" accept=".pdf" className="text-sm" />
+            {FILE_TYPES.includes(contentType) && (
+              <div className="space-y-1">
+                <input ref={fileRef} type="file" accept={getAcceptedExtensions(contentType)} className="text-sm" />
+                <p className="text-xs text-muted-foreground">File will be converted to Markdown automatically (may take a few seconds)</p>
+              </div>
             )}
             <div className="flex gap-2">
               <Button size="sm" onClick={() => uploadMutation.mutate()} disabled={!title || uploadMutation.isPending}>
                 {uploadMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null}
-                Upload & Chunk
+                Upload
               </Button>
               <Button size="sm" variant="ghost" onClick={() => setAdding(false)}>Cancel</Button>
             </div>
@@ -112,30 +160,34 @@ export default function MaterialLibrary({ certificationId, selectedId, onSelect 
       )}
 
       {materials.length === 0 && !adding && (
-        <p className="text-xs text-muted-foreground text-center py-4">No materials yet. Add study notes, PDFs, or URLs.</p>
+        <p className="text-xs text-muted-foreground text-center py-4">No materials yet. Add study notes, PDFs, Word docs, or URLs.</p>
       )}
 
-      {materials.map(m => {
-        const Icon = TYPE_ICONS[m.contentType];
+      {materials.map((m: any) => {
+        const Icon = TYPE_ICONS[m.contentType] ?? FileText;
         const isSelected = m.id === selectedId;
+        const isProcessing = m.status === 'processing';
+        const isFailed = m.status === 'failed';
         return (
           <Card
             key={m.id}
-            className={`cursor-pointer transition-colors ${isSelected ? 'border-primary bg-primary/5' : 'hover:border-primary/50'}`}
-            onClick={() => onSelect?.(m.id)}
+            className={`transition-colors ${isProcessing || isFailed ? 'opacity-70 cursor-not-allowed' : 'cursor-pointer'} ${isSelected ? 'border-primary bg-primary/5' : 'hover:border-primary/50'}`}
+            onClick={() => !isProcessing && !isFailed && onSelect?.(isSelected ? undefined : m.id)}
           >
             <CardContent className="py-3 flex items-center justify-between gap-2">
               <div className="flex items-center gap-2 min-w-0">
                 <Icon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                 <div className="min-w-0">
                   <p className="text-sm font-medium truncate">{m.title}</p>
-                  <p className="text-xs text-muted-foreground">{m._count.chunks} chunks</p>
+                  <p className="text-xs text-muted-foreground">
+                    {isProcessing ? 'Converting…' : isFailed ? 'Conversion failed' : `${m._count.chunks} chunks`}
+                  </p>
                 </div>
               </div>
               <div className="flex items-center gap-1 flex-shrink-0">
-                {m.status === 'ready'
-                  ? <CheckCircle className="h-3 w-3 text-green-500" />
-                  : <Clock className="h-3 w-3 text-yellow-500 animate-spin" />}
+                {isProcessing && <Loader2 className="h-3 w-3 text-yellow-500 animate-spin" />}
+                {isFailed && <AlertCircle className="h-3 w-3 text-destructive" />}
+                {!isProcessing && !isFailed && <CheckCircle className="h-3 w-3 text-green-500" />}
                 <Badge variant="outline" className="text-xs">{m.contentType}</Badge>
                 <Button
                   size="sm" variant="ghost"

--- a/src/services/ai-questions.ts
+++ b/src/services/ai-questions.ts
@@ -65,26 +65,32 @@ export const uploadTextMaterial = async (payload: {
   return res.data;
 };
 
-export const uploadPdfMaterial = async (
+export const uploadFileMaterial = async (
   file: File,
   title: string,
+  contentType: "PDF" | "DOCX" | "PPTX" | "XLSX",
   certificationId?: string,
 ): Promise<SourceMaterial> => {
   const form = new FormData();
   form.append("file", file);
   form.append("title", title);
-  form.append("contentType", "PDF");
+  form.append("contentType", contentType);
   if (certificationId) form.append("certificationId", certificationId);
 
   const res = await api.post<SourceMaterial>(
-    "/ai-questions/materials/pdf",
+    "/ai-questions/materials/file",
     form,
-    {
-      headers: { "Content-Type": "multipart/form-data" },
-    },
+    { headers: { "Content-Type": "multipart/form-data" } },
   );
   return res.data;
 };
+
+/** @deprecated Use uploadFileMaterial instead */
+export const uploadPdfMaterial = async (
+  file: File,
+  title: string,
+  certificationId?: string,
+): Promise<SourceMaterial> => uploadFileMaterial(file, title, "PDF", certificationId);
 
 export const deleteMaterial = async (id: string): Promise<void> => {
   await api.delete(`/ai-questions/materials/${id}`);

--- a/src/services/ai-questions.ts
+++ b/src/services/ai-questions.ts
@@ -96,6 +96,12 @@ export const deleteMaterial = async (id: string): Promise<void> => {
   await api.delete(`/ai-questions/materials/${id}`);
 };
 
+/** Fetch ordered text chunks for a material — used by local LLM to build context. */
+export const getMaterialChunks = async (id: string): Promise<string[]> => {
+  const res = await api.get<{ chunks: string[] }>(`/ai-questions/materials/${id}/chunks`);
+  return res.data.chunks;
+};
+
 // ─── Generation ──────────────────────────────────────────────────────────────
 
 export const estimateTokens = async (payload: {

--- a/src/services/local-llm/prompt-builder.ts
+++ b/src/services/local-llm/prompt-builder.ts
@@ -28,9 +28,13 @@ export function buildLocalUserPrompt(params: LocalGenerationParams): string {
       ? "MULTIPLE choice (2-3 correct answers out of 5-6 options)"
       : "SINGLE choice (exactly 1 correct answer out of 4 options)";
 
+  const contextSection = params.materialContext
+    ? `\n\nUse the following study material as your primary source for question content:\n\n---\n${params.materialContext}\n---\n`
+    : "";
+
   return `Generate ${params.questionCount} ${typeGuide} questions for the **${params.certificationName} (${params.certificationCode})** certification exam.
 ${params.domainName ? `Domain/Topic: ${params.domainName}` : ""}
-Difficulty: ${params.difficulty} — focus on ${difficultyGuide[params.difficulty]}.
+Difficulty: ${params.difficulty} — focus on ${difficultyGuide[params.difficulty]}.${contextSection}
 
 Return a JSON object with this exact schema:
 {

--- a/src/services/local-llm/types.ts
+++ b/src/services/local-llm/types.ts
@@ -29,4 +29,6 @@ export interface LocalGenerationParams {
   difficulty: Difficulty;
   questionCount: number;
   questionType?: QuestionType;
+  /** Concatenated material chunks injected as context into the prompt. */
+  materialContext?: string;
 }

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -315,7 +315,7 @@ export type GenerationJobStatus =
   | "PROCESSING"
   | "COMPLETED"
   | "FAILED";
-export type MaterialContentType = "PDF" | "URL" | "TEXT";
+export type MaterialContentType = "PDF" | "URL" | "TEXT" | "DOCX" | "PPTX" | "XLSX";
 
 export interface LlmConfig {
   id: string;

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -331,6 +331,7 @@ export interface SourceMaterial {
   title: string;
   contentType: MaterialContentType;
   certificationId?: string;
+  certification?: { code: string };
   sourceUrl?: string;
   chunkCount: number;
   status: string;


### PR DESCRIPTION
## Summary

- **Markitdown conversion pipeline**: uploaded study files (PDF, DOCX, PPTX, XLSX) are converted to clean Markdown via Microsoft Markitdown before being chunked and stored, preserving document structure (headers, tables, lists) and reducing LLM token noise
- **AWS Lambda** (Python, ECR container) handles conversion in production; **FastAPI local server** (Docker Compose) handles it in dev — no ffmpeg dependency (targeted extras: `markitdown[pdf,docx,pptx,xlsx]`)
- **Async via BullMQ** (`material-conversion` queue, concurrency 2) — HTTP request returns immediately with `status: processing`; frontend polls every 4 s until `ready`
- **S3 temp bucket** (`materials-tmp`) stages files for Lambda with 24 h lifecycle auto-delete + eager cleanup in `finally` block; local dev embeds buffer as base64 in Redis with immediate eviction on job completion (`removeOnComplete: true`)
- **Prisma**: added `DOCX`, `PPTX`, `XLSX` to `MaterialContentType` enum
- **Terraform**: Lambda function + ECR repo + S3 temp bucket + IAM least-privilege policies
- **CI/CD**: `build-push-lambda` job builds/pushes Lambda image in parallel with backend; `deploy-backend` waits on both

### UX fixes (found during local testing)

- **nginx**: raised `client_max_body_size` to 50 MB — default 1 MB caused 413 on any real file upload
- **"Upload File" button**: was buried 4 clicks deep; now a dedicated primary button opens the form pre-set to file mode with the file picker immediately visible
- **Materials no longer disappear**: list was filtered by `certificationId` in the query key — changing the cert dropdown emptied the list; now all user materials are always shown with a subtle cert-code hint on cross-cert items
- **Local LLM gets material context**: `MaterialLibrary` was hidden when a local provider was selected; now always visible; new `GET /materials/:id/chunks` endpoint lets local generation fetch and inject Markdown chunks into the prompt
- **Stale selection cleared**: `materialId` is reset when cert changes to avoid passing a hidden material to generation

## Test plan

- [ ] Upload a PDF → card shows "Converting…" spinner → transitions to "X chunks" when ready
- [ ] Upload DOCX / PPTX / XLSX — same flow
- [ ] Select material + Generate (cloud LLM) → questions are grounded in document content
- [ ] Select material + Generate (local LLM) → chunks injected as context into prompt
- [ ] Change certification → material list stays visible (no longer empties); selected material deselects
- [ ] Delete material → card disappears; DB confirms 0 rows in `source_chunks` for that `material_id`
- [ ] Upload file > 1 MB → no 413 from nginx
- [ ] `terraform plan` → no breaking changes to existing resources

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)