### PR TITLE
fix(material-conversion): preserve S3 temp across BullMQ retries (#93)

### DIFF
--- a/backend/src/queues/material-conversion/material-conversion.processor.spec.ts
+++ b/backend/src/queues/material-conversion/material-conversion.processor.spec.ts
@@ -1,0 +1,119 @@
+import { Job } from 'bullmq';
+import { MaterialConversionProcessor } from './material-conversion.processor';
+import { MaterialConversionJobData } from './material-conversion.job.interface';
+
+/**
+ * Regression coverage for #93: the S3 temp object must survive across BullMQ
+ * retries so a transient failure on attempt 1 doesn't permanently break the
+ * material. It may only be deleted on success or the final failed attempt.
+ */
+describe('MaterialConversionProcessor', () => {
+  const S3_BUCKET = 'tmp-materials';
+  const S3_KEY = 'uploads/material-123.pdf';
+
+  let prisma: {
+    sourceChunk: { createMany: jest.Mock };
+    sourceMaterial: { update: jest.Mock };
+  };
+  let s3Upload: { deleteTemp: jest.Mock };
+  let processor: MaterialConversionProcessor;
+
+  const makeJob = (
+    attemptsMade: number,
+    attempts: number,
+    data: Partial<MaterialConversionJobData> = {},
+  ): Job<MaterialConversionJobData> =>
+    ({
+      attemptsMade,
+      opts: { attempts },
+      data: {
+        materialId: 'material-123',
+        filename: 'spec.pdf',
+        s3Bucket: S3_BUCKET,
+        s3Key: S3_KEY,
+        ...data,
+      },
+    }) as unknown as Job<MaterialConversionJobData>;
+
+  beforeEach(() => {
+    prisma = {
+      sourceChunk: { createMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      sourceMaterial: { update: jest.fn().mockResolvedValue({}) },
+    };
+    s3Upload = { deleteTemp: jest.fn().mockResolvedValue(undefined) };
+    processor = new MaterialConversionProcessor(prisma as any, s3Upload as any);
+  });
+
+  const mockConvert = (impl: () => Promise<string>) =>
+    jest.spyOn(processor as any, 'convertToMarkdown').mockImplementation(impl);
+
+  it('deletes the S3 temp object after a successful conversion', async () => {
+    mockConvert(async () => '# Hello\n\nSome content.');
+
+    await processor.process(makeJob(0, 3));
+
+    expect(prisma.sourceMaterial.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'ready' }),
+      }),
+    );
+    expect(s3Upload.deleteTemp).toHaveBeenCalledWith(S3_BUCKET, S3_KEY);
+  });
+
+  it('keeps the S3 temp object on a non-final failed attempt and stays processing', async () => {
+    mockConvert(async () => {
+      throw new Error('Lambda throttled');
+    });
+
+    // attempt 1 of 3 (attemptsMade=0) — retries remain.
+    await expect(processor.process(makeJob(0, 3))).rejects.toThrow(
+      'Lambda throttled',
+    );
+
+    expect(s3Upload.deleteTemp).not.toHaveBeenCalled();
+    // Must NOT flip to 'failed' while retries are pending.
+    expect(prisma.sourceMaterial.update).not.toHaveBeenCalled();
+  });
+
+  it('deletes the S3 temp object and marks failed on the final attempt', async () => {
+    mockConvert(async () => {
+      throw new Error('Lambda throttled');
+    });
+
+    // attempt 3 of 3 (attemptsMade=2) — no retry left.
+    await expect(processor.process(makeJob(2, 3))).rejects.toThrow(
+      'Lambda throttled',
+    );
+
+    expect(s3Upload.deleteTemp).toHaveBeenCalledWith(S3_BUCKET, S3_KEY);
+    expect(prisma.sourceMaterial.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'failed' } }),
+    );
+  });
+
+  it('treats empty markdown as a retryable failure (temp preserved when retries remain)', async () => {
+    mockConvert(async () => '   ');
+
+    await expect(processor.process(makeJob(0, 3))).rejects.toThrow(
+      /empty content/i,
+    );
+
+    expect(s3Upload.deleteTemp).not.toHaveBeenCalled();
+    expect(prisma.sourceMaterial.update).not.toHaveBeenCalled();
+  });
+
+  it('handles a single-attempt job (no retries) by cleaning up on failure', async () => {
+    mockConvert(async () => {
+      throw new Error('boom');
+    });
+
+    // opts.attempts undefined -> defaults to 1, so attempt 1 is also the last.
+    const job = makeJob(0, undefined as unknown as number);
+    await expect(processor.process(job)).rejects.toThrow('boom');
+
+    expect(s3Upload.deleteTemp).toHaveBeenCalledWith(S3_BUCKET, S3_KEY);
+    expect(prisma.sourceMaterial.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'failed' } }),
+    );
+  });
+});

--- a/backend/src/queues/material-conversion/material-conversion.processor.spec.ts
+++ b/backend/src/queues/material-conversion/material-conversion.processor.spec.ts
@@ -48,7 +48,7 @@ describe('MaterialConversionProcessor', () => {
     jest.spyOn(processor as any, 'convertToMarkdown').mockImplementation(impl);
 
   it('deletes the S3 temp object after a successful conversion', async () => {
-    mockConvert(async () => '# Hello\n\nSome content.');
+    mockConvert(() => Promise.resolve('# Hello\n\nSome content.'));
 
     await processor.process(makeJob(0, 3));
 
@@ -61,9 +61,7 @@ describe('MaterialConversionProcessor', () => {
   });
 
   it('keeps the S3 temp object on a non-final failed attempt and stays processing', async () => {
-    mockConvert(async () => {
-      throw new Error('Lambda throttled');
-    });
+    mockConvert(() => Promise.reject(new Error('Lambda throttled')));
 
     // attempt 1 of 3 (attemptsMade=0) — retries remain.
     await expect(processor.process(makeJob(0, 3))).rejects.toThrow(
@@ -76,9 +74,7 @@ describe('MaterialConversionProcessor', () => {
   });
 
   it('deletes the S3 temp object and marks failed on the final attempt', async () => {
-    mockConvert(async () => {
-      throw new Error('Lambda throttled');
-    });
+    mockConvert(() => Promise.reject(new Error('Lambda throttled')));
 
     // attempt 3 of 3 (attemptsMade=2) — no retry left.
     await expect(processor.process(makeJob(2, 3))).rejects.toThrow(
@@ -92,7 +88,7 @@ describe('MaterialConversionProcessor', () => {
   });
 
   it('treats empty markdown as a retryable failure (temp preserved when retries remain)', async () => {
-    mockConvert(async () => '   ');
+    mockConvert(() => Promise.resolve('   '));
 
     await expect(processor.process(makeJob(0, 3))).rejects.toThrow(
       /empty content/i,
@@ -103,9 +99,7 @@ describe('MaterialConversionProcessor', () => {
   });
 
   it('handles a single-attempt job (no retries) by cleaning up on failure', async () => {
-    mockConvert(async () => {
-      throw new Error('boom');
-    });
+    mockConvert(() => Promise.reject(new Error('boom')));
 
     // opts.attempts undefined -> defaults to 1, so attempt 1 is also the last.
     const job = makeJob(0, undefined as unknown as number);

--- a/backend/src/queues/material-conversion/material-conversion.processor.ts
+++ b/backend/src/queues/material-conversion/material-conversion.processor.ts
@@ -32,6 +32,14 @@ export class MaterialConversionProcessor extends WorkerHost {
     const { materialId, filename, s3Bucket, s3Key, bufferBase64 } = job.data;
     this.logger.log(`Converting material ${materialId} (${filename})`);
 
+    // Fix #93: BullMQ retries (default attempts: 3) re-run this processor on
+    // transient failures. The S3 temp object is the only file source for the
+    // production (Lambda) path, so it must survive until no further retry can
+    // run — otherwise retries re-download a deleted key and fail with NoSuchKey.
+    const maxAttempts = job.opts.attempts ?? 1;
+    const isLastAttempt = job.attemptsMade + 1 >= maxAttempts;
+    let succeeded = false;
+
     try {
       const markdown = await this.convertToMarkdown(
         filename,
@@ -66,21 +74,34 @@ export class MaterialConversionProcessor extends WorkerHost {
         data: { status: 'ready', chunkCount: chunks.length },
       });
 
-      this.logger.log(
-        `Material ${materialId} ready — ${chunks.length} chunks`,
-      );
+      succeeded = true;
+      this.logger.log(`Material ${materialId} ready — ${chunks.length} chunks`);
     } catch (err) {
-      this.logger.error(`Failed to convert material ${materialId}: ${err}`);
-      await this.prisma.sourceMaterial.update({
-        where: { id: materialId },
-        data: { status: 'failed' },
-      });
+      // Fix #93: Only flip the material to `failed` once retries are exhausted.
+      // While attempts remain, leave it `processing` so a transient failure
+      // doesn't surface a permanent failure the user must re-upload to clear.
+      if (isLastAttempt) {
+        this.logger.error(
+          `Failed to convert material ${materialId} (final attempt): ${err}`,
+        );
+        await this.prisma.sourceMaterial.update({
+          where: { id: materialId },
+          data: { status: 'failed' },
+        });
+      } else {
+        this.logger.warn(
+          `Conversion attempt ${job.attemptsMade + 1}/${maxAttempts} failed ` +
+            `for material ${materialId}, will retry: ${err}`,
+        );
+      }
       throw err;
     } finally {
-      // Fix #3: Always clean up the S3 temp object, even on conversion failure.
-      // The 24h lifecycle rule is a safety net, but eager cleanup avoids leaked
-      // objects accumulating across BullMQ retries (default: 3 attempts).
-      if (s3Bucket && s3Key) {
+      // Fix #93: Clean up the S3 temp object only when no further retry will
+      // run — on success or the last failed attempt. Deleting on every attempt
+      // defeats BullMQ retries because retries 2..n can no longer re-download
+      // the staged file. The 24h S3 lifecycle rule is the safety net for any
+      // object left behind on an unexpected exit.
+      if (s3Bucket && s3Key && (succeeded || isLastAttempt)) {
         await this.s3Upload.deleteTemp(s3Bucket, s3Key);
       }
     }
@@ -163,8 +184,12 @@ export class MaterialConversionProcessor extends WorkerHost {
       fileBuffer = Buffer.from(bufferBase64, 'base64');
     } else if (s3Bucket && s3Key) {
       const { GetObjectCommand, S3Client } = await import('@aws-sdk/client-s3');
-      const s3 = new S3Client({ region: process.env.AWS_REGION ?? 'us-east-1' });
-      const obj = await s3.send(new GetObjectCommand({ Bucket: s3Bucket, Key: s3Key }));
+      const s3 = new S3Client({
+        region: process.env.AWS_REGION ?? 'us-east-1',
+      });
+      const obj = await s3.send(
+        new GetObjectCommand({ Bucket: s3Bucket, Key: s3Key }),
+      );
       const chunks: Uint8Array[] = [];
       for await (const chunk of obj.Body as any) chunks.push(chunk);
       fileBuffer = Buffer.concat(chunks);
@@ -177,8 +202,12 @@ export class MaterialConversionProcessor extends WorkerHost {
     form.append('file', new Blob([new Uint8Array(fileBuffer)]), filename);
     form.append('filename', filename);
 
-    const res = await fetch(`${baseUrl}/convert`, { method: 'POST', body: form });
-    if (!res.ok) throw new Error(`Markitdown local server error: ${res.statusText}`);
+    const res = await fetch(`${baseUrl}/convert`, {
+      method: 'POST',
+      body: form,
+    });
+    if (!res.ok)
+      throw new Error(`Markitdown local server error: ${res.statusText}`);
     const json = (await res.json()) as { markdown: string };
     return json.markdown;
   }


### PR DESCRIPTION
## Mo ta

Khoi `finally` trong material-conversion processor xoa object S3 tam sau **moi** lan thu — ke ca khi that bai tam thoi. Vi BullMQ cau hinh `attempts: 3`, mot loi tam thoi o lan 1 xoa mat file staged → retry 2..n khong the tai lai key, luon fail voi `NoSuchKey`/403. Duong production (S3/Lambda) thuc chat chi chay duoc mot lan.

**Fix:** chi xoa S3 temp khi khong con retry nao nua (`success || isLastAttempt`), va chi flip material sang `failed` khi het luot thu (giu `processing` trong luc con retry). Lifecycle rule 24h cua S3 van la luoi an toan cho object con sot. Duong local-dev (base64 buffer) khong bi anh huong.

## Loai thay doi

- [x] fix: sua bug
- [x] test: them/sua test

## Story / Issue

Closes #93. Bug duoc gioi thieu o #91.

## Definition of Done (DoD)

- [x] Unit test coverage cho file moi (5 test phu day acceptance criteria)
- [x] Lint + type check sach cho file thay doi (khong phat sinh loi tsc moi)
- [x] Telemetry/log du de debug production (log warn/error phan biet retry vs final)
- [ ] Code review tu >=1 dev khac
- [ ] Demo tren staging + PO sign-off

## Acceptance (tu issue)

- [x] Loi tam thoi o lan thu dau → thanh cong o retry ma khong can re-upload.
- [x] S3 temp van duoc xoa sau success va sau terminal failure (khong leak).
- [x] Material ket thuc o `ready` khi cuoi cung thanh cong, `failed` chi sau khi het attempts.

## Notes cho reviewer

- Retry policy: `defaultJobOptions: { attempts: 3, backoff: { type: 'exponential', delay: 5000 } }` trong `queues.module.ts`.
- `isLastAttempt = job.attemptsMade + 1 >= (job.opts.attempts ?? 1)` — fallback 1 cho job khong cau hinh retry.
- Test mock `convertToMarkdown` + Prisma + S3 service; chay: `npx jest src/queues/material-conversion/material-conversion.processor.spec.ts` (5 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)