### PR TITLE
feat(sprint-0): competency data model, scoring algorithm, Redis OTP, and module scaffold

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -212,6 +212,16 @@ enum ExamCatalogItemType {
   DYNAMIC
 }
 
+// ==================== COMPETENCY ENUMS ====================
+
+/// Discriminates which domainScores namespace a CompetencyDomain key belongs to.
+/// ORG_QUESTION_CATEGORY: keys from OrgQuestion.category (CandidateInvite.domainScores, hiring flow)
+/// PUBLIC_DOMAIN:         keys from Domain.name (ExamAttempt.domainScores, employee assessment flow)
+enum CompetencyDomainSource {
+  ORG_QUESTION_CATEGORY
+  PUBLIC_DOMAIN
+}
+
 enum OrgQuestionStatus {
   DRAFT
   UNDER_REVIEW
@@ -839,6 +849,7 @@ model Organization {
   peerExplanations PeerExplanation[]
   userReputations  UserReputation[]
   reputationFlags  ReputationFlag[]
+  competencies     Competency[]
 
   @@map("organizations")
 }
@@ -927,11 +938,12 @@ model OrgQuestion {
   createdAt        DateTime          @default(now()) @map("created_at")
   updatedAt        DateTime          @updatedAt @map("updated_at")
 
-  organization    Organization          @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  certification   Certification?        @relation(fields: [certificationId], references: [id])
-  choices         OrgQuestionChoice[]
-  catalogLinks    ExamCatalogQuestion[]
-  assessmentLinks AssessmentQuestion[]
+  organization      Organization          @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  certification     Certification?        @relation(fields: [certificationId], references: [id])
+  choices           OrgQuestionChoice[]
+  catalogLinks      ExamCatalogQuestion[]
+  assessmentLinks   AssessmentQuestion[]
+  competencyLinks   QuestionCompetency[]
 
   @@index([orgId, status])
   @@map("org_questions")
@@ -1038,8 +1050,9 @@ model JobRole {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  organization Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  assessments  Assessment[]
+  organization    Organization        @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  assessments     Assessment[]
+  competencyReqs  JobRoleCompetency[]
 
   @@index([orgId])
   @@map("job_roles")
@@ -1560,3 +1573,72 @@ model DdsConfig {
   @@map("dds_configs")
 }
 
+
+// ==================== COMPETENCY MODELS (Sprint 0 — FR-1) ====================
+
+model Competency {
+  id          String   @id @default(uuid())
+  orgId       String   @map("org_id")
+  name        String
+  description String?
+  scaleMin    Int      @default(1) @map("scale_min")
+  scaleMax    Int      @default(5) @map("scale_max")
+  isActive    Boolean  @default(true) @map("is_active")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  organization Organization         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  domains      CompetencyDomain[]
+  questions    QuestionCompetency[]
+  jobRoles     JobRoleCompetency[]
+
+  @@unique([orgId, name])
+  @@index([orgId])
+  @@map("competencies")
+}
+
+model CompetencyDomain {
+  id           String                 @id @default(uuid())
+  competencyId String                 @map("competency_id")
+  domainName   String                 @map("domain_name") @db.VarChar(200)
+  source       CompetencyDomainSource @default(ORG_QUESTION_CATEGORY) @map("source")
+  createdAt    DateTime               @default(now()) @map("created_at")
+
+  competency Competency @relation(fields: [competencyId], references: [id], onDelete: Cascade)
+
+  @@unique([competencyId, source, domainName])
+  @@index([competencyId])
+  @@map("competency_domains")
+}
+
+model QuestionCompetency {
+  id            String   @id @default(uuid())
+  competencyId  String   @map("competency_id")
+  orgQuestionId String   @map("org_question_id")
+  weight        Float    @default(1)
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  competency  Competency  @relation(fields: [competencyId], references: [id], onDelete: Cascade)
+  orgQuestion OrgQuestion @relation(fields: [orgQuestionId], references: [id], onDelete: Cascade)
+
+  @@unique([competencyId, orgQuestionId])
+  @@index([orgQuestionId])
+  @@map("question_competencies")
+}
+
+model JobRoleCompetency {
+  id            String   @id @default(uuid())
+  jobRoleId     String   @map("job_role_id")
+  competencyId  String   @map("competency_id")
+  requiredLevel Int      @map("required_level")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  jobRole    JobRole    @relation(fields: [jobRoleId], references: [id], onDelete: Cascade)
+  competency Competency @relation(fields: [competencyId], references: [id], onDelete: Restrict)
+
+  @@unique([jobRoleId, competencyId])
+  @@index([competencyId])
+  @@map("job_role_competencies")
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -39,6 +39,8 @@ import { InsightsModule } from './insights/insights.module';
 import { PassLikelihoodModule } from './surveys/pass-likelihood.module';
 import { SquadsModule } from './squads/squads.module';
 import { KnowledgeGraphModule } from './knowledge-graph/knowledge-graph.module';
+import { RedisModule } from './redis/redis.module';
+import { CompetencyModule } from './competency/competency.module';
 
 @Module({
   imports: [
@@ -82,6 +84,8 @@ import { KnowledgeGraphModule } from './knowledge-graph/knowledge-graph.module';
     PassLikelihoodModule,
     SquadsModule,
     KnowledgeGraphModule,
+    RedisModule,
+    CompetencyModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/assessments/candidate.service.ts
+++ b/backend/src/assessments/candidate.service.ts
@@ -5,7 +5,8 @@ import {
   ForbiddenException,
   GoneException,
   ServiceUnavailableException,
-  TooManyRequestsException,
+  HttpException,
+  HttpStatus,
   Inject,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
@@ -77,8 +78,9 @@ export class CandidateService {
       );
     }
     if (locked) {
-      throw new TooManyRequestsException(
+      throw new HttpException(
         'Too many failed attempts — try again later',
+        HttpStatus.TOO_MANY_REQUESTS,
       );
     }
 
@@ -110,13 +112,14 @@ export class CandidateService {
     try {
       locked = await this.redis.get(lockKey);
       if (locked) {
-        throw new TooManyRequestsException(
+        throw new HttpException(
           'Too many failed attempts — try again later',
+          HttpStatus.TOO_MANY_REQUESTS,
         );
       }
       storedHash = await this.redis.getdel(otpKey);
     } catch (err) {
-      if (err instanceof TooManyRequestsException) throw err;
+      if (err instanceof HttpException) throw err;
       throw new ServiceUnavailableException(
         'OTP service temporarily unavailable',
       );

--- a/backend/src/assessments/candidate.service.ts
+++ b/backend/src/assessments/candidate.service.ts
@@ -4,25 +4,31 @@ import {
   BadRequestException,
   ForbiddenException,
   GoneException,
+  ServiceUnavailableException,
+  TooManyRequestsException,
+  Inject,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AssessmentsService } from './assessments.service';
+import { MailService } from '../mail/mail.service';
+import { REDIS_CLIENT } from '../redis/redis.module';
 import { CandidateSubmitDto } from './dto/candidate-submit.dto';
 import { AssessmentSelectionMode } from '@prisma/client';
 import * as crypto from 'crypto';
+import type Redis from 'ioredis';
 
-const OTP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const OTP_TTL_SEC = 600; // 10 minutes
+const OTP_LOCK_TTL_SEC = 3600; // 1 hour lockout after max attempts
+const OTP_MAX_ATTEMPTS = 5;
 const CLIENT_TS_SKEW_MS = 60 * 60 * 1000; // allow ±1 hour skew
-
-// In-memory OTP store — works for single-process (dev/single-pod).
-// Replace otpStore.get/set/delete with Redis calls (SETEX + GET + DEL) for multi-process.
-const otpStore = new Map<string, { hash: string; expiresAt: number }>();
 
 @Injectable()
 export class CandidateService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly assessmentsService: AssessmentsService,
+    private readonly mailService: MailService,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
   ) {}
 
   async loadAssessment(token: string) {
@@ -61,39 +67,103 @@ export class CandidateService {
       throw new BadRequestException('OTP is not required for this assessment');
     }
 
-    // Fix #9: use cryptographically secure random integer
+    const lockKey = `otp:locked:${invite.id}`;
+    let locked: string | null;
+    try {
+      locked = await this.redis.get(lockKey);
+    } catch {
+      throw new ServiceUnavailableException(
+        'OTP service temporarily unavailable',
+      );
+    }
+    if (locked) {
+      throw new TooManyRequestsException(
+        'Too many failed attempts — try again later',
+      );
+    }
+
     const code = crypto.randomInt(100_000, 1_000_000).toString();
     const hash = crypto.createHash('sha256').update(code).digest('hex');
-    otpStore.set(invite.id, { hash, expiresAt: Date.now() + OTP_TTL_MS });
 
-    // Fix #3: never log the raw OTP code — only log masked email for traceability
-    const masked = invite.candidateEmail.replace(/(.{2}).+(@.+)/, '$1***$2');
-    console.log(`[OTP] code sent to ${masked}`);
+    try {
+      await this.redis.setex(`otp:${invite.id}`, OTP_TTL_SEC, hash);
+    } catch {
+      throw new ServiceUnavailableException(
+        'OTP service temporarily unavailable',
+      );
+    }
 
-    // TODO: integrate real email service (Mailtrap dev → SES/SendGrid prod)
-    // emailService.sendOtp(invite.candidateEmail, code);
+    await this.mailService.sendOtp(invite.candidateEmail, code, invite.id);
 
-    return { message: `OTP sent to ${invite.candidateEmail}` };
+    return { message: 'OTP sent' };
   }
 
   async verifyOtp(token: string, code: string) {
     const invite = await this.findInviteByToken(token);
-    const entry = otpStore.get(invite.id);
 
-    if (!entry) {
-      throw new BadRequestException('No OTP requested — please request a new code');
-    }
-    if (Date.now() > entry.expiresAt) {
-      otpStore.delete(invite.id);
-      throw new BadRequestException('OTP has expired — please request a new code');
+    const lockKey = `otp:locked:${invite.id}`;
+    const attemptsKey = `otp:attempts:${invite.id}`;
+    const otpKey = `otp:${invite.id}`;
+
+    let locked: string | null;
+    let storedHash: string | null;
+    try {
+      locked = await this.redis.get(lockKey);
+      if (locked) {
+        throw new TooManyRequestsException(
+          'Too many failed attempts — try again later',
+        );
+      }
+      storedHash = await this.redis.getdel(otpKey);
+    } catch (err) {
+      if (err instanceof TooManyRequestsException) throw err;
+      throw new ServiceUnavailableException(
+        'OTP service temporarily unavailable',
+      );
     }
 
-    const inputHash = crypto.createHash('sha256').update(code.trim()).digest('hex');
-    if (inputHash !== entry.hash) {
+    if (!storedHash) {
+      throw new BadRequestException(
+        'No OTP requested — please request a new code',
+      );
+    }
+
+    // Strip CRLF then hash, compare with timing-safe equality
+    const sanitized = code.replace(/[\r\n]/g, '').trim();
+    const inputHash = crypto
+      .createHash('sha256')
+      .update(sanitized)
+      .digest('hex');
+    const inputBuf = Buffer.from(inputHash, 'utf8');
+    const storedBuf = Buffer.from(storedHash, 'utf8');
+
+    const match =
+      inputBuf.length === storedBuf.length &&
+      crypto.timingSafeEqual(inputBuf, storedBuf);
+
+    if (!match) {
+      try {
+        const attempts = await this.redis.incr(attemptsKey);
+        if (attempts >= OTP_MAX_ATTEMPTS) {
+          await this.redis.setex(lockKey, OTP_LOCK_TTL_SEC, '1');
+          await this.redis.del(attemptsKey);
+        } else {
+          // Expire the counter so stale failures from days ago don't accumulate
+          await this.redis.expire(attemptsKey, OTP_LOCK_TTL_SEC);
+        }
+      } catch {
+        // best-effort; do not mask the user-facing error
+      }
       throw new BadRequestException('Invalid OTP');
     }
 
-    otpStore.delete(invite.id);
+    // Clear attempt counter on success
+    try {
+      await this.redis.del(attemptsKey);
+    } catch {
+      // best-effort
+    }
+
     await this.prisma.candidateInvite.update({
       where: { id: invite.id },
       data: { otpVerifiedAt: new Date() },
@@ -218,7 +288,8 @@ export class CandidateService {
 
       if (isCorrect) totalCorrect++;
 
-      if (!domainScores[domain]) domainScores[domain] = { correct: 0, total: 0 };
+      if (!domainScores[domain])
+        domainScores[domain] = { correct: 0, total: 0 };
       domainScores[domain].total++;
       if (isCorrect) domainScores[domain].correct++;
 
@@ -231,7 +302,8 @@ export class CandidateService {
     }
 
     const totalQuestions = scoringQuestions.length;
-    const score = totalQuestions > 0 ? (totalCorrect / totalQuestions) * 100 : 0;
+    const score =
+      totalQuestions > 0 ? (totalCorrect / totalQuestions) * 100 : 0;
     const timeSpent = invite.startedAt
       ? Math.round((Date.now() - invite.startedAt.getTime()) / 1000)
       : null;
@@ -243,7 +315,10 @@ export class CandidateService {
         where: { inviteId: invite.id },
         select: { eventType: true },
       });
-      const integrityScore = this.calcIntegrityScore(events, invite.tabSwitchCount ?? 0);
+      const integrityScore = this.calcIntegrityScore(
+        events,
+        invite.tabSwitchCount ?? 0,
+      );
 
       await tx.candidateAnswer.createMany({ data: answerRecords });
       await tx.candidateInvite.update({
@@ -276,13 +351,20 @@ export class CandidateService {
     };
   }
 
-  async reportEvent(token: string, eventType: string, clientTs?: string, payload?: any) {
+  async reportEvent(
+    token: string,
+    eventType: string,
+    clientTs?: string,
+    payload?: any,
+  ) {
     const invite = await this.findInviteByToken(token);
 
     // Fix #5: clamp client-supplied timestamp to ±1 hour of server time
     const now = Date.now();
     const rawTs = clientTs ? new Date(clientTs).getTime() : now;
-    const clampedTs = new Date(Math.max(now - CLIENT_TS_SKEW_MS, Math.min(now, rawTs)));
+    const clampedTs = new Date(
+      Math.max(now - CLIENT_TS_SKEW_MS, Math.min(now, rawTs)),
+    );
 
     await this.prisma.candidateEvent.create({
       data: {
@@ -308,7 +390,8 @@ export class CandidateService {
       where: { id: inviteId, assessmentId },
       select: { id: true },
     });
-    if (!invite) throw new NotFoundException('Candidate not found for this assessment');
+    if (!invite)
+      throw new NotFoundException('Candidate not found for this assessment');
 
     return this.prisma.candidateEvent.findMany({
       where: { inviteId },
@@ -400,7 +483,11 @@ export class CandidateService {
         const domain = (q as any).category ?? 'General';
         return { questionId: q.id, question: q, domain };
       })
-      .filter(Boolean) as { questionId: string; question: any; domain: string }[];
+      .filter(Boolean) as {
+      questionId: string;
+      question: any;
+      domain: string;
+    }[];
   }
 
   /**
@@ -414,8 +501,12 @@ export class CandidateService {
         questions: {
           orderBy: { sortOrder: 'asc' },
           include: {
-            orgQuestion: { include: { choices: { orderBy: { sortOrder: 'asc' } } } },
-            publicQuestion: { include: { choices: { orderBy: { sortOrder: 'asc' } } } },
+            orgQuestion: {
+              include: { choices: { orderBy: { sortOrder: 'asc' } } },
+            },
+            publicQuestion: {
+              include: { choices: { orderBy: { sortOrder: 'asc' } } },
+            },
           },
         },
       },

--- a/backend/src/common/csv/parse-candidate-csv.spec.ts
+++ b/backend/src/common/csv/parse-candidate-csv.spec.ts
@@ -1,0 +1,169 @@
+import { parseCandidateCsv, MAX_ROWS } from './parse-candidate-csv';
+
+describe('parseCandidateCsv', () => {
+  describe('valid rows', () => {
+    it('parses email-only CSV', () => {
+      const input = 'email\nalice@example.com\nbob@example.com';
+      const result = parseCandidateCsv(input);
+      expect(result.valid).toEqual([
+        { email: 'alice@example.com' },
+        { email: 'bob@example.com' },
+      ]);
+      expect(result.invalid).toHaveLength(0);
+      expect(result.duplicatesRemoved).toBe(0);
+    });
+
+    it('parses name column', () => {
+      const input = 'email,name\nalice@example.com,Alice\nbob@example.com,Bob';
+      const result = parseCandidateCsv(input);
+      expect(result.valid[0]).toEqual({
+        email: 'alice@example.com',
+        name: 'Alice',
+      });
+    });
+
+    it('parses candidateName column variant', () => {
+      const input = 'email,candidateName\nalice@example.com,Alice';
+      const result = parseCandidateCsv(input);
+      expect(result.valid[0]).toEqual({
+        email: 'alice@example.com',
+        name: 'Alice',
+      });
+    });
+
+    it('ignores extra columns', () => {
+      const input =
+        'email,department,name\nalice@example.com,Engineering,Alice';
+      const result = parseCandidateCsv(input);
+      expect(result.valid[0]).toEqual({
+        email: 'alice@example.com',
+        name: 'Alice',
+      });
+    });
+
+    it('normalises email to lowercase', () => {
+      const input = 'email\nALICE@Example.COM';
+      const result = parseCandidateCsv(input);
+      expect(result.valid[0].email).toBe('alice@example.com');
+    });
+
+    it('trims whitespace around fields', () => {
+      const input = 'email , name\n  alice@example.com , Alice  ';
+      const result = parseCandidateCsv(input);
+      expect(result.valid[0]).toEqual({
+        email: 'alice@example.com',
+        name: 'Alice',
+      });
+    });
+
+    it('skips blank lines', () => {
+      const input = 'email\nalice@example.com\n\nbob@example.com\n';
+      const result = parseCandidateCsv(input);
+      expect(result.valid).toHaveLength(2);
+    });
+
+    it('handles CRLF line endings', () => {
+      const input = 'email\r\nalice@example.com\r\nbob@example.com';
+      const result = parseCandidateCsv(input);
+      expect(result.valid).toHaveLength(2);
+    });
+  });
+
+  describe('invalid rows', () => {
+    it('reports missing email column in header', () => {
+      const input = 'name\nAlice';
+      const result = parseCandidateCsv(input);
+      expect(result.invalid[0].reason).toMatch(/Missing required "email"/);
+      expect(result.valid).toHaveLength(0);
+    });
+
+    it('reports invalid email format', () => {
+      const input = 'email\nnot-an-email';
+      const result = parseCandidateCsv(input);
+      expect(result.invalid[0]).toMatchObject({
+        row: 2,
+        reason: expect.stringContaining('Invalid email'),
+      });
+    });
+
+    it('reports empty email', () => {
+      const input = 'email,name\n,Alice';
+      const result = parseCandidateCsv(input);
+      expect(result.invalid[0].reason).toBe('Email is empty');
+    });
+
+    it('continues processing after invalid row', () => {
+      const input = 'email\nnot-valid\nbob@example.com';
+      const result = parseCandidateCsv(input);
+      expect(result.valid).toHaveLength(1);
+      expect(result.invalid).toHaveLength(1);
+    });
+  });
+
+  describe('deduplication', () => {
+    it('removes duplicate emails (case-insensitive)', () => {
+      const input =
+        'email\nalice@example.com\nALICE@Example.COM\nbob@example.com';
+      const result = parseCandidateCsv(input);
+      expect(result.valid).toHaveLength(2);
+      expect(result.duplicatesRemoved).toBe(1);
+    });
+
+    it('keeps first occurrence when deduping', () => {
+      const input =
+        'email,name\nalice@example.com,Alice1\nalice@example.com,Alice2';
+      const result = parseCandidateCsv(input);
+      expect(result.valid[0].name).toBe('Alice1');
+    });
+  });
+
+  describe('formula injection sanitization', () => {
+    it('prefixes name starting with = to prevent formula injection', () => {
+      const input = 'email,name\nalice@example.com,=SUM(1+1)';
+      const result = parseCandidateCsv(input);
+      expect(result.valid[0].name).toBe("'=SUM(1+1)");
+    });
+
+    it('prefixes names starting with + - @', () => {
+      const cases = ['+cmd', '-cmd', '@cmd'];
+      for (const val of cases) {
+        const input = `email,name\nalice@example.com,${val}`;
+        const r = parseCandidateCsv(input);
+        expect(r.valid[0].name).toBe(`'${val}`);
+      }
+    });
+  });
+
+  describe('MAX_ROWS limit', () => {
+    it('flags rows beyond MAX_ROWS as invalid', () => {
+      const rows = Array.from(
+        { length: MAX_ROWS + 5 },
+        (_, i) => `user${i}@example.com`,
+      );
+      const input = ['email', ...rows].join('\n');
+      const result = parseCandidateCsv(input);
+      const limitErrors = result.invalid.filter((e) =>
+        e.reason.includes('MAX_ROWS'),
+      );
+      expect(limitErrors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty result for empty string', () => {
+      const result = parseCandidateCsv('');
+      expect(result.valid).toHaveLength(0);
+      expect(result.invalid).toHaveLength(0);
+    });
+
+    it('returns empty result for header-only CSV', () => {
+      const result = parseCandidateCsv('email');
+      expect(result.valid).toHaveLength(0);
+    });
+
+    it('handles single candidate', () => {
+      const result = parseCandidateCsv('email\nalice@example.com');
+      expect(result.valid).toHaveLength(1);
+    });
+  });
+});

--- a/backend/src/common/csv/parse-candidate-csv.ts
+++ b/backend/src/common/csv/parse-candidate-csv.ts
@@ -1,0 +1,103 @@
+export const MAX_ROWS = 1000;
+
+export interface ParsedCandidate {
+  email: string;
+  name?: string;
+}
+
+export interface ParseCandidateCsvResult {
+  valid: ParsedCandidate[];
+  invalid: { row: number; raw: string; reason: string }[];
+  duplicatesRemoved: number;
+}
+
+// RFC 5322 simplified — good enough for server-side pre-validation
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Sanitize values that could cause formula injection if exported to spreadsheets
+function sanitizeField(value: string): string {
+  return /^[=+\-@]/.test(value) ? `'${value}` : value;
+}
+
+export function parseCandidateCsv(input: string): ParseCandidateCsvResult {
+  const lines = input.split(/\r?\n/);
+  const valid: ParsedCandidate[] = [];
+  const invalid: { row: number; raw: string; reason: string }[] = [];
+  let duplicatesRemoved = 0;
+
+  if (lines.length === 0) {
+    return { valid, invalid, duplicatesRemoved };
+  }
+
+  const headerLine = lines[0].trim();
+  if (!headerLine) {
+    return { valid, invalid, duplicatesRemoved };
+  }
+
+  const headers = headerLine.split(',').map((h) => h.trim().toLowerCase());
+  const emailIdx = headers.indexOf('email');
+
+  if (emailIdx === -1) {
+    invalid.push({
+      row: 0,
+      raw: headerLine,
+      reason: 'Missing required "email" column',
+    });
+    return { valid, invalid, duplicatesRemoved };
+  }
+
+  const nameIdx =
+    headers.indexOf('name') !== -1
+      ? headers.indexOf('name')
+      : headers.indexOf('candidatename');
+
+  const seen = new Set<string>();
+
+  for (let i = 1; i < lines.length; i++) {
+    const raw = lines[i];
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+
+    if (valid.length + invalid.length >= MAX_ROWS) {
+      invalid.push({
+        row: i + 1,
+        raw: trimmed,
+        reason: `Exceeds MAX_ROWS limit of ${MAX_ROWS}`,
+      });
+      continue;
+    }
+
+    const cols = trimmed.split(',').map((c) => c.trim());
+    const email = (cols[emailIdx] ?? '').toLowerCase().trim();
+
+    if (!email) {
+      invalid.push({ row: i + 1, raw: trimmed, reason: 'Email is empty' });
+      continue;
+    }
+
+    if (!EMAIL_RE.test(email)) {
+      invalid.push({
+        row: i + 1,
+        raw: trimmed,
+        reason: `Invalid email: "${email}"`,
+      });
+      continue;
+    }
+
+    if (seen.has(email)) {
+      duplicatesRemoved++;
+      continue;
+    }
+
+    seen.add(email);
+
+    const candidate: ParsedCandidate = { email };
+    if (nameIdx !== -1 && cols[nameIdx]) {
+      candidate.name = sanitizeField(cols[nameIdx].trim());
+    }
+
+    valid.push(candidate);
+  }
+
+  return { valid, invalid, duplicatesRemoved };
+}

--- a/backend/src/competency/competency.controller.ts
+++ b/backend/src/competency/competency.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
+import { OrgRoles } from '../common/decorators/org-roles.decorator';
+import { OrgRole } from '@prisma/client';
+import { CompetencyService } from './competency.service';
+import { CreateCompetencyDto } from './dto/create-competency.dto';
+import { UpdateCompetencyDto } from './dto/update-competency.dto';
+import { ListCompetenciesDto } from './dto/list-competencies.dto';
+
+@ApiTags('competencies')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, OrgRoleGuard)
+@Controller('orgs/:orgId/competencies')
+export class CompetencyController {
+  constructor(private readonly competencyService: CompetencyService) {}
+
+  @Post()
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Create a competency' })
+  @ApiParam({ name: 'orgId', type: 'string' })
+  create(@Param('orgId') orgId: string, @Body() dto: CreateCompetencyDto) {
+    return this.competencyService.create(orgId, dto);
+  }
+
+  @Get()
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MEMBER, OrgRole.RECRUITER)
+  @ApiOperation({ summary: 'List competencies' })
+  @ApiParam({ name: 'orgId', type: 'string' })
+  findAll(@Param('orgId') orgId: string, @Query() query: ListCompetenciesDto) {
+    return this.competencyService.findAll(orgId, query);
+  }
+
+  @Get(':id')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MEMBER, OrgRole.RECRUITER)
+  @ApiOperation({ summary: 'Get competency by id' })
+  @ApiParam({ name: 'orgId', type: 'string' })
+  @ApiParam({ name: 'id', type: 'string' })
+  findOne(@Param('orgId') orgId: string, @Param('id') id: string) {
+    return this.competencyService.findOne(orgId, id);
+  }
+
+  @Patch(':id')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Update a competency' })
+  @ApiParam({ name: 'orgId', type: 'string' })
+  @ApiParam({ name: 'id', type: 'string' })
+  update(
+    @Param('orgId') orgId: string,
+    @Param('id') id: string,
+    @Body() dto: UpdateCompetencyDto,
+  ) {
+    return this.competencyService.update(orgId, id, dto);
+  }
+
+  @Delete(':id')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a competency' })
+  @ApiParam({ name: 'orgId', type: 'string' })
+  @ApiParam({ name: 'id', type: 'string' })
+  remove(@Param('orgId') orgId: string, @Param('id') id: string) {
+    return this.competencyService.remove(orgId, id);
+  }
+}

--- a/backend/src/competency/competency.module.ts
+++ b/backend/src/competency/competency.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CompetencyController } from './competency.controller';
+import { CompetencyService } from './competency.service';
+import { OrganizationsModule } from '../organizations/organizations.module';
+
+@Module({
+  imports: [OrganizationsModule],
+  controllers: [CompetencyController],
+  providers: [CompetencyService],
+  exports: [CompetencyService],
+})
+export class CompetencyModule {}

--- a/backend/src/competency/competency.service.ts
+++ b/backend/src/competency/competency.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateCompetencyDto } from './dto/create-competency.dto';
+import { UpdateCompetencyDto } from './dto/update-competency.dto';
+import { ListCompetenciesDto } from './dto/list-competencies.dto';
+
+@Injectable()
+export class CompetencyService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(orgId: string, dto: CreateCompetencyDto) {
+    return this.prisma.competency.create({
+      data: {
+        orgId,
+        name: dto.name,
+        description: dto.description,
+        scaleMin: dto.scaleMin ?? 1,
+        scaleMax: dto.scaleMax ?? 5,
+      },
+    });
+  }
+
+  findAll(orgId: string, query: ListCompetenciesDto) {
+    return this.prisma.competency.findMany({
+      where: {
+        orgId,
+        ...(query.isActive !== undefined ? { isActive: query.isActive } : {}),
+      },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async findOne(orgId: string, id: string) {
+    const competency = await this.prisma.competency.findFirst({
+      where: { id, orgId },
+      include: { domains: true },
+    });
+    if (!competency) throw new NotFoundException('Competency not found');
+    return competency;
+  }
+
+  async update(orgId: string, id: string, dto: UpdateCompetencyDto) {
+    await this.findOne(orgId, id);
+    return this.prisma.competency.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  async remove(orgId: string, id: string) {
+    await this.findOne(orgId, id);
+    return this.prisma.competency.delete({ where: { id } });
+  }
+}

--- a/backend/src/competency/dto/create-competency.dto.ts
+++ b/backend/src/competency/dto/create-competency.dto.ts
@@ -1,0 +1,25 @@
+import { IsString, IsOptional, IsInt, Min, Max } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateCompetencyDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiPropertyOptional({ default: 1 })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  scaleMin?: number;
+
+  @ApiPropertyOptional({ default: 5 })
+  @IsInt()
+  @Max(10)
+  @IsOptional()
+  scaleMax?: number;
+}

--- a/backend/src/competency/dto/list-competencies.dto.ts
+++ b/backend/src/competency/dto/list-competencies.dto.ts
@@ -1,0 +1,11 @@
+import { IsBoolean, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListCompetenciesDto {
+  @ApiPropertyOptional({ description: 'Filter by active status' })
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  isActive?: boolean;
+}

--- a/backend/src/competency/dto/update-competency.dto.ts
+++ b/backend/src/competency/dto/update-competency.dto.ts
@@ -1,0 +1,11 @@
+import { PartialType } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { CreateCompetencyDto } from './create-competency.dto';
+
+export class UpdateCompetencyDto extends PartialType(CreateCompetencyDto) {
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/backend/src/competency/scoring/infer-competency-level.spec.ts
+++ b/backend/src/competency/scoring/infer-competency-level.spec.ts
@@ -1,0 +1,147 @@
+import {
+  inferCompetencyLevel,
+  DEFAULT_THRESHOLDS_1_5,
+  InferCompetencyLevelOptions,
+} from './infer-competency-level';
+
+const opts: InferCompetencyLevelOptions = {
+  scaleMin: 1,
+  scaleMax: 5,
+  thresholds: DEFAULT_THRESHOLDS_1_5,
+};
+
+describe('inferCompetencyLevel', () => {
+  // TC1 — happy path: multiple domains, sufficient sample → HIGH
+  it('aggregates multiple domains and returns HIGH confidence when sample >= 20', () => {
+    const result = inferCompetencyLevel(
+      {
+        Networking: { correct: 18, total: 20 },
+        Security: { correct: 9, total: 10 },
+        Storage: { correct: 1, total: 5 }, // not in mappedDomains — ignored
+      },
+      ['Networking', 'Security'],
+      opts,
+    );
+    expect(result.level).toBe(5);
+    expect(result.percentage).toBe(90.0);
+    expect(result.confidence).toBe('HIGH');
+    expect(result.sampleSize).toBe(30);
+    expect(result.matchedDomains).toEqual(['Networking', 'Security']);
+  });
+
+  // TC2 — no matching domain
+  it('returns level=scaleMin, percentage=0, confidence=LOW when no domain matches', () => {
+    const result = inferCompetencyLevel(
+      { Compute: { correct: 4, total: 5 } },
+      ['Networking'],
+      opts,
+    );
+    expect(result.level).toBe(1);
+    expect(result.percentage).toBe(0);
+    expect(result.confidence).toBe('LOW');
+    expect(result.sampleSize).toBe(0);
+    expect(result.matchedDomains).toHaveLength(0);
+  });
+
+  // TC3 — case-insensitive, partial overlap, small sample → LOW
+  it('matches case-insensitively and returns LOW for small sample', () => {
+    const result = inferCompetencyLevel(
+      { networking: { correct: 3, total: 6 } },
+      ['NETWORKING', 'Databases'],
+      opts,
+    );
+    expect(result.level).toBe(2); // 50% → bucket [40,60) → level 2
+    expect(result.percentage).toBe(50.0);
+    expect(result.confidence).toBe('LOW'); // sampleSize 6 < 8
+    expect(result.sampleSize).toBe(6);
+    expect(result.matchedDomains).toEqual(['NETWORKING']);
+  });
+
+  // TC4 — boundary: exactly 75% uses >= so hits level 4; sampleSize=8 → MEDIUM
+  it('uses >= for threshold boundary and returns MEDIUM at sample=8', () => {
+    const result = inferCompetencyLevel(
+      { Security: { correct: 6, total: 8 } },
+      ['security'],
+      opts,
+    );
+    expect(result.level).toBe(4);
+    expect(result.percentage).toBe(75.0);
+    expect(result.confidence).toBe('MEDIUM');
+  });
+
+  // TC5 — empty domainScores
+  it('handles empty domainScores', () => {
+    const result = inferCompetencyLevel({}, ['Networking'], opts);
+    expect(result.level).toBe(1);
+    expect(result.percentage).toBe(0);
+    expect(result.confidence).toBe('LOW');
+    expect(result.sampleSize).toBe(0);
+  });
+
+  // TC6 — empty mappedDomains
+  it('handles empty mappedDomains', () => {
+    const result = inferCompetencyLevel(
+      { Networking: { correct: 5, total: 10 } },
+      [],
+      opts,
+    );
+    expect(result.level).toBe(1);
+    expect(result.percentage).toBe(0);
+  });
+
+  // TC7 — domain with total=0 does not produce NaN or division-by-zero
+  it('ignores domains with total=0 without crashing', () => {
+    const result = inferCompetencyLevel(
+      {
+        Networking: { correct: 0, total: 0 },
+        Security: { correct: 8, total: 10 },
+      },
+      ['Networking', 'Security'],
+      opts,
+    );
+    expect(result.percentage).toBe(80.0);
+    expect(result.sampleSize).toBe(10);
+  });
+
+  // TC8 — custom scale 1–4
+  it('respects custom scaleMin/scaleMax and thresholds', () => {
+    const customOpts: InferCompetencyLevelOptions = {
+      scaleMin: 1,
+      scaleMax: 4,
+      thresholds: [
+        { minPercentage: 80, level: 4 },
+        { minPercentage: 55, level: 3 },
+        { minPercentage: 30, level: 2 },
+        { minPercentage: 0, level: 1 },
+      ],
+    };
+    const result = inferCompetencyLevel(
+      { Networking: { correct: 9, total: 10 } },
+      ['Networking'],
+      customOpts,
+    );
+    expect(result.level).toBe(4); // 90% >= 80 → level 4
+  });
+
+  // TC9 — whitespace trimming
+  it('trims whitespace from domain keys', () => {
+    const result = inferCompetencyLevel(
+      { ' networking ': { correct: 5, total: 10 } },
+      ['NETWORKING'],
+      opts,
+    );
+    expect(result.percentage).toBe(50.0);
+    expect(result.matchedDomains).toEqual(['NETWORKING']);
+  });
+
+  // TC10 — HIGH confidence at exactly minSampleForHigh
+  it('returns HIGH confidence when sampleSize equals minSampleForHigh (20)', () => {
+    const result = inferCompetencyLevel(
+      { Networking: { correct: 10, total: 20 } },
+      ['Networking'],
+      opts,
+    );
+    expect(result.confidence).toBe('HIGH');
+    expect(result.level).toBe(2); // 50% → level 2
+  });
+});

--- a/backend/src/competency/scoring/infer-competency-level.ts
+++ b/backend/src/competency/scoring/infer-competency-level.ts
@@ -1,0 +1,111 @@
+export interface DomainScore {
+  correct: number;
+  total: number;
+}
+
+export interface Threshold {
+  /** Inclusive lower bound. Thresholds must be sorted descending by minPercentage. */
+  minPercentage: number;
+  level: number;
+}
+
+export interface InferCompetencyLevelOptions {
+  scaleMin: number;
+  scaleMax: number;
+  thresholds: Threshold[];
+  /** sumTotal threshold for HIGH confidence (default 20) */
+  minSampleForHigh?: number;
+  /** sumTotal threshold for MEDIUM confidence (default 8) */
+  minSampleForMedium?: number;
+}
+
+export interface CompetencyLevelResult {
+  level: number;
+  percentage: number;
+  confidence: 'LOW' | 'MEDIUM' | 'HIGH';
+  sampleSize: number;
+  matchedDomains: string[];
+}
+
+/** Default thresholds for a 1–5 scale. */
+export const DEFAULT_THRESHOLDS_1_5: Threshold[] = [
+  { minPercentage: 90, level: 5 },
+  { minPercentage: 75, level: 4 },
+  { minPercentage: 60, level: 3 },
+  { minPercentage: 40, level: 2 },
+  { minPercentage: 0, level: 1 },
+];
+
+/**
+ * Pure function — no I/O, no DB, deterministic.
+ *
+ * Aggregates domainScores for the mapped domains (case-insensitive) and
+ * buckets the result into a level using the provided thresholds.
+ */
+export function inferCompetencyLevel(
+  domainScores: Record<string, DomainScore>,
+  mappedDomains: string[],
+  options: InferCompetencyLevelOptions,
+): CompetencyLevelResult {
+  const { scaleMin, scaleMax, thresholds } = options;
+  const minSampleForHigh = options.minSampleForHigh ?? 20;
+  const minSampleForMedium = options.minSampleForMedium ?? 8;
+
+  // Build a normalised lookup: lowercaseTrim(key) → score
+  const normalised = new Map<string, DomainScore>();
+  for (const [key, score] of Object.entries(domainScores)) {
+    normalised.set(key.toLowerCase().trim(), score);
+  }
+
+  let sumCorrect = 0;
+  let sumTotal = 0;
+  const matchedDomains: string[] = [];
+
+  for (const domain of mappedDomains) {
+    const key = domain.toLowerCase().trim();
+    const score = normalised.get(key);
+    if (score) {
+      sumCorrect += score.correct;
+      sumTotal += score.total;
+      matchedDomains.push(domain);
+    }
+  }
+
+  if (sumTotal === 0) {
+    return {
+      level: scaleMin,
+      percentage: 0,
+      confidence: 'LOW',
+      sampleSize: 0,
+      matchedDomains: [],
+    };
+  }
+
+  const rawPercentage = (sumCorrect / sumTotal) * 100;
+  const percentage = Math.round(rawPercentage * 10) / 10;
+
+  // Find first threshold (sorted descending) where percentage >= minPercentage
+  let level = scaleMin;
+  for (const t of thresholds) {
+    if (percentage >= t.minPercentage) {
+      level = t.level;
+      break;
+    }
+  }
+  level = Math.max(scaleMin, Math.min(scaleMax, level));
+
+  const confidence: CompetencyLevelResult['confidence'] =
+    sumTotal >= minSampleForHigh
+      ? 'HIGH'
+      : sumTotal >= minSampleForMedium
+        ? 'MEDIUM'
+        : 'LOW';
+
+  return {
+    level,
+    percentage,
+    confidence,
+    sampleSize: sumTotal,
+    matchedDomains,
+  };
+}

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -126,4 +126,35 @@ export class MailService {
       this.logger.error(`Failed to send email to ${options.to}`, error);
     }
   }
+
+  async sendOtp(email: string, code: string, inviteId: string): Promise<void> {
+    const maskedEmail = email.replace(/(.{2}).+(@.+)/, '$1***$2');
+    try {
+      await this.transporter.sendMail({
+        from: this.from,
+        to: email,
+        subject: 'Your assessment verification code',
+        html: `
+          <div style="font-family:sans-serif;max-width:480px;margin:auto">
+            <h2>Verification code</h2>
+            <p>Use the code below to start your assessment:</p>
+            <p style="font-size:32px;font-weight:bold;letter-spacing:6px;text-align:center;
+                      background:#f4f4f5;padding:16px;border-radius:8px;margin:24px 0">
+              ${code}
+            </p>
+            <p>This code expires in <strong>10 minutes</strong>.<br>
+               Do not share this code with anyone.</p>
+          </div>
+        `,
+      });
+    } catch (error) {
+      // Structured log — no code or hash exposed
+      this.logger.error('OTP_MAIL_FAILED', {
+        event: 'OTP_MAIL_FAILED',
+        maskedEmail,
+        inviteId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 }

--- a/backend/src/redis/redis.module.ts
+++ b/backend/src/redis/redis.module.ts
@@ -1,0 +1,25 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+export const REDIS_CLIENT = 'REDIS_CLIENT';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      useFactory: (config: ConfigService) => {
+        return new Redis({
+          host: config.get('REDIS_HOST', 'localhost'),
+          port: config.get<number>('REDIS_PORT', 6379),
+          password: config.get('REDIS_PASSWORD') || undefined,
+          lazyConnect: false,
+        });
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [REDIS_CLIENT],
+})
+export class RedisModule {}

--- a/backend/src/redis/redis.module.ts
+++ b/backend/src/redis/redis.module.ts
@@ -10,11 +10,26 @@ export const REDIS_CLIENT = 'REDIS_CLIENT';
     {
       provide: REDIS_CLIENT,
       useFactory: (config: ConfigService) => {
+        if (process.env.NODE_ENV === 'test') {
+          // Stub that satisfies the injection token without opening a socket.
+          // Tests needing real Redis behaviour should override REDIS_CLIENT
+          // in their own Test.createTestingModule().
+          return {
+            get: async () => null,
+            set: async () => 'OK',
+            setex: async () => 'OK',
+            getdel: async () => null,
+            del: async () => 0,
+            incr: async () => 1,
+            expire: async () => 1,
+            quit: async () => 'OK',
+          } as unknown as Redis;
+        }
         return new Redis({
           host: config.get('REDIS_HOST', 'localhost'),
           port: config.get<number>('REDIS_PORT', 6379),
           password: config.get('REDIS_PASSWORD') || undefined,
-          lazyConnect: false,
+          lazyConnect: true,
         });
       },
       inject: [ConfigService],

--- a/backend/src/redis/redis.module.ts
+++ b/backend/src/redis/redis.module.ts
@@ -15,14 +15,14 @@ export const REDIS_CLIENT = 'REDIS_CLIENT';
           // Tests needing real Redis behaviour should override REDIS_CLIENT
           // in their own Test.createTestingModule().
           return {
-            get: async () => null,
-            set: async () => 'OK',
-            setex: async () => 'OK',
-            getdel: async () => null,
-            del: async () => 0,
-            incr: async () => 1,
-            expire: async () => 1,
-            quit: async () => 'OK',
+            get: () => Promise.resolve(null),
+            set: () => Promise.resolve('OK'),
+            setex: () => Promise.resolve('OK'),
+            getdel: () => Promise.resolve(null),
+            del: () => Promise.resolve(0),
+            incr: () => Promise.resolve(1),
+            expire: () => Promise.resolve(1),
+            quit: () => Promise.resolve('OK'),
           } as unknown as Redis;
         }
         return new Redis({

--- a/docs/adr/00-index.md
+++ b/docs/adr/00-index.md
@@ -23,6 +23,7 @@ This directory contains architecture decision records for CertGym. Each ADR docu
 | 025 | Reputation model and tier thresholds            | Accepted | S10    | 2026-05-24   |
 | 026 | DDS auto-apply GA & canary promotion policy     | Accepted | S11    | 2026-05-24   |
 | 027 | Reputation anti-gaming detection thresholds     | Accepted | S11    | 2026-05-24   |
+| 028 | Competency level inference algorithm (v0)       | Proposed | S0     | 2026-06-14   |
 
 ---
 

--- a/docs/adr/028-competency-scoring.md
+++ b/docs/adr/028-competency-scoring.md
@@ -1,0 +1,190 @@
+# ADR 003 — Competency Scoring Algorithm (S0-2 / FR-2)
+
+**Status:** Proposed
+**Date:** 2026-06-14
+**Deciders:** ThanhPT (Architect)
+**Liên quan:** [Sprint 0 — Foundation Basic Design](../specs/sprint-0-foundation-basic-design.md) §5
+
+> ⚠️ **Lưu ý số hiệu:** số `003` hiện đã thuộc về `003-pass-predictor-v0.md` trong `00-index.md`.
+> Tên file này theo yêu cầu enabler S0-2; **cần đổi số (vd 028) trước khi merge** để tránh trùng. Xem Consequences.
+
+---
+
+## Context
+
+Sáng kiến Enterprise Organization cần suy ra **mức năng lực (competency level, thang 1–5)** của một người (nhân viên hoặc ứng viên) cho mỗi competency mà org định nghĩa. Dữ liệu điểm số sau mỗi bài đánh giá **đã được tổng hợp sẵn theo tên domain** dưới dạng JSON:
+
+- `CandidateInvite.domainScores` và `ExamAttempt.domainScores` có shape
+  `Record<string, { correct: number; total: number }>`, key là **tên domain/category** (string).
+- Được tính tại thời điểm nộp bài — xem `candidate.service.ts submitAttempt` (L197–223) và
+  `org-analytics.service.ts getSkillGaps` (L179). Không có bảng "raw answer per competency" sẵn dùng cho chấm điểm năng lực.
+- Model `CompetencyDomain` (FR-1) ánh xạ một competency tới **nhiều tên domain** (so khớp case-insensitive).
+- Model `QuestionCompetency` (FR-1) ánh xạ competency tới từng câu hỏi org, có `weight` — nhưng chưa được dùng ở đâu.
+
+Có **hai phương án** để tính điểm năng lực:
+
+- **Phương án A — recompute từ raw answers theo từng câu hỏi qua `QuestionCompetency`.**
+  Với mỗi competency, lấy tập câu hỏi liên kết (qua `weight`), truy ngược các bản ghi answer của người đó, tính tỷ lệ đúng có trọng số. **Chính xác hơn** (chấm đúng theo câu hỏi thuộc competency, không phụ thuộc cách gom domain), nhưng đòi hỏi:
+  - re-fetch raw answers (`Answer` / answer records của `CandidateInvite`) — thêm I/O, thêm join;
+  - dữ liệu `QuestionCompetency` phải được điền đầy đủ (hiện chưa có UI/seed nào điền) → v0 sẽ không có gì để tính.
+
+- **Phương án B — aggregate `domainScores` đã lưu qua mapping `CompetencyDomain`.**
+  Với mỗi competency, lấy danh sách `CompetencyDomain.domainName`, cộng dồn `correct`/`total` của các domain khớp (case-insensitive) trong `domainScores`, ra tỷ lệ phần trăm → bucket thành level. **Tái dùng dữ liệu đã có**, không re-fetch raw answers, chạy được ngay khi org chỉ cần map domain (việc nhẹ) thay vì gán từng câu hỏi.
+
+---
+
+## Decision
+
+### Chọn **Phương án B cho v0.**
+
+Lý do:
+
+1. **Tái dùng dữ liệu đã lưu** — `domainScores` đã tồn tại trên mọi attempt/invite đã nộp; không cần re-fetch hay re-score raw answers. I/O tối thiểu, tính được cả trên dữ liệu lịch sử.
+2. **Chi phí cấu hình thấp** — org chỉ cần map vài tên domain vào competency (`CompetencyDomain`), thay vì gán nhãn competency cho từng câu hỏi. Điều này khả thi ngay Sprint 0; phương án A sẽ "rỗng" vì `QuestionCompetency` chưa được điền.
+3. **Giữ cửa cho độ chính xác sau này** — `QuestionCompetency` vẫn được tạo ở FR-1 và **giữ lại** cho v1: khi dữ liệu gán câu hỏi đủ dày, có thể nâng cấp sang phương án A (hoặc lai) mà không phá schema.
+
+### Pure function `inferCompetencyLevel()`
+
+Vị trí: `backend/src/competency/scoring/infer-competency-level.ts` — thuần, không I/O.
+
+```ts
+interface DomainScore {
+  correct: number;
+  total: number;
+}
+interface Threshold {
+  minPercentage: number;
+  level: number;
+} // sắp xếp giảm dần theo minPercentage
+
+interface InferCompetencyLevelOptions {
+  scaleMin: number; // mặc định 1
+  scaleMax: number; // mặc định 5
+  thresholds: Threshold[]; // bảng ngưỡng (xem mặc định bên dưới)
+  minSampleForHigh?: number; // mặc định 20
+  minSampleForMedium?: number; // mặc định 8
+}
+
+interface CompetencyLevelResult {
+  level: number; // trong [scaleMin, scaleMax]
+  percentage: number; // 0..100, làm tròn 1 chữ số thập phân
+  confidence: "LOW" | "MEDIUM" | "HIGH";
+  sampleSize: number; // Σtotal trên các domain khớp
+}
+
+function inferCompetencyLevel(
+  domainScores: Record<string, DomainScore>,
+  mappedDomains: string[],
+  options: InferCompetencyLevelOptions,
+): CompetencyLevelResult;
+```
+
+**Thuật toán:**
+
+1. Chuẩn hóa key: lập map `lowercaseTrim(domainName) → DomainScore` từ `domainScores`; chuẩn hóa `mappedDomains` tương tự (**case-insensitive matching**).
+2. Cộng dồn `sumCorrect = Σcorrect`, `sumTotal = Σtotal` chỉ trên các domain **vừa được map vừa có mặt** trong `domainScores`.
+3. **Edge — không có dữ liệu** (`sumTotal === 0`, do không domain nào khớp / `domainScores` rỗng / `mappedDomains` rỗng):
+   trả `{ level: scaleMin, percentage: 0, confidence: 'LOW', sampleSize: 0 }`. Không chia cho 0.
+4. `percentage = (sumCorrect / sumTotal) * 100`.
+5. **Bucket level:** duyệt `thresholds` (giảm dần theo `minPercentage`), chọn `level` đầu tiên có `percentage >= minPercentage`; nếu không khớp ngưỡng nào → `scaleMin`. Clamp kết quả vào `[scaleMin, scaleMax]`.
+6. **Confidence theo sample size** (`sumTotal`):
+   - `HIGH` nếu `sumTotal >= minSampleForHigh` (mặc định 20),
+   - `MEDIUM` nếu `sumTotal >= minSampleForMedium` (mặc định 8),
+   - ngược lại `LOW`.
+     Confidence **độc lập** với level — báo cho người dùng "level này đáng tin tới đâu" dựa trên số câu đã làm.
+
+**Edge cases được xử lý tường minh:**
+
+| Edge                                                                       | Hành vi                                                                     |
+| :------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| Không domain nào khớp / `domainScores` rỗng                                | `level=scaleMin, percentage=0, confidence=LOW, sampleSize=0` (không chia 0) |
+| **Partial overlap** (chỉ một phần `mappedDomains` có trong `domainScores`) | Chỉ cộng phần khớp; `sampleSize` phản ánh đúng cỡ mẫu thực                  |
+| **Case-insensitive** ("Networking" vs "networking" vs " NETWORKING ")      | Khớp sau khi `lowercaseTrim`                                                |
+| Domain có `total=0` lọt vào                                                | Cộng vào sumTotal không đổi → không ảnh hưởng; vẫn an toàn                  |
+| `percentage` đúng ngưỡng (vd = 80)                                         | Dùng `>=` → rơi vào bucket cao hơn                                          |
+
+### Bảng ngưỡng mặc định (thang 1–5)
+
+| Level | Nhãn gợi ý | `minPercentage` (≥) | Khoảng % |
+| :---- | :--------- | :------------------ | :------- |
+| **5** | Expert     | 90                  | 90–100   |
+| **4** | Proficient | 75                  | 75–89    |
+| **3** | Competent  | 60                  | 60–74    |
+| **2** | Developing | 40                  | 40–59    |
+| **1** | Novice     | 0                   | 0–39     |
+
+```ts
+const DEFAULT_THRESHOLDS_1_5: Threshold[] = [
+  { minPercentage: 90, level: 5 },
+  { minPercentage: 75, level: 4 },
+  { minPercentage: 60, level: 3 },
+  { minPercentage: 40, level: 2 },
+  { minPercentage: 0, level: 1 },
+];
+```
+
+### Unit-test cases (đại diện)
+
+```ts
+const opts = { scaleMin: 1, scaleMax: 5, thresholds: DEFAULT_THRESHOLDS_1_5 };
+
+// TC1 — happy path, gộp nhiều domain, sample đủ lớn → HIGH
+// Networking 18/20 + Security 9/10 = 27/30 = 90.0% → level 5; sample 30 ≥ 20 → HIGH
+inferCompetencyLevel(
+  {
+    Networking: { correct: 18, total: 20 },
+    Security: { correct: 9, total: 10 },
+    Storage: { correct: 1, total: 5 },
+  },
+  ["Networking", "Security"],
+  opts,
+); // => { level: 5, percentage: 90.0, confidence: 'HIGH', sampleSize: 30 }
+
+// TC2 — không có dữ liệu (mapped domain không xuất hiện trong domainScores)
+inferCompetencyLevel(
+  { Compute: { correct: 4, total: 5 } },
+  ["Networking"],
+  opts,
+); // => { level: 1, percentage: 0, confidence: 'LOW', sampleSize: 0 }
+
+// TC3 — case-insensitive + partial overlap, sample nhỏ → LOW
+// chỉ 'networking' khớp ('Databases' không có): 3/6 = 50.0% → level 2; sample 6 < 8 → LOW
+inferCompetencyLevel(
+  { networking: { correct: 3, total: 6 } },
+  ["NETWORKING", "Databases"],
+  opts,
+); // => { level: 2, percentage: 50.0, confidence: 'LOW', sampleSize: 6 }
+
+// TC4 — biên ngưỡng dùng '>=' và confidence MEDIUM
+// 6/8 = 75.0% đúng ngưỡng level 4; sample 8 ≥ 8 → MEDIUM
+inferCompetencyLevel(
+  { Security: { correct: 6, total: 8 } },
+  ["security"],
+  opts,
+); // => { level: 4, percentage: 75.0, confidence: 'MEDIUM', sampleSize: 8 }
+```
+
+---
+
+## Consequences
+
+### Positive
+
+- **Chạy được ngay trên dữ liệu hiện có** — tái dùng `domainScores` đã lưu, không cần backfill, không re-fetch raw answers; tính được cả cho attempt lịch sử.
+- **Pure function, dễ test** — tách hoàn toàn khỏi Prisma/HTTP; toàn bộ nhánh (no-data, partial overlap, case-insensitive, biên ngưỡng, các mức confidence) phủ được bằng unit test, không cần DB.
+- **Cấu hình nhẹ cho org** — chỉ cần map tên domain vào competency là có điểm; không bắt buộc gán nhãn từng câu hỏi.
+- **Không khóa tương lai** — `QuestionCompetency` vẫn tồn tại; có thể nâng lên phương án A (chấm theo câu hỏi có trọng số) ở v1 mà không phá schema hay đổi chữ ký public (chỉ thay phần chuẩn bị input ở service layer).
+- **Confidence tách khỏi level** — người dùng biết một level "4" dựa trên 6 câu là kém tin hơn dựa trên 40 câu, tránh quyết định tuyển dụng/đánh giá trên mẫu quá nhỏ.
+
+### Risks / mitigations
+
+- **Lệ thuộc chất lượng mapping domain** — nếu org map sai/thiếu tên domain, điểm sẽ lệch hoặc rỗng. _Mitigation:_ trả `confidence: LOW` + `sampleSize` rõ ràng để lộ "thiếu dữ liệu"; UI cảnh báo khi `sampleSize` thấp; validate domain tồn tại khi map.
+- **`domainScores` aggregate, không weighted theo câu hỏi** — mọi domain trong competency được cộng "bình đẳng" theo số câu, không theo `weight`. _Mitigation:_ chấp nhận ở v0 (đủ tốt cho sàng lọc); v1 chuyển phương án A nếu cần độ chính xác.
+- **Ngưỡng mặc định chỉ đúng cho thang 1–5** — org đặt `scaleMin/scaleMax` khác sẽ cần bảng ngưỡng riêng. _Mitigation:_ `thresholds` là tham số đầu vào (không hardcode); v0 chỉ ship bảng 1–5 và **giới hạn org dùng thang 1–5** cho tới khi có cơ chế ngưỡng tổng quát (ghi nhận open question §11.5 của basic design).
+- **Tie-break / ranking hiring** — level rời rạc (1–5) gây nhiều ứng viên cùng level. _Mitigation:_ khi xếp hạng, dùng `percentage` (liên tục) làm tie-break thứ cấp, không chỉ `level`.
+- **Trùng số ADR** — `003` đã dùng cho pass-predictor. _Mitigation:_ đổi số file (vd `028-competency-scoring.md`) và cập nhật `docs/adr/00-index.md` trước khi merge; nội dung quyết định không đổi.
+- **Schema-only ở Sprint 0** — pure function + test được giao, nhưng endpoint chấm điểm thật chưa nối. _Mitigation:_ service layer kết nối ở sprint sau; Sprint 0 chỉ cam kết hàm thuần đã test.
+
+```
+
+```

--- a/docs/specs/sprint-0-foundation-basic-design.md
+++ b/docs/specs/sprint-0-foundation-basic-design.md
@@ -1,0 +1,565 @@
+# Sprint 0 — Foundation: Basic Design
+
+> **Phiên bản:** 1.0
+> **Ngày:** 14/06/2026
+> **Trạng thái:** Draft (chờ review từ Architect / Security / Database)
+> **Sprint:** Sprint 0 — Foundation / De-risking cho sáng kiến Enterprise Organization
+> **ADR liên quan:** [ADR-028 — Competency Scoring Algorithm](../adr/028-competency-scoring.md)
+
+---
+
+## Mục lục
+
+1. [Tổng quan & Mục tiêu](#1-tổng-quan--mục-tiêu)
+2. [Phạm vi & Truy vết FR-1..FR-6](#2-phạm-vi--truy-vết-fr-1fr-6)
+3. [Mô hình dữ liệu (FR-1)](#3-mô-hình-dữ-liệu-fr-1)
+4. [Kiến trúc module `competency` (FR-4)](#4-kiến-trúc-module-competency-fr-4)
+5. [Thuật toán suy luận competency level (FR-2)](#5-thuật-toán-suy-luận-competency-level-fr-2)
+6. [Thiết kế OTP → Redis + gửi email (FR-3)](#6-thiết-kế-otp--redis--gửi-email-fr-3)
+7. [`parseCandidateCsv` & contract-check `getResults` (FR-5)](#7-parsecandidatecsv--contract-check-getresults-fr-5)
+8. [Project hygiene (FR-6)](#8-project-hygiene-fr-6)
+9. [Bảo mật & Kiểm thử](#9-bảo-mật--kiểm-thử)
+10. [Feature-flag / Rollout](#10-feature-flag--rollout)
+11. [Open questions](#11-open-questions)
+
+---
+
+## 1. Tổng quan & Mục tiêu
+
+Sprint 0 là sprint **nền tảng / de-risking** cho sáng kiến **Enterprise Organization** — gồm hai năng lực lõi:
+
+- **Employee Competency Assessment** — đánh giá năng lực nhân viên hiện hữu theo khung năng lực (competency) của tổ chức.
+- **Entry-selection Hiring** — sàng lọc ứng viên đầu vào dựa trên kết quả assessment, xếp hạng và quyết định tuyển dụng.
+
+Mục tiêu của Sprint 0 **không phải** là giao tính năng người dùng cuối mà là **gỡ rủi ro kỹ thuật** và **dựng khung** để các sprint sau xây tính năng trên nền ổn định:
+
+1. Đặt **mô hình dữ liệu competency** (additive, zero-downtime) làm xương sống cho cả assessment lẫn hiring.
+2. Chốt **thuật toán suy luận competency level** (xem ADR-003) ở dạng pure function, có unit test, không phụ thuộc tầng I/O.
+3. Đưa **OTP store** từ in-memory `Map` (chỉ đúng trên 1 pod) sang **Redis** (đúng trên multi-pod) và nối **gửi OTP qua email thật** (hiện đang là stub `console.log`).
+4. **Scaffold module `competency`** ở cả backend (NestJS) và frontend (service + route + sidebar) theo đúng pattern hiện có, để các sprint sau "điền" logic mà không phải dựng lại khung.
+5. Tách **util parse CSV ứng viên** dùng chung và **kiểm tra contract** của `getResults` (ranking) để tránh nợ kỹ thuật khi mở rộng.
+6. **Project hygiene** — chuẩn hóa quy trình (CI, migration, env validation) để các enabler trên không tạo drift.
+
+### 1.1 Nguyên tắc thiết kế xuyên suốt
+
+| Nguyên tắc                   | Áp dụng                                                                                                       |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| **Additive-only schema**     | 4 model mới, không sửa/không drop cột model cũ → migration zero-downtime                                      |
+| **Mirror existing patterns** | Module `competency` sao chép cấu trúc `org-questions/`; guard `OrgRoleGuard` + decorator `@OrgRoles`          |
+| **Pure core, thin shell**    | Logic chấm điểm là pure function thuần (test được, không I/O); service chỉ điều phối                          |
+| **Reuse stored data**        | v0 tái dùng `domainScores` đã lưu thay vì re-fetch raw answers (xem ADR-003)                                  |
+| **Multi-pod correctness**    | Mọi state runtime (OTP) phải nằm ở Redis, không nằm trong process memory                                      |
+| **TS loose**                 | Tôn trọng `noImplicitAny: false` / `strictNullChecks: false` của repo — không thêm strictness không cần thiết |
+
+---
+
+## 2. Phạm vi & Truy vết FR-1..FR-6
+
+Sprint 0 gồm **6 enabler issue**, ánh xạ 1:1 với FR-1..FR-6 (SRS đang viết song song dùng cùng mapping):
+
+| FR       | Issue       | Tên enabler                      | Deliverable chính                                                                         | Mục                                                          |
+| :------- | :---------- | :------------------------------- | :---------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
+| **FR-1** | S0-1 (#123) | Prisma data model                | 4 model + migration (Competency, CompetencyDomain, QuestionCompetency, JobRoleCompetency) | [§3](#3-mô-hình-dữ-liệu-fr-1)                                |
+| **FR-2** | S0-2 (#124) | Scoring algorithm                | `inferCompetencyLevel()` pure function + unit tests                                       | [§5](#5-thuật-toán-suy-luận-competency-level-fr-2) + ADR-028 |
+| **FR-3** | S0-3 (#125) | OTP → Redis + email              | Redis-backed OTP store; gửi OTP qua `MailService`; validate SMTP env lúc khởi động        | [§6](#6-thiết-kế-otp--redis--gửi-email-fr-3)                 |
+| **FR-4** | S0-4 (#126) | Scaffold `competency` module     | BE module (controller/service/module/dto + guard) + FE service/route/sidebar              | [§4](#4-kiến-trúc-module-competency-fr-4)                    |
+| **FR-5** | S0-5 (#127) | Shared CSV util + contract-check | `parseCandidateCsv` util; xác nhận contract `getResults` cho ranking                      | [§7](#7-parsecandidatecsv--contract-check-getresults-fr-5)   |
+| **FR-6** | S0-6 (#128) | Project hygiene                  | Quy trình CI/migration/env validation                                                     | [§8](#8-project-hygiene-fr-6)                                |
+
+**Ngoài phạm vi (out of scope) Sprint 0:** UI competency hoàn chỉnh, gán Competency↔Question qua UI, dashboard hiring, tích hợp ATS bên ngoài, tính toán confidence nâng cao. Các phần này nằm trên khung do Sprint 0 dựng.
+
+---
+
+## 3. Mô hình dữ liệu (FR-1)
+
+### 3.1 ERD
+
+```mermaid
+erDiagram
+    Organization ||--o{ Competency : "định nghĩa"
+    Competency  ||--o{ CompetencyDomain : "ánh xạ tới domain"
+    Competency  ||--o{ QuestionCompetency : "liên kết câu hỏi"
+    Competency  ||--o{ JobRoleCompetency : "yêu cầu bởi role"
+    OrgQuestion ||--o{ QuestionCompetency : "thuộc competency"
+    JobRole     ||--o{ JobRoleCompetency : "yêu cầu competency"
+
+    Competency {
+        string id PK
+        string orgId FK
+        string name
+        string description
+        int    scaleMin
+        int    scaleMax
+        bool   isActive
+        datetime createdAt
+        datetime updatedAt
+    }
+    CompetencyDomain {
+        string   id PK
+        string   competencyId FK
+        string   domainName
+        string   source
+        datetime createdAt
+    }
+    QuestionCompetency {
+        string   id PK
+        string   competencyId FK
+        string   orgQuestionId FK
+        float    weight
+        datetime createdAt
+        datetime updatedAt
+    }
+    JobRoleCompetency {
+        string   id PK
+        string   jobRoleId FK
+        string   competencyId FK
+        int      requiredLevel
+        datetime createdAt
+        datetime updatedAt
+    }
+```
+
+**Vai trò từng model:**
+
+- **`Competency`** — đơn vị năng lực do org định nghĩa (vd "Cloud Networking", "Secure Coding"). `scaleMin/scaleMax` (mặc định 1–5) cho phép từng org chọn thang riêng.
+- **`CompetencyDomain`** — **cầu nối tới các key của `domainScores`** (so khớp **case-insensitive**). Đây là bảng then chốt cho thuật toán chấm điểm v0 (xem ADR-028 phương án B): một competency gom nhiều domain-name string. Trường `source` (`CompetencyDomainSource`) phân biệt hai namespace của `domainScores` key: `ORG_QUESTION_CATEGORY` (key từ `OrgQuestion.category` — `CandidateInvite.domainScores` dùng trong hiring workflow) và `PUBLIC_DOMAIN` (key từ `Domain.name` — `ExamAttempt.domainScores` dùng trong employee assessment workflow). Cùng tên domain có thể tồn tại ở cả hai namespace mà không xung đột nhờ unique constraint `(competencyId, source, domainName)`.
+- **`QuestionCompetency`** — liên kết câu hỏi org (`OrgQuestion`) với competency, có `weight`. **Chưa dùng để chấm điểm ở v0**, giữ sẵn cho v1 (chấm chính xác theo từng câu hỏi).
+- **`JobRoleCompetency`** — định nghĩa **ngưỡng năng lực yêu cầu** (`requiredLevel`) của một `JobRole` cho từng competency → dùng cho hiring (so sánh level đạt được vs level yêu cầu).
+
+### 3.2 Prisma DDL (final)
+
+> Thêm vào `backend/prisma/schema.prisma`. Quan hệ ngược (`competencies Competency[]` …) được thêm vào các model hiện hữu — đây là thay đổi **schema-only, không đổi cột vật lý** nên an toàn.
+
+```prisma
+// Enum phân biệt namespace của domainScores keys:
+// ORG_QUESTION_CATEGORY → keyed theo OrgQuestion.category (CandidateInvite.domainScores, hiring workflow)
+// PUBLIC_DOMAIN         → keyed theo Domain.name (ExamAttempt.domainScores, employee assessment workflow)
+enum CompetencyDomainSource {
+  ORG_QUESTION_CATEGORY
+  PUBLIC_DOMAIN
+}
+
+model Competency {
+  id          String   @id @default(uuid())
+  orgId       String   @map("org_id")
+  name        String
+  description String?
+  scaleMin    Int      @default(1)  @map("scale_min")
+  scaleMax    Int      @default(5)  @map("scale_max")
+  isActive    Boolean  @default(true) @map("is_active")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  organization Organization         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  domains      CompetencyDomain[]
+  questions    QuestionCompetency[]
+  jobRoles     JobRoleCompetency[]
+
+  @@unique([orgId, name])
+  @@index([orgId])
+  @@map("competencies")
+}
+
+model CompetencyDomain {
+  id           String                 @id @default(uuid())
+  competencyId String                 @map("competency_id")
+  domainName   String                 @map("domain_name") @db.VarChar(200)
+  source       CompetencyDomainSource @default(ORG_QUESTION_CATEGORY) @map("source")
+  createdAt    DateTime               @default(now()) @map("created_at")
+
+  competency Competency @relation(fields: [competencyId], references: [id], onDelete: Cascade)
+
+  // Unique per (competencyId, source, domainName) — cho phép cùng tên domain tồn tại ở cả hai namespace
+  @@unique([competencyId, source, domainName])
+  @@index([competencyId])
+  @@map("competency_domains")
+}
+
+model QuestionCompetency {
+  id            String   @id @default(uuid())
+  competencyId  String   @map("competency_id")
+  orgQuestionId String   @map("org_question_id")
+  weight        Float    @default(1)
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  competency  Competency  @relation(fields: [competencyId], references: [id], onDelete: Cascade)
+  orgQuestion OrgQuestion @relation(fields: [orgQuestionId], references: [id], onDelete: Cascade)
+
+  @@unique([competencyId, orgQuestionId])
+  @@index([orgQuestionId])
+  @@map("question_competencies")
+}
+
+model JobRoleCompetency {
+  id            String   @id @default(uuid())
+  jobRoleId     String   @map("job_role_id")
+  competencyId  String   @map("competency_id")
+  requiredLevel Int      @map("required_level")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  jobRole    JobRole    @relation(fields: [jobRoleId], references: [id], onDelete: Cascade)
+  // Restrict: không cho xóa Competency khi còn JobRole đang tham chiếu; dùng isActive=false để retire
+  competency Competency @relation(fields: [competencyId], references: [id], onDelete: Restrict)
+
+  @@unique([jobRoleId, competencyId])
+  @@index([competencyId])
+  @@map("job_role_competencies")
+}
+```
+
+**Quan hệ ngược cần thêm vào model hiện hữu (chỉ tồn tại ở tầng Prisma, không phát sinh DDL):**
+
+```prisma
+// model Organization  (L806)
+competencies Competency[]
+
+// model OrgQuestion   (L908)
+competencyLinks QuestionCompetency[]
+
+// model JobRole       (L1031)
+competencyReqs JobRoleCompetency[]
+```
+
+### 3.3 Chiến lược migration (additive, zero-downtime)
+
+| Khía cạnh          | Quyết định                                                                                                                                                                                                                                      |
+| :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Loại migration** | **Additive-only** — chỉ `CREATE TABLE` + `CREATE INDEX`. Không `ALTER`/`DROP` cột của bảng cũ → không khóa bảng nóng, không downtime.                                                                                                           |
+| **Thứ tự deploy**  | (1) chạy migration tạo bảng mới → (2) deploy code đọc/ghi bảng mới. Vì code cũ không tham chiếu bảng mới nên hai bước **độc lập, có thể rollback từng bước**.                                                                                   |
+| **Cascade rules**  | `onDelete: Cascade` ở mọi FK: xóa Organization → dọn Competency → dọn CompetencyDomain/QuestionCompetency/JobRoleCompetency; xóa OrgQuestion → dọn QuestionCompetency; xóa JobRole → dọn JobRoleCompetency. Không để dữ liệu mồ côi.            |
+| **Index**          | `@@index([orgId])` (list theo org), `@@index([competencyId])` (join từ competency), `@@index([orgQuestionId])` (impact khi xóa question). Mọi `@@unique` cũng tạo index ngầm phục vụ idempotent upsert.                                         |
+| **Backfill**       | **Không cần** — bảng mới rỗng, không có dữ liệu lịch sử để di trú.                                                                                                                                                                              |
+| **Lệnh**           | `npx prisma migrate dev --name s0_competency_models` (dev) → migration SQL được commit và chạy ở môi trường cao hơn qua `prisma migrate deploy`. **Bắt buộc** chạy `npm install` (postinstall → `prisma generate`) trên worktree mới (US-1111). |
+
+---
+
+## 4. Kiến trúc module `competency` (FR-4)
+
+### 4.1 Cây file backend (mirror `org-questions/`)
+
+```
+backend/src/competency/
+├── competency.module.ts
+├── competency.controller.ts
+├── competency.service.ts
+└── dto/
+    ├── create-competency.dto.ts
+    ├── update-competency.dto.ts
+    ├── list-competencies.dto.ts
+    ├── map-domain.dto.ts                # gắn domainName vào competency
+    └── set-job-role-requirement.dto.ts
+```
+
+Module đăng ký trong `app.module.ts` (`AppModule → CompetencyModule`), import `PrismaModule`. Controller dùng `@UseGuards(OrgRoleGuard)` ở cấp class (giống `OrgQuestionsController`), `@SkipThrottle()`, `@ApiTags('competency')`, `@ApiBearerAuth()`.
+
+> **Lưu ý đường dẫn:** Đề bài mô tả endpoint dưới `/orgs/:slug/competencies`. Các controller org hiện hữu (`org-questions`, `organizations`) dùng base **`organizations/:orgId/...`** với `OrgRoleGuard` đã resolve **cả `:orgId` lẫn `:slug`** (xem guard: `OR: [{ orgId }, { organization: { slug: orgId } }]`). Để **không tạo pattern thứ hai**, scaffold dùng base `organizations/:orgId/competencies` cho nhất quán; tham số `:orgId` chấp nhận cả slug. (Xem [Open questions](#11-open-questions) #1.)
+
+### 4.2 Bảng REST endpoints
+
+Base: `organizations/:orgId/competencies` (`:orgId` = id **hoặc** slug). Tất cả yêu cầu JWT + là member của org.
+
+| Method   | Path (dưới base) | Role guard (`@OrgRoles`) | Mục đích (Sprint 0)                            |
+| :------- | :--------------- | :----------------------- | :--------------------------------------------- |
+| `GET`    | `/`              | member (any)             | List competency của org — scaffold trả `[]`    |
+| `GET`    | `/:competencyId` | member (any)             | Chi tiết 1 competency — scaffold trả `501`     |
+| `POST`   | `/`              | `OWNER, ADMIN, MANAGER`  | Tạo competency — scaffold trả `501` (xem §10)  |
+| `PATCH`  | `/:competencyId` | `OWNER, ADMIN, MANAGER`  | Sửa metadata / `isActive` — scaffold trả `501` |
+| `DELETE` | `/:competencyId` | `OWNER, ADMIN`           | Xóa (cascade) — scaffold trả `501`             |
+
+> **Defer (Sprint 1+):** Sub-resource endpoints `/:competencyId/domains` (POST/DELETE) và `/:competencyId/job-roles/:jobRoleId` (PUT) **không mount trong Sprint 0** khi `FEATURE_COMPETENCY=false`. Thêm sau khi UI và business logic hoàn thiện ở sprint sau. Khi `FEATURE_COMPETENCY=true` (staging), chỉ 5 endpoint trên được mount.
+
+> **Read permissions:** `GET` endpoints trả dữ liệu lọc theo `isActive = true` cho RECRUITER/MEMBER; OWNER/ADMIN/MANAGER thấy cả inactive. `JwtAuthGuard` chạy **trước** `OrgRoleGuard` — không có endpoint nào bypass JWT.
+
+> Phân quyền theo `OrgRole` (OWNER/ADMIN/MANAGER/RECRUITER/MEMBER). RECRUITER/MEMBER chỉ đọc; thao tác cấu hình khung năng lực dành cho MANAGER trở lên. Đây là baseline — sprint sau có thể tinh chỉnh.
+
+### 4.3 DTO (class-validator)
+
+```ts
+// create-competency.dto.ts
+export class CreateCompetencyDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(1000)
+  description?: string;
+
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  scaleMin?: number; // default 1
+
+  @IsInt()
+  @Max(10)
+  @IsOptional()
+  scaleMax?: number; // default 5
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  domainNames?: string[]; // tiện ích: map domain ngay khi tạo
+}
+
+// map-domain.dto.ts
+export class MapDomainDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  domainName: string;
+}
+
+// set-job-role-requirement.dto.ts
+export class SetJobRoleRequirementDto {
+  @IsInt()
+  @Min(1)
+  requiredLevel: number; // validate ≤ scaleMax ở service layer
+}
+```
+
+### 4.4 Frontend
+
+- **`src/services/competency.ts`** — service Axios mirror các `src/services/*.ts` khác; dùng instance chung trong `api.ts` (JWT injection + 401 refresh sẵn có). Hàm: `listCompetencies(orgId)`, `getCompetency(orgId, id)`, `createCompetency`, `updateCompetency`, `deleteCompetency`, `mapDomain`, `setJobRoleRequirement`. Tiêu thụ qua TanStack Query (`useQuery`/`useMutation`, `queryKey: ['competencies', orgId]`).
+- **Route** — thêm trang lazy-loaded dưới `/org/:slug/competencies` trong `App.tsx`, bọc `<ProtectedRoute>` + `<PageTransition>`.
+- **`src/components/org/OrgSidebar.tsx`** — thêm mục "Competencies" (ẩn sau feature-flag, xem §10).
+
+---
+
+## 5. Thuật toán suy luận competency level (FR-2)
+
+Chi tiết quyết định và đặc tả hàm thuần nằm trong **[ADR-028 — Competency Scoring](../adr/028-competency-scoring.md)**. Tóm tắt cho basic design:
+
+- **Vị trí:** pure function trong `backend/src/competency/scoring/infer-competency-level.ts` — **không phụ thuộc Prisma/HTTP**, nhận tham số đã chuẩn bị sẵn, dễ unit test.
+- **Chữ ký (canonical — xem ADR-028):**
+  ```ts
+  inferCompetencyLevel(
+    domainScores: Record<string, { correct: number; total: number }>,
+    mappedDomains: string[],
+    options: { scaleMin: number; scaleMax: number; thresholds: Threshold[] },
+  ): { level: number; percentage: number; confidence: 'LOW' | 'MEDIUM' | 'HIGH'; sampleSize: number; matchedDomains: string[] };
+  ```
+- **Cách tính (v0 — phương án B):** `percentage = Σcorrect / Σtotal` trên các domain (case-insensitive) thuộc `mappedDomains`, rồi bucket vào level theo bảng ngưỡng. Không re-fetch raw answers.
+- **Nguồn `domainScores`:** đã được tính sẵn khi nộp bài (`candidate.service.ts submitAttempt` L197–223, `org-analytics getSkillGaps` L179), shape `Record<string,{correct,total}>` keyed theo tên domain/category.
+
+Service layer chịu trách nhiệm: lấy `CompetencyDomain.domainName[]` của competency → đọc `CandidateInvite.domainScores` (hoặc `ExamAttempt.domainScores`) → gọi pure function → trả kết quả. Toàn bộ logic chấm điểm "thật" được kết nối ở sprint sau; Sprint 0 chỉ giao **pure function + test**.
+
+---
+
+## 6. Thiết kế OTP → Redis + gửi email (FR-3)
+
+### 6.1 Vấn đề hiện tại
+
+`candidate.service.ts:19` lưu OTP trong **in-memory `Map`** (`otpStore`). Trên môi trường multi-pod (production scale-out), OTP set ở pod A không đọc được ở pod B → verify fail ngẫu nhiên. Ngoài ra `requestOtp` **chưa gửi email thật** (chỉ `console.log` masked email, L71–74 là TODO).
+
+### 6.2 Redis key scheme
+
+| Thuộc tính               | Giá trị                                                                                                                                   |
+| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Key OTP**              | `otp:{inviteId}` → sha256 hash của code (không lưu code thô)                                                                              |
+| **Lệnh ghi OTP**         | `SETEX otp:{inviteId} 600 {hash}` (TTL = 600s = 10 phút)                                                                                  |
+| **Lệnh verify (atomic)** | `GETDEL otp:{inviteId}` (Redis 7) — đọc và xóa nguyên tử; chống race condition GET+DEL; key vắng sau khi verify                           |
+| **TTL OTP**              | Redis tự expire → loại bỏ logic `expiresAt` thủ công; vắng key ⇒ "chưa request hoặc đã hết hạn"                                           |
+| **Key counter**          | `otp:attempts:{inviteId}` → số lần verify sai; `INCR` mỗi lần sai; `EXPIRE 600` sau mỗi lần ghi                                           |
+| **Key lock**             | `otp:locked:{inviteId}` → `SETEX otp:locked:{inviteId} 3600 "1"` khi counter ≥ 5; `GET` để chặn verify/request mới; TTL 1 giờ             |
+| **Fail-CLOSED Redis**    | Nếu Redis không thể kết nối → `requestOtp`/`verifyOtp` trả **503** (không fallback về in-memory); ghi log alert và trả lỗi rõ ràng cho FE |
+
+### 6.3 Wiring Redis client provider
+
+Repo **đã có ioredis** dùng trực tiếp ở `backend/src/mastery/mastery.service.ts` (`new Redis({ host: REDIS_HOST, port: REDIS_PORT })`) và qua BullMQ ở `queues.module.ts`. **Không cần thêm dependency.** Để tránh mỗi service tự `new Redis()` (rải rác config, nhiều kết nối), Sprint 0 chuẩn hóa:
+
+- Tạo **`RedisModule` (@Global)** với provider `REDIS_CLIENT` export một instance `ioredis` duy nhất cấu hình từ `REDIS_HOST`, `REDIS_PORT`, **`REDIS_PASSWORD`** (bắt buộc có trong ConfigModule validation schema). Thiếu `REDIS_PASSWORD` trên môi trường production → fail-fast lúc bootstrap.
+- `CandidateService` inject `REDIS_CLIENT` thay cho `Map`.
+- (Cleanup theo sau — không bắt buộc trong Sprint 0): `mastery.service.ts` chuyển sang dùng provider chung. Ghi nhận như hygiene item (FR-6).
+
+### 6.4 Sequence — request & verify
+
+```mermaid
+sequenceDiagram
+    participant FE as Candidate (FE)
+    participant API as CandidateService
+    participant R as Redis
+    participant M as MailService
+
+    Note over FE,M: requestOtp(token)
+    FE->>API: POST /assess/:token/otp/request
+    API->>API: resolve invite, check requireOtp
+    API->>R: GET otp:locked:{inviteId}
+    alt locked (≥5 lần sai)
+        R-->>API: "1"
+        API-->>FE: 429 "Too many failed attempts"
+    else not locked
+        API->>API: code = crypto.randomInt(100000,1000000)
+        API->>API: hash = sha256(code)
+        API->>R: SETEX otp:{inviteId} 600 {hash}
+        API->>M: sendEmail({ to, subject: "Mã OTP", html: code })
+        alt mail fail
+            M-->>API: error
+            API->>API: Logger.error OTP_MAIL_FAILED (no code, masked email)
+        end
+        API-->>FE: { message: "OTP sent" }
+    end
+
+    Note over FE,M: verifyOtp(token, code)
+    FE->>API: POST /assess/:token/otp/verify { code }
+    API->>R: GET otp:locked:{inviteId}
+    alt locked
+        R-->>API: "1"
+        API-->>FE: 429 "Too many failed attempts"
+    else not locked
+        API->>R: GETDEL otp:{inviteId}
+        alt key vắng (expired / never requested)
+            R-->>API: nil
+            API-->>FE: 400 "No OTP or expired — request new"
+        else key tồn tại
+            R-->>API: {hash}
+            API->>API: timingSafeEqual(sha256(code.trim()), hash) ?
+            alt khớp
+                API->>API: update otpVerifiedAt = now()
+                API-->>FE: { verified: true }
+            else không khớp
+                API->>R: INCR otp:attempts:{inviteId}
+                API->>R: EXPIRE otp:attempts:{inviteId} 600
+                API->>R: attempts ≥ 5 ? SETEX otp:locked:{inviteId} 3600 "1"
+                API-->>FE: 400 "Invalid OTP"
+            end
+        end
+    end
+```
+
+### 6.5 Gửi OTP qua MailService
+
+- Dùng `MailService.sendEmail({ to, subject, html })` (đã có, `@Global MailModule`). Inject `MailService` vào `CandidateService`.
+- Template HTML tối giản, hiển thị code lớn, có cảnh báo hết hạn 10 phút và "không chia sẻ code":
+  ```html
+  <h2>Mã xác thực của bạn</h2>
+  <p>Mã OTP để bắt đầu bài đánh giá:</p>
+  <p style="font-size:28px;font-weight:bold;letter-spacing:4px;">{code}</p>
+  <p>Mã có hiệu lực trong 10 phút. Không chia sẻ mã này với bất kỳ ai.</p>
+  ```
+- **Tuyệt đối không log code** (giữ nguyên nguyên tắc Fix #3). Chỉ log masked email khi cần truy vết. `sendEmail` đã nuốt lỗi và log qua `Logger` — đảm bảo error path không leak code.
+- **Khi gửi mail thất bại:** ghi log có cấu trúc `OTP_MAIL_FAILED` với event, masked email, và inviteId (không có code/hash) để alert theo dõi được. Fail-open (không block flow tạo OTP) nhất quán với pattern `try/catch` của các mail khác — ghi nhận trade-off trong PR.
+- **HTML template:** chỉ chứa code OTP. Các field có nội dung từ người dùng (tên, email) phải HTML-escape trước khi nhúng vào template; strip CRLF khỏi subject line để chống header injection.
+
+### 6.6 Loại bỏ in-memory Map & validate SMTP env
+
+- Xóa `const otpStore = new Map(...)` và mọi `otpStore.get/set/delete`; logic so sánh `expiresAt` thủ công không còn cần (Redis TTL lo).
+- **Validate env lúc khởi động (ConfigModule validation schema):** kiểm tra `MAIL_HOST`, `MAIL_PORT`, `MAIL_USER`, `MAIL_PASS`, `MAIL_FROM`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` hiện diện khi `NODE_ENV !== 'test'`. Không dùng fallback giá trị mặc định cho các biến này (dẫn đến "im lặng mà sai"). Fail-fast với thông báo rõ ràng nếu thiếu — tránh tình huống OTP "gửi thành công" nhưng email không bao giờ tới do SMTP rỗng, hoặc OTP lưu in-memory do Redis thiếu config.
+
+---
+
+## 7. `parseCandidateCsv` & contract-check `getResults` (FR-5)
+
+### 7.1 `parseCandidateCsv` util
+
+- **Vị trí:** `backend/src/common/csv/parse-candidate-csv.ts` (pure util, không phụ thuộc Nest).
+- **Lý do tách:** logic parse CSV ứng viên hiện đang nằm lẫn trong bulk-invite (`organizations.controller.ts:113` → service). Tách dùng chung cho cả org member bulk-invite **và** candidate assessment invite, tránh drift.
+- **Chữ ký:**
+  ```ts
+  interface ParsedCandidate {
+    email: string;
+    name?: string;
+  }
+  interface ParseCandidateCsvResult {
+    valid: ParsedCandidate[];
+    invalid: { row: number; raw: string; reason: string }[];
+    duplicatesRemoved: number;
+  }
+  function parseCandidateCsv(input: string): ParseCandidateCsvResult;
+  ```
+- **Validation:**
+  - Header linh hoạt: nhận cột `email` (bắt buộc), `name`/`candidateName` (tùy chọn); bỏ qua cột thừa.
+  - Validate email bằng regex/Zod; dòng sai → đẩy vào `invalid` kèm `row` + `reason` (không ném làm hỏng cả batch).
+  - Trim mọi field; bỏ dòng rỗng.
+- **Dedupe:** chuẩn hóa email về **lowercase + trim**, loại trùng (giữ lần xuất hiện đầu), đếm `duplicatesRemoved`.
+- **Giới hạn:** áp `MAX_ROWS` (vd 1000) để chặn payload lạm dụng; vượt ngưỡng → ném `BadRequestException` ở tầng gọi.
+
+### 7.2 Contract-check `getResults`
+
+Đã xác nhận `assessments.service.ts:614 getResults(slugOrId, assessmentId)` trả về contract phục vụ **ranking**:
+
+```ts
+{
+  assessment,                          // kèm jobRole
+  funnel: { total, started, submitted, passed },
+  candidates: Array<CandidateInvite & { percentile: number | null }>
+}
+```
+
+- `candidates` đã **sort `score desc, createdAt asc`** (orderBy ở query) — thứ tự ranking ổn định, tie-break theo thời gian nộp.
+- `percentile` tính trên tập `SUBMITTED`; non-submitted → `null` (không lẫn vào xếp hạng). Công thức `below/(submittedCount-1)*100`, trường hợp 1 ứng viên → 100.
+- `passed` chỉ tính khi `passingScore != null`.
+
+**Kết luận contract-check:** contract đủ cho ranking entry-selection v0 — có thứ tự, có percentile, có funnel. **Khuyến nghị (không bắt buộc Sprint 0):** khi nối competency vào hiring, bổ sung trường `competencyLevels` per-candidate vào `candidates[]`; cần đảm bảo `percentile` được tính **độc lập với** field bổ sung này (đừng để thêm field phá tie-break). Ghi nhận làm spec cho sprint sau.
+
+---
+
+## 8. Project hygiene (FR-6)
+
+Cover ngắn gọn — đây là enabler quy trình, không phải tính năng:
+
+| Hạng mục                 | Hành động                                                                                                     |
+| :----------------------- | :------------------------------------------------------------------------------------------------------------ |
+| **Worktree init**        | Tài liệu hóa `npm install` trong `backend/` trước khi chạy test (postinstall → `prisma generate`, US-1111).   |
+| **Migration discipline** | Mọi schema change qua `prisma migrate`, commit file migration; cấm `db push` lên môi trường chia sẻ.          |
+| **Env validation**       | Schema-validate biến môi trường bắt buộc (SMTP, Redis, JWT) lúc bootstrap (liên kết §6.6).                    |
+| **Redis client**         | Một provider `REDIS_CLIENT` dùng chung; ghi nhận chuyển `mastery.service.ts` sang provider chung như cleanup. |
+| **CI gate**              | Lint + `tsc --noEmit` + Jest cho backend; Vitest cho FE chạy trên PR đụng `competency`/`candidate`.           |
+| **Dead-code/flag**       | Scaffold trả `501` được gắn feature-flag (xem §10) để không lộ endpoint chưa hoàn thiện ra production.        |
+
+---
+
+## 9. Bảo mật & Kiểm thử
+
+### 9.1 Bảo mật
+
+| Mối lo                     | Biện pháp                                                                                                                                                                                                            |
+| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **OTP brute-force**        | **Bắt buộc Sprint 0:** counter `otp:attempts:{inviteId}` (INCR, EXPIRE 600s); khóa invite sau 5 lần sai (`otp:locked:{inviteId}`, SETEX 3600s); verify/request khi locked → 429. Xem §6.2 và §6.4.                   |
+| **OTP leak qua log**       | Không bao giờ log code; chỉ log masked email. Log `OTP_MAIL_FAILED` có cấu trúc (event, masked email, inviteId) — không chứa code hoặc hash. Error path của `sendEmail` không in code.                               |
+| **OTP timing-safe**        | So sánh hash bằng `crypto.timingSafeEqual(Buffer.from(expectedHash), Buffer.from(providedHash))` — không dùng `===` string comparison (vulnerable to timing attacks).                                                |
+| **OTP atomic GETDEL**      | Dùng `GETDEL otp:{inviteId}` (Redis 7) thay GET+DEL riêng lẻ — loại bỏ TOCTOU race condition giữa 2 request verify đồng thời.                                                                                        |
+| **Multi-tenant isolation** | Mọi truy vấn competency service phải include `orgId` trong `where` clause (không chỉ dựa vào guard); service phải kiểm tra `JobRole.orgId === Competency.orgId` khi tạo `JobRoleCompetency`. IDOR → 404 (không 403). |
+| **RBAC**                   | Thao tác cấu hình khung năng lực giới hạn MANAGER↑; xóa giới hạn ADMIN↑. `JwtAuthGuard` luôn chạy trước `OrgRoleGuard`.                                                                                              |
+| **Input validation**       | DTO class-validator ở mọi endpoint; CSV: `MAX_ROWS = 1000`, file size ≤ 5 MB, sanitize giá trị có thể gây formula injection khi export (prefix `'` nếu bắt đầu bằng `=`,`+`,`-`,`@`).                                |
+| **Injection**              | Prisma parameterized; không nối chuỗi query.                                                                                                                                                                         |
+| **Secrets in env**         | `REDIS_PASSWORD`, `MAIL_PASS`, `JWT_SECRET` không bao giờ log; validate hiện diện lúc bootstrap (§6.6); thêm vào `.env.example` với placeholder.                                                                     |
+
+### 9.2 Kiểm thử (mục tiêu ≥80% coverage)
+
+| Loại                             | Phạm vi                                                                                                                                     |
+| :------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Unit — scoring**               | `inferCompetencyLevel()`: các case trong ADR-028 (no data, partial overlap, case-insensitive, đủ bucket level, confidence LOW/MEDIUM/HIGH). |
+| **Unit — CSV**                   | `parseCandidateCsv`: email hợp lệ/sai, dedupe, header biến thể, dòng rỗng, vượt `MAX_ROWS`.                                                 |
+| **Integration — OTP**            | request→verify happy path (Redis), expired (giả lập TTL), invalid code, key vắng, multi-pod (2 client ioredis cùng key).                    |
+| **Integration — competency API** | RBAC (RECRUITER bị 403 khi POST), cascade delete, `@@unique` conflict → 409.                                                                |
+| **Contract — getResults**        | snapshot shape `{assessment, funnel, candidates[]}`, thứ tự sort, percentile edge (0/1/n ứng viên).                                         |
+
+---
+
+## 10. Feature-flag / Rollout
+
+Vì Sprint 0 chỉ giao **khung rỗng**, cần tránh lộ chức năng nửa vời:
+
+- **Env flag** `FEATURE_COMPETENCY=false` (mặc định off ở prod).
+- Khi off:
+  - **Backend:** `CompetencyController` vẫn mount nhưng các handler ghi (POST/PATCH/DELETE) trả **`501 Not Implemented`**; GET trả list rỗng. (Hoặc không đăng ký route ghi — tùy chọn an toàn hơn.)
+  - **Frontend:** mục sidebar "Competencies" và route ẩn khi flag off.
+- **Rollout:** bật flag trên staging trước → smoke test RBAC + OTP-on-Redis → bật theo từng org (nếu cần) qua org-setting ở sprint sau.
+- **OTP→Redis & email** **không** đặt sau flag — đây là sửa lỗi đúng đắn (multi-pod correctness + gửi email thật), cần bật ngay sau khi qua test.
+
+---
+
+## 11. Open questions
+
+Các mục còn mở để Architect / PO chốt trước khi implement:
+
+1. **Base path `:slug` vs `:orgId`** — pattern hiện hữu là `organizations/:orgId/...` (guard resolve cả id và slug). Đề xuất dùng base cũ cho nhất quán. **Cần Architect chốt.**
+2. ~~**Số hiệu ADR trùng**~~ — **Đã giải quyết:** file đổi thành `028-competency-scoring.md`; `00-index.md` đã cập nhật.
+3. ~~**OTP rate-limit**~~ — **Đã giải quyết:** counter + lockout bắt buộc trong Sprint 0 (xem §6.2, §6.4, §9.1).
+4. **Redis provider chung vs per-service** — `mastery.service.ts` đang tự `new Redis()`. Migrate ngay sang `REDIS_CLIENT` provider hay để cleanup sau Sprint 0? **Architect quyết.** (Đề xuất: ghi nhận làm FR-6 hygiene, không bắt buộc Sprint 0.)
+5. ~~**Scale thresholds per-org**~~ — **Đã giải quyết bởi ADR-028:** v0 giới hạn thang 1–5; `thresholds` là tham số đầu vào (không hardcode); multi-scale để ngỏ cho v1.
+6. **`domainScores` dual namespace** — service layer cần quyết định khi nào dùng `CandidateInvite.domainScores` (hiring) vs `ExamAttempt.domainScores` (employee assessment). Model `CompetencyDomain.source` đã phân biệt hai namespace (§3.2). **Cần xác nhận mapping logic ở sprint sau.**

--- a/docs/specs/sprint-0-foundation-srs.md
+++ b/docs/specs/sprint-0-foundation-srs.md
@@ -1,0 +1,411 @@
+# SRS — Sprint 0: Foundation (Competency & De-risking)
+
+|                      |                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tài liệu**         | Software Requirements Specification (SRS)                                                                                                         |
+| **Tính năng**        | Sprint 0 — Foundation                                                                                                                             |
+| **Phiên bản**        | 1.0 (Draft)                                                                                                                                       |
+| **Ngày**             | 2026-06-14                                                                                                                                        |
+| **Trạng thái**       | Draft                                                                                                                                             |
+| **Phụ thuộc**        | P0 (Smart Assessment Builder), P1 (Recruiting Workflow) — đã có; ADR-003 (suy luận competency level) phải được ratify trước khi merge FR-1        |
+| **Module liên quan** | `competency` (mới), `assessments`, `organizations`, `mail`, `org-analytics` (backend) · `src/services/competency.ts`, `OrgSidebar.tsx` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Tài liệu này đặc tả yêu cầu cho **Sprint 0 — Foundation**, sprint nền tảng & de-risking cho sáng kiến **Organization Enterprise** (đánh giá năng lực nhân sự — _employee competency assessment_ — và tuyển chọn đầu vào — _entry-selection hiring_).
+
+Sprint 0 **không** giao một tính năng end-user hoàn chỉnh. Mục tiêu là dựng các _enabler_ (data model, thuật toán cốt lõi, hạ tầng, scaffold module, util dùng chung, quy trình) để các sprint sau xây dựng bảng năng lực (competency matrix), xếp hạng ứng viên theo năng lực, và gating tuyển dụng mà không phải làm lại nền móng. Mỗi yêu cầu chức năng FR ánh xạ 1–1 với một enabler issue (S0-1…S0-6).
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+
+- **FR-1 (S0-1, #123)**: Data model Prisma cho `Competency`, `CompetencyDomain`, `QuestionCompetency`, `JobRoleCompetency` + migration.
+- **FR-2 (S0-2, #124)**: Spike thuật toán suy luận competency level (1–5) từ `domainScores` JSON → ADR-003 + pure function `inferCompetencyLevel()` có unit test.
+- **FR-3 (S0-3, #125)**: Chuyển OTP store từ in-memory `Map` → Redis; gửi OTP email thật qua `MailService` (hiện đang là stub TODO); validate biến môi trường SMTP lúc khởi động.
+- **FR-4 (S0-4, #126)**: Scaffold NestJS module `competency` (controller/service/module/DTO + `OrgRoleGuard`) + frontend `src/services/competency.ts` + route + entry trong `OrgSidebar` (rỗng / feature-flagged, biên dịch được).
+- **FR-5 (S0-5, #127)**: Tách util dùng chung `parseCandidateCsv`; contract-check `getResults` trả về đủ field cho bảng xếp hạng ứng viên.
+- **FR-6 (S0-6, #128)**: Project hygiene — Definition of Done, branch/PR conventions, board (chỉ quy trình, không code).
+
+**Ngoài phạm vi (để cho các sprint sau):**
+
+- UI competency matrix thật (CRUD competency, gắn question/domain, bảng năng lực ứng viên).
+- Tính & hiển thị competency level cho ứng viên/nhân viên thực tế (chỉ _pure function_ trong Sprint 0, chưa wire vào endpoint).
+- Gating tuyển dụng theo `requiredLevel` của `JobRoleCompetency`.
+- Recompute điểm ở mức câu hỏi (question-level) — Sprint 0 chốt v0 dùng aggregation theo `domainScores` (xem FR-2).
+- Migration dữ liệu lịch sử để gán competency cho question/job-role đã tồn tại.
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ              | Ý nghĩa                                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Competency**         | Một năng lực được đặt tên trong phạm vi một org (vd "Backend Engineering", "Data Analysis"), thang điểm `scaleMin..scaleMax` (mặc định 1–5) |
+| **CompetencyDomain**   | Bản ghi bắc cầu một competency tới một _key_ trong `domainScores` (tên domain/category); một competency có thể gom nhiều domain             |
+| **QuestionCompetency** | Gắn một `OrgQuestion` vào một competency với `weight` — dùng cho chấm điểm mức câu hỏi ở các sprint sau (Sprint 0 chỉ tạo schema)           |
+| **JobRoleCompetency**  | Mức năng lực yêu cầu (`requiredLevel`) của một competency đối với một `JobRole` — phục vụ gating tuyển dụng sau này                         |
+| **Competency level**   | Số nguyên trong `[scaleMin..scaleMax]` suy ra từ `domainScores` qua `inferCompetencyLevel()`                                                |
+| **`domainScores`**     | JSON `Record<string, { correct: number; total: number }>`, key là tên domain/category; có trên `CandidateInvite` và `ExamAttempt`           |
+| **OTP**                | Mã 6 chữ số xác thực ứng viên trước khi làm bài (TTL 10 phút, lưu sha256-hash)                                                              |
+| **Enabler**            | Hạng mục nền tảng/de-risk không phải user story; tạo điều kiện cho story sau                                                                |
+| **ADR-003**            | Architecture Decision Record chốt thuật toán suy luận competency level và lựa chọn v0 (domainScores aggregation)                            |
+
+### 1.4. Hiện trạng (trước Sprint 0)
+
+- **Chưa có** khái niệm competency: schema chỉ có `Organization`, `OrgMember`, `OrgQuestion` (`category String?`, `tags String[]`), `JobRole`, `Assessment`, `CandidateInvite` (`domainScores Json`, `integrityScore`, `otpVerifiedAt`), `ExamAttempt`, `Domain`.
+- **OTP** lưu trong `Map` in-memory tại `backend/src/assessments/candidate.service.ts:19` — mất khi restart và **không** chia sẻ giữa nhiều pod. Việc gửi email OTP mới là **stub TODO** (`candidate.service.ts:73`): chỉ `console.log` email đã mask, chưa gọi `MailService`.
+- **`MailService`** (`backend/src/mail/mail.service.ts`) đã có transporter nodemailer thật và các hàm `sendEmail`/`sendOrgInvite`/`sendAssessmentInvite`/`sendExamAssigned` — nhưng chưa có hàm gửi OTP và chưa validate biến SMTP lúc khởi động.
+- **Redis 7** đã có trong stack (đang dùng cho BullMQ tại `backend/src/queues/*`) — sẵn sàng tái sử dụng cho OTP.
+- **CSV parsing** ứng viên hiện nằm rải rác phía client (xem P1 `CsvImportModal`), chưa có util thuần dùng chung, khó viết unit test.
+- **`getResults`** (`backend/src/assessments/assessments.service.ts:614`) đã trả `funnel` + `candidates[]` nhưng chưa được "đóng băng" bằng contract test cho nhu cầu xếp hạng năng lực sắp tới.
+- **Quy trình** Definition of Done / branch / PR / board cho sáng kiến Enterprise chưa được thống nhất chính thức.
+
+---
+
+## 2. Mô tả tổng quan
+
+### 2.1. Bối cảnh sản phẩm
+
+Sáng kiến Enterprise mở rộng CertGym từ "luyện thi chứng chỉ" sang "đánh giá năng lực nhân sự & tuyển chọn đầu vào". Điều này cần một mô hình **competency** ổn định, một **thuật toán suy luận level** đáng tin, và hạ tầng xác thực ứng viên **multi-pod-safe**. Sprint 0 cố tình tách các rủi ro kỹ thuật này ra trước, để các sprint feature về sau chỉ tập trung vào UX/business logic trên một nền đã ratify (ADR-003) và không bị chặn bởi schema migration hay refactor hạ tầng.
+
+Nguyên tắc chủ đạo của Sprint 0: **mọi thứ phải biên dịch & xanh CI, nhưng phần lớn còn ẩn sau feature flag / chưa wire end-to-end.** Không thay đổi hành vi người dùng hiện hữu (trừ FR-3, là cải thiện độ tin cậy OTP — phải tương thích ngược).
+
+### 2.2. Nhóm người dùng & vai trò
+
+| Vai trò                    | Liên quan tới Sprint 0                                                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Owner / Admin**          | Sẽ là người quản trị competency matrix (UI ở sprint sau). Trong Sprint 0: là role được phép gọi endpoint scaffold của module `competency` (FR-4) |
+| **Manager**                | Quản lý competency & gán cho job role/assessment (sau này). Có quyền trên các endpoint competency (FR-4)                                         |
+| **Recruiter**              | Người tiêu thụ bảng xếp hạng ứng viên theo năng lực (sau này) — phụ thuộc contract `getResults` ở FR-5                                           |
+| **Candidate (ứng viên)**   | Người nhận & nhập OTP khi làm bài — trực tiếp hưởng lợi từ FR-3 (OTP tin cậy hơn, email thật)                                                    |
+| **Developer / Maintainer** | Đối tượng chính của FR-2 (pure function + ADR), FR-5 (util dùng chung) và FR-6 (quy trình)                                                       |
+
+---
+
+## 3. Yêu cầu chức năng
+
+### FR-1 — Data model Competency (S0-1, #123)
+
+**Mô tả:** Bổ sung 4 model Prisma nền tảng cho competency vào `backend/prisma/schema.prisma` + một migration. Sprint 0 chỉ tạo schema + quan hệ + index; **không** seed dữ liệu, **không** wire vào business logic.
+
+**Đầu vào / Đầu ra:**
+
+- Đầu vào: schema hiện tại (`Organization` L806, `OrgQuestion` L908, `JobRole` L1031).
+- Đầu ra: 4 model mới + migration SQL (`npx prisma migrate dev`); `npx prisma generate` sinh client không lỗi.
+
+**Mô hình dữ liệu chuẩn (provisional, ratify bởi ADR-003):**
+
+```prisma
+model Competency {
+  id          String   @id @default(uuid())
+  orgId       String   @map("org_id")
+  name        String
+  description String?
+  scaleMin    Int      @default(1) @map("scale_min")
+  scaleMax    Int      @default(5) @map("scale_max")
+  isActive    Boolean  @default(true) @map("is_active")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  organization Organization          @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  domains      CompetencyDomain[]
+  questions    QuestionCompetency[]
+  jobRoles     JobRoleCompetency[]
+
+  @@unique([orgId, name])
+  @@map("competencies")
+}
+
+model CompetencyDomain {
+  id           String @id @default(uuid())
+  competencyId String @map("competency_id")
+  domainName   String @map("domain_name") // khớp key trong domainScores (case-insensitive)
+
+  competency Competency @relation(fields: [competencyId], references: [id], onDelete: Cascade)
+
+  @@unique([competencyId, domainName])
+  @@map("competency_domains")
+}
+
+model QuestionCompetency {
+  id            String @id @default(uuid())
+  competencyId  String @map("competency_id")
+  orgQuestionId String @map("org_question_id")
+  weight        Float  @default(1)
+
+  competency  Competency  @relation(fields: [competencyId], references: [id], onDelete: Cascade)
+  orgQuestion OrgQuestion @relation(fields: [orgQuestionId], references: [id], onDelete: Cascade)
+
+  @@unique([competencyId, orgQuestionId])
+  @@map("question_competencies")
+}
+
+model JobRoleCompetency {
+  id            String @id @default(uuid())
+  jobRoleId     String @map("job_role_id")
+  competencyId  String @map("competency_id")
+  requiredLevel Int    @map("required_level")
+
+  jobRole    JobRole    @relation(fields: [jobRoleId], references: [id], onDelete: Cascade)
+  competency Competency @relation(fields: [competencyId], references: [id], onDelete: Cascade)
+
+  @@unique([jobRoleId, competencyId])
+  @@map("job_role_competencies")
+}
+```
+
+**Quy tắc nghiệp vụ:**
+
+- Competency luôn thuộc về đúng một org (`orgId`); tên duy nhất trong org (`@@unique([orgId, name])`).
+- `CompetencyDomain.domainName` bắc cầu sang **key** của `domainScores` và phải so khớp **case-insensitive** khi chấm điểm (chuẩn hóa lúc đọc, không lúc ghi).
+- `requiredLevel`, `scaleMin`, `scaleMax` là số nguyên; ràng buộc `scaleMin <= requiredLevel <= scaleMax` được kiểm ở tầng service các sprint sau (không phải DB constraint trong Sprint 0).
+- Cascade delete: xóa org/question/job-role kéo theo bản ghi liên quan.
+
+**Ràng buộc:**
+
+- Phải thêm quan hệ ngược trên `Organization`, `OrgQuestion`, `JobRole` để Prisma client hợp lệ.
+- TS loose (`noImplicitAny`/`strictNullChecks` = false) — không thay đổi cấu hình này.
+- Migration phải reversible về mặt thực tế (không drop dữ liệu hiện hữu).
+
+**Tiêu chí hoàn thành:**
+
+- [ ] `npx prisma migrate dev` chạy sạch trên DB rỗng và DB đã seed.
+- [ ] `npx prisma generate` không lỗi; build backend xanh.
+- [ ] 4 bảng + 4 unique index xuất hiện trong migration SQL.
+
+---
+
+### FR-2 — Spike: `inferCompetencyLevel()` + ADR-003 (S0-2, #124)
+
+**Mô tả:** Nghiên cứu (spike) và chốt thuật toán suy luận competency level (1–5, tổng quát hóa `scaleMin..scaleMax`) từ `domainScores`. Sản phẩm: (a) **ADR-003** ghi lại quyết định + open question; (b) **pure function** `inferCompetencyLevel()` thuần (không side-effect, không DB) kèm unit test.
+
+**Đầu vào / Đầu ra:**
+
+```ts
+interface CompetencyScaleConfig {
+  scaleMin: number; // mặc định 1
+  scaleMax: number; // mặc định 5
+  domainNames: string[]; // các CompetencyDomain.domainName của competency
+}
+
+type DomainScores = Record<string, { correct: number; total: number }>;
+
+// Pure function — đầu ra tất định, không phụ thuộc DB / clock
+function inferCompetencyLevel(
+  domainScores: DomainScores,
+  config: CompetencyScaleConfig,
+): { level: number; percentage: number; matchedDomains: string[] };
+```
+
+- Đầu vào: `domainScores` (từ `CandidateInvite`/`ExamAttempt`), cấu hình thang điểm + danh sách domain của competency.
+- Đầu ra: `level` ∈ `[scaleMin..scaleMax]`, `percentage` ∈ `[0..100]`, danh sách domain đã khớp.
+
+**Quy tắc nghiệp vụ (Scoring v0 — chốt bởi ADR-003):**
+
+- `percentage = Σ correct / Σ total` trên các domain của competency được khớp (case-insensitive theo `domainNames`).
+- Bucket `percentage` → `level` đều trên dải `[scaleMin..scaleMax]`. Số bucket = `scaleMax - scaleMin + 1`. Ví dụ thang 1–5: `[0,20) → 1`, `[20,40) → 2`, `[40,60) → 3`, `[60,80) → 4`, `[80,100] → 5` (biên/làm tròn phải ghi rõ trong ADR và phản ánh trong test).
+- **Open question (ghi trong ADR):** chấm điểm mức câu hỏi (`QuestionCompetency.weight`) vs aggregation theo `domainScores`. **Sprint 0 chọn `domainScores` aggregation cho v0**; question-level để ngỏ cho v1.
+- Edge cases bắt buộc xử lý: không domain nào khớp → trả `level = scaleMin`, `percentage = 0`, `matchedDomains = []`; `Σ total = 0` → tránh chia 0, trả `percentage = 0`.
+
+**Ràng buộc:**
+
+- Hàm **thuần**: không đọc DB, không `Date.now()`, không random — để test tất định.
+- Khớp domain phải case-insensitive và bỏ qua key trong `domainScores` không thuộc competency.
+- Tham chiếu hình dạng `domainScores` thực tế tại `org-analytics.service.ts` (`getSkillGaps` ~L179) và `candidate.service.ts` (`submitAttempt` L197–223) để không lệch schema.
+
+**Tiêu chí hoàn thành:**
+
+- [ ] ADR-003 tồn tại (xem ghi chú đánh số ADR ở §6): nêu vấn đề, các phương án, quyết định v0, open question (question-level recompute), hệ quả.
+- [ ] `inferCompetencyLevel()` có unit test phủ: nhiều domain, 1 domain, không khớp domain, `total = 0`, biên bucket, thang điểm tùy biến (vd 1–4).
+- [ ] Hàm thuần — test chạy không cần DB/Redis.
+
+---
+
+### FR-3 — OTP qua Redis + email thật + validate SMTP (S0-3, #125)
+
+**Mô tả:** Thay `Map` in-memory bằng Redis cho OTP store (multi-pod-safe, TTL tự hết hạn), hiện thực việc gửi OTP qua `MailService` (thay stub TODO), và validate biến môi trường SMTP lúc khởi động ứng dụng.
+
+**Đầu vào / Đầu ra:**
+
+- `requestOtp(token)`: sinh mã 6 chữ số, hash sha256, `SETEX` vào Redis, gửi email chứa mã; trả `{ message }` (không lộ mã).
+- `verifyOtp(token, code)`: `GET` hash từ Redis, so khớp, `DEL` khi đúng, set `CandidateInvite.otpVerifiedAt = now()`.
+
+**Quy tắc nghiệp vụ:**
+
+- **Redis key scheme:** `otp:{inviteId}` → giá trị = sha256-hash của mã. TTL = **600s** (10 phút), set bằng `SETEX` (hết hạn tự động, không cần job dọn dẹp).
+- Một mã mới ghi đè key cũ (reset TTL). Verify thành công → `DEL otp:{inviteId}` (one-shot).
+- Verify khi key không tồn tại/đã hết hạn → lỗi 400 "No OTP requested / OTP has expired" (giữ nguyên thông điệp hiện tại).
+- **Email:** thêm `MailService.sendOtp(email, code)` (HTML giống style các template hiện có) và gọi nó trong `requestOtp` thay cho TODO. Lỗi gửi mail được log (không lộ mã) và **không** chặn flow tạo OTP nếu hạ tầng mail tạm lỗi (giữ nhất quán với pattern `try/catch` của `MailService`) — quyết định "fail open vs fail closed" ghi trong PR; mặc định fail-open như các mail khác.
+- **Validate SMTP lúc khởi động:** kiểm tra `MAIL_HOST`, `MAIL_PORT`, `MAIL_USER`, `MAIL_PASS`, `MAIL_FROM` hiện diện khi `NODE_ENV !== 'test'`; thiếu biến bắt buộc → log cảnh báo rõ ràng (và/hoặc fail-fast theo quyết định ADR/PR). `NODE_ENV === 'test'` giữ transporter no-op như hiện tại.
+- Giữ nguyên: TTL 10 phút, mã sinh bằng `crypto.randomInt(100_000, 1_000_000)`, hash sha256.
+
+**Ràng buộc:**
+
+- Tái sử dụng Redis client đang có trong stack (BullMQ/`backend/src/queues/*`); không thêm dependency mới nếu tránh được.
+- **Không bao giờ** log mã OTP thô (giữ nguyên log email đã mask tại `candidate.service.ts:70–71`).
+- Tương thích ngược: client gọi `requestOtp`/`verifyOtp` không đổi contract HTTP.
+
+**Tiêu chí hoàn thành:**
+
+- [ ] OTP lưu ở Redis key `otp:{inviteId}` với TTL 600s; restart 1 pod không mất OTP đang hiệu lực; 2 pod chia sẻ được OTP.
+- [ ] `requestOtp` gửi email thật qua `MailService.sendOtp` (verify bằng Mailtrap/no-op ở test).
+- [ ] App fail-fast/cảnh báo khi thiếu biến SMTP bắt buộc (ngoài môi trường test).
+- [ ] Không có log nào in mã OTP thô; test xanh.
+
+---
+
+### FR-4 — Scaffold module `competency` (BE + FE) (S0-4, #126)
+
+**Mô tả:** Dựng khung module NestJS `competency` (mirror pattern `backend/src/org-questions/`) + service frontend + route + entry sidebar — tất cả **rỗng/feature-flagged nhưng biên dịch được**. Không có business logic thật trong Sprint 0.
+
+**Đầu vào / Đầu ra:**
+
+- Backend: `competency.module.ts`, `competency.controller.ts`, `competency.service.ts`, `dto/` (vd `create-competency.dto.ts`, `update-competency.dto.ts`) dưới `backend/src/competency/`.
+- Frontend: `src/services/competency.ts` (TanStack-Query-ready functions), route trong `App.tsx`, entry trong `OrgSidebar.tsx`.
+
+**Quy tắc nghiệp vụ:**
+
+- **Endpoints scaffold** (org-scoped, guard `OrgRoleGuard` + `@OrgRoles('OWNER','ADMIN','MANAGER')`):
+
+  ```
+  GET    /organizations/:orgId/competencies            → list (Sprint 0: trả [] hoặc 501-stub)
+  POST   /organizations/:orgId/competencies            → create (stub)
+  GET    /organizations/:orgId/competencies/:id        → detail (stub)
+  PATCH  /organizations/:orgId/competencies/:id        → update (stub)
+  DELETE /organizations/:orgId/competencies/:id        → soft delete (stub)
+  ```
+
+- Guard và decorator tái dùng `backend/src/organizations/guards/org-role.guard.ts` + `backend/src/common/decorators/org-roles.decorator.ts` (`OrgRoles(...roles: OrgRole[])`).
+- DTO dùng `class-validator`; mọi endpoint org-scoped phải lấy `orgId` từ path và bị guard chặn theo role (tenant isolation — xem NFR).
+- **Feature flag:** entry sidebar "Competencies" và route ẩn sau cờ (vd `VITE_FEATURE_COMPETENCY` hoặc cờ org). Tab `OrgSidebar` theo đúng pattern `roles: ['OWNER','ADMIN','MANAGER']` đã dùng cho Tracks/Manage Catalog; **ẩn với RECRUITER/MEMBER**.
+- `src/services/competency.ts` gọi qua axios instance dùng chung (`src/services/api.ts`) với base `/api/v1`.
+
+**Ràng buộc:**
+
+- Module phải được import vào `AppModule`; app khởi động không lỗi.
+- Không expose endpoint hoạt động thật (stub trả rỗng hoặc 501) để tránh dùng nhầm khi chưa ratify.
+- FE phải build (`npm run build`) và lint (`npm run lint`) xanh kể cả khi flag tắt.
+
+**Tiêu chí hoàn thành:**
+
+- [ ] `backend/src/competency/` đủ controller/service/module/DTO; `AppModule` import; backend build + start xanh.
+- [ ] Endpoint competency bị `OrgRoleGuard` chặn: gọi với role MEMBER/RECRUITER → `403`.
+- [ ] `src/services/competency.ts` + route + sidebar entry tồn tại; FE build/lint xanh; entry ẩn khi flag tắt.
+
+---
+
+### FR-5 — Util `parseCandidateCsv` + contract-check `getResults` (S0-5, #127)
+
+**Mô tả:** Tách logic parse CSV ứng viên thành một util thuần dùng chung, có unit test; đồng thời "đóng băng" hợp đồng (contract) của `getResults` bằng test khẳng định nó trả đủ field cho bảng xếp hạng ứng viên (chuẩn bị cho xếp hạng theo năng lực).
+
+**Đầu vào / Đầu ra:**
+
+```ts
+interface ParsedCandidateRow {
+  name?: string;
+  email: string;
+}
+interface ParseCandidateCsvResult {
+  valid: ParsedCandidateRow[];
+  errors: { row: number; reason: string }[];
+}
+function parseCandidateCsv(raw: string): ParseCandidateCsvResult;
+```
+
+- Đầu vào: nội dung CSV thô (header `name,email` tùy chọn, auto-detect).
+- Đầu ra: danh sách hợp lệ + danh sách lỗi theo dòng (email không hợp lệ, thiếu email, trùng).
+
+**Quy tắc nghiệp vụ:**
+
+- Util **thuần** (string in → object out), không side-effect, dùng được cả FE (thay logic trong `CsvImportModal`) lẫn BE nếu cần.
+- Auto-detect header row; bỏ dòng trống; trim; validate email; đánh dấu duplicate trong cùng file.
+- **Contract `getResults`** (`backend/src/assessments/assessments.service.ts:614`): viết contract test khẳng định response chứa `funnel { total, started, submitted, passed }` và mỗi phần tử `candidates[]` có tối thiểu: `percentile`, `domainScores`, `integrityScore`, `stage`, `rating`, `recruiterNote`, `timeSpent`, `tabSwitchCount` (cộng `name`, `email`). Đây là các field bảng xếp hạng năng lực sẽ tiêu thụ; test sẽ **fail** nếu sprint sau vô tình bỏ field.
+
+**Ràng buộc:**
+
+- Không đổi hành vi `getResults`; chỉ thêm test khóa contract.
+- Util đặt nơi cả FE/BE truy cập được (vd `src/lib/` cho FE; nếu BE cần thì cân nhắc package dùng chung — quyết định ghi trong PR, mặc định bản FE trước).
+- Giữ tương thích với `CsvImportModal` hiện có (tối thiểu 200 dòng/lần, không streaming).
+
+**Tiêu chí hoàn thành:**
+
+- [ ] `parseCandidateCsv` có unit test: có/không header, email lỗi, thiếu email, trùng, dòng trống.
+- [ ] `CsvImportModal` dùng util (không còn parse inline trùng lặp).
+- [ ] Contract test `getResults` xanh và fail khi xóa thử một field bắt buộc.
+
+---
+
+### FR-6 — Project hygiene (S0-6, #128)
+
+**Mô tả:** Thiết lập quy trình cho sáng kiến Enterprise — **chỉ quy trình, không code**: Definition of Done (DoD), branch/PR conventions, và board sprint.
+
+**Đầu vào / Đầu ra:**
+
+- Đầu ra: tài liệu DoD + tài liệu/wiki conventions + board được cấu hình (cột, label, mapping issue → sprint).
+
+**Quy tắc nghiệp vụ:**
+
+- **Definition of Done:** mỗi PR phải — build + lint + test xanh; coverage ≥ 80% cho code mới (xem NFR); migration (nếu có) chạy được; cập nhật doc/ADR liên quan; review bởi ≥1 người.
+- **Branch convention:** `feat/`, `fix/`, `chore/`, `spike/`, `docs/` + tham chiếu issue (vd `feat/s0-4-competency-scaffold`).
+- **PR convention:** tiêu đề conventional-commits (`feat(...)`, `fix(...)`, `chore(...)`), mô tả + test plan + liên kết issue #123–#128.
+- **Board:** cột (Backlog → In Progress → In Review → Done), label cho enabler vs story, gắn 6 issue Sprint 0 vào board.
+
+**Ràng buộc:**
+
+- Không sửa code sản phẩm; có thể thêm/sửa file docs và (tùy chọn) template PR/issue.
+
+**Tiêu chí hoàn thành:**
+
+- [ ] DoD viết thành văn và được team đồng thuận.
+- [ ] Branch/PR conventions tài liệu hóa.
+- [ ] Board cấu hình; 6 issue #123–#128 nằm trên board đúng cột/label.
+
+---
+
+## 4. Yêu cầu phi chức năng (NFR)
+
+| ID        | Nhóm                               | Yêu cầu                                                                                                                                                                                                                                                                                                    |
+| --------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **NFR-1** | Bảo mật — Tenant isolation         | Mọi endpoint của module `competency` (FR-4) phải org-scoped và qua `OrgRoleGuard`; truy cập sai org hoặc sai role → `403` (không `404`, không lộ tồn tại tài nguyên). `Competency.orgId` luôn được áp khi truy vấn ở các sprint sau.                                                                       |
+| **NFR-2** | Bảo mật — OTP brute-force          | `verifyOtp` (FR-3) phải chống đoán mò: cân nhắc đếm số lần thử/`otp:{inviteId}` và khóa sau N lần sai (vd 5) hoặc rate-limit theo IP/invite. Mã 6 chữ số + TTL 600s; sai mã trả thông điệp chung (không tạo oracle phân biệt "sai" vs "hết hạn" quá chi tiết).                                             |
+| **NFR-3** | Bảo mật — No secrets in logs       | Tuyệt đối không log mã OTP thô; chỉ log email đã mask. Không log biến SMTP (`MAIL_PASS`). Lỗi không được leak hash/secret.                                                                                                                                                                                 |
+| **NFR-4** | Hiệu năng                          | `inferCompetencyLevel()` (FR-2) là O(số domain) thuần CPU, < 1ms/lần gọi điển hình. OTP qua Redis: `SETEX`/`GET`/`DEL` < 5ms. `parseCandidateCsv` 200 dòng < 50ms.                                                                                                                                         |
+| **NFR-5** | Độ tin cậy (Reliability)           | OTP TTL tự hết hạn qua Redis `SETEX` (không cần cron dọn). Multi-pod: OTP đặt ở pod A verify được ở pod B. Mất kết nối Redis được xử lý có kiểm soát (lỗi rõ ràng, không crash app); restart pod không mất OTP đang hiệu lực.                                                                              |
+| **NFR-6** | Khả năng bảo trì (Maintainability) | Module `competency` mirror đúng pattern `org-questions` (controller/service/module/dto). Util/pure function (FR-2, FR-5) thuần, không side-effect, dễ test. File < 800 dòng, hàm < 50 dòng. Migration reversible.                                                                                          |
+| **NFR-7** | Khả năng kiểm thử (Testability)    | Coverage ≥ **80%** cho code mới. `inferCompetencyLevel` và `parseCandidateCsv` phủ edge case. OTP-Redis test bằng Redis thật (testcontainer) hoặc mock có kiểm soát. Contract test `getResults` khóa các field bắt buộc. Tất cả test chạy không phụ thuộc môi trường ngoài (no-op mail ở `NODE_ENV=test`). |
+| **NFR-8** | Tương thích ngược                  | FR-3 không đổi contract HTTP của `requestOtp`/`verifyOtp`. FR-1/FR-4 không thay đổi hành vi người dùng hiện hữu (schema/endpoint mới, feature-flagged). FR-5 không đổi output `getResults`.                                                                                                                |
+
+---
+
+## 5. Acceptance Criteria
+
+Truy vết tới FR tương ứng.
+
+- [ ] **(FR-1)** `npx prisma migrate dev` + `npx prisma generate` xanh; 4 bảng `competencies`, `competency_domains`, `question_competencies`, `job_role_competencies` + 4 unique index tồn tại; quan hệ ngược trên `Organization`/`OrgQuestion`/`JobRole` hợp lệ.
+- [ ] **(FR-2)** ADR-003 tồn tại với quyết định v0 (`domainScores` aggregation) + open question (question-level). `inferCompetencyLevel({}, …)` → `{ level: scaleMin, percentage: 0 }`; `total = 0` không chia 0; bucket biên đúng theo ADR; phủ thang 1–5 và thang tùy biến.
+- [ ] **(FR-3)** OTP nằm ở Redis `otp:{inviteId}` TTL 600s; 2 pod chia sẻ OTP; `requestOtp` gửi email qua `MailService.sendOtp`; thiếu biến SMTP → cảnh báo/fail-fast (ngoài test); không log mã thô.
+- [ ] **(FR-4)** `backend/src/competency/*` (controller/service/module/dto) + import vào `AppModule`; gọi competency endpoint với role MEMBER/RECRUITER → `403`; `src/services/competency.ts` + route + sidebar entry tồn tại, ẩn khi flag tắt; BE & FE build/lint xanh.
+- [ ] **(FR-5)** `parseCandidateCsv` có unit test đầy đủ và được `CsvImportModal` dùng; contract test `getResults` khẳng định `funnel` + các field candidate (`percentile`, `domainScores`, `integrityScore`, `stage`, `rating`, `recruiterNote`, `timeSpent`, `tabSwitchCount`) và fail khi thiếu field.
+- [ ] **(FR-6)** DoD + branch/PR conventions tài liệu hóa; board cấu hình với 6 issue #123–#128.
+- [ ] **(NFR)** Coverage code mới ≥ 80%; CI xanh; không secret/OTP trong log; module competency org-scoped + guard reject `403`.
+
+---
+
+## 6. Liên kết
+
+> **Lưu ý đánh số ADR:** brief gọi tài liệu là **ADR-003**, nhưng `docs/adr/003-pass-predictor-v0.md` đã tồn tại. Khi tạo ở FR-2, dùng số ADR còn trống tiếp theo (vd `004-competency-level-inference.md`) và giữ alias "ADR-003" trong nội dung nếu team muốn, hoặc thống nhất đổi tên — cần reviewer xác nhận.
+
+- **Issues:** #123 (S0-1, FR-1) · #124 (S0-2, FR-2) · #125 (S0-3, FR-3) · #126 (S0-4, FR-4) · #127 (S0-5, FR-5) · #128 (S0-6, FR-6)
+- **ADR (tạo ở FR-2):** [docs/adr/](../adr/) — competency level inference v0 (xem lưu ý đánh số ở trên)
+- **Basic design (Enterprise initiative):** [enterprise-entrance-exam-plan.md](../enterprise-entrance-exam-plan.md)
+- **SRS liên quan:** [P1 — Recruiting Workflow (ATS-lite)](./p1-recruiting-workflow-srs.md) · [P0 — Smart Assessment Builder](./p0-smart-assessment-builder-srs.md)
+- **Schema:** [backend/prisma/schema.prisma](../../backend/prisma/schema.prisma)
+- **OTP hiện tại:** [backend/src/assessments/candidate.service.ts](../../backend/src/assessments/candidate.service.ts) (otpStore L19, requestOtp L54, verifyOtp L79)
+- **Mail service:** [backend/src/mail/mail.service.ts](../../backend/src/mail/mail.service.ts)
+- **Pattern module mẫu:** [backend/src/org-questions/](../../backend/src/org-questions/) · guard [org-role.guard.ts](../../backend/src/organizations/guards/org-role.guard.ts) · decorator [org-roles.decorator.ts](../../backend/src/common/decorators/org-roles.decorator.ts)
+- **`getResults`:** [backend/src/assessments/assessments.service.ts](../../backend/src/assessments/assessments.service.ts) (L614)
+- **domainScores tham chiếu:** [org-analytics.service.ts](../../backend/src/org-analytics/org-analytics.service.ts) (getSkillGaps ~L179) · [candidate.service.ts](../../backend/src/assessments/candidate.service.ts) (submitAttempt L197–223)
+- **Frontend:** [src/services/competency.ts](../../src/services/competency.ts) _(tạo ở FR-4)_ · [src/components/org/OrgSidebar.tsx](../../src/components/org/OrgSidebar.tsx)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ const OrgAssessments = lazy(() => import("./pages/org/OrgAssessments"));
 const AssessmentBuilder = lazy(() => import("./pages/org/AssessmentBuilder"));
 const AssessmentResults = lazy(() => import("./pages/org/AssessmentResults"));
 const OrgJobRoles = lazy(() => import("./pages/org/OrgJobRoles"));
+const OrgCompetencies = lazy(() => import("./pages/org/OrgCompetencies"));
 const OrgAnalytics = lazy(() => import("./pages/org/OrgAnalytics"));
 const OrgAuditLog = lazy(() => import("./pages/org/OrgAuditLog"));
 const CandidateExam = lazy(() => import("./pages/CandidateExam"));
@@ -391,6 +392,7 @@ const AnimatedRoutes = () => {
           <Route path="assessments/:aid" element={<AssessmentResults />} />
           <Route path="assessments/:aid/edit" element={<AssessmentBuilder />} />
           <Route path="job-roles" element={<OrgJobRoles />} />
+          <Route path="competencies" element={<OrgCompetencies />} />
           <Route path="analytics" element={<OrgAnalytics />} />
           <Route path="settings" element={<OrgSettings />} />
           <Route path="settings/audit" element={<OrgAuditLog />} />

--- a/src/components/org/OrgSidebar.tsx
+++ b/src/components/org/OrgSidebar.tsx
@@ -1,11 +1,21 @@
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useOrgStore } from '@/stores/org.store';
+import { useLocation, useNavigate } from "react-router-dom";
+import { useOrgStore } from "@/stores/org.store";
 import {
-  LayoutDashboard, Users, Settings, Shield, BookOpen,
-  GraduationCap, Library, BookMarked, ClipboardList, BarChart3, Briefcase,
-} from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import type { OrgRole } from '@/types/org-types';
+  LayoutDashboard,
+  Users,
+  Settings,
+  Shield,
+  BookOpen,
+  GraduationCap,
+  Library,
+  BookMarked,
+  ClipboardList,
+  BarChart3,
+  Briefcase,
+  Award,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { OrgRole } from "@/types/org-types";
 
 const OrgSidebar = () => {
   const navigate = useNavigate();
@@ -18,31 +28,82 @@ const OrgSidebar = () => {
 
   // RECRUITER: only assessments + job-roles visible; no question bank / settings / catalog
   const links = [
-    { label: 'Dashboard',      href: `/org/${slug}`,               icon: LayoutDashboard, exact: true,
-      hidden: role === 'RECRUITER' },
-    { label: 'Members',        href: `/org/${slug}/members`,        icon: Users,
-      hidden: role === 'RECRUITER' },
-    { label: 'Groups',         href: `/org/${slug}/groups`,         icon: Shield,
-      hidden: role === 'RECRUITER' },
-    { label: 'Questions',      href: `/org/${slug}/questions`,      icon: BookOpen,
-      hidden: role === 'RECRUITER' },
-    { label: 'Exam Catalog',   href: `/org/${slug}/catalog`,        icon: GraduationCap,
-      hidden: role === 'RECRUITER' },
-    { label: 'Manage Catalog', href: `/org/${slug}/catalog/manage`, icon: Library,
-      roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[],
-      hidden: role === 'RECRUITER' },
-    { label: 'Tracks',         href: `/org/${slug}/tracks`,         icon: BookMarked,
-      roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[],
-      hidden: role === 'RECRUITER' },
+    {
+      label: "Dashboard",
+      href: `/org/${slug}`,
+      icon: LayoutDashboard,
+      exact: true,
+      hidden: role === "RECRUITER",
+    },
+    {
+      label: "Members",
+      href: `/org/${slug}/members`,
+      icon: Users,
+      hidden: role === "RECRUITER",
+    },
+    {
+      label: "Groups",
+      href: `/org/${slug}/groups`,
+      icon: Shield,
+      hidden: role === "RECRUITER",
+    },
+    {
+      label: "Questions",
+      href: `/org/${slug}/questions`,
+      icon: BookOpen,
+      hidden: role === "RECRUITER",
+    },
+    {
+      label: "Exam Catalog",
+      href: `/org/${slug}/catalog`,
+      icon: GraduationCap,
+      hidden: role === "RECRUITER",
+    },
+    {
+      label: "Manage Catalog",
+      href: `/org/${slug}/catalog/manage`,
+      icon: Library,
+      roles: ["OWNER", "ADMIN", "MANAGER"] as OrgRole[],
+      hidden: role === "RECRUITER",
+    },
+    {
+      label: "Tracks",
+      href: `/org/${slug}/tracks`,
+      icon: BookMarked,
+      roles: ["OWNER", "ADMIN", "MANAGER"] as OrgRole[],
+      hidden: role === "RECRUITER",
+    },
     // P1: Recruiting — visible to OWNER/ADMIN/MANAGER/RECRUITER
-    { label: 'Assessments',    href: `/org/${slug}/assessments`,    icon: ClipboardList,
-      roles: ['OWNER', 'ADMIN', 'MANAGER', 'RECRUITER'] as OrgRole[] },
-    { label: 'Job Roles',      href: `/org/${slug}/job-roles`,      icon: Briefcase,
-      roles: ['OWNER', 'ADMIN', 'MANAGER', 'RECRUITER'] as OrgRole[] },
-    { label: 'Analytics',      href: `/org/${slug}/analytics`,      icon: BarChart3,
-      roles: ['OWNER', 'ADMIN', 'MANAGER'] as OrgRole[] },
-    { label: 'Settings',       href: `/org/${slug}/settings`,       icon: Settings,
-      roles: ['OWNER', 'ADMIN'] as OrgRole[] },
+    {
+      label: "Assessments",
+      href: `/org/${slug}/assessments`,
+      icon: ClipboardList,
+      roles: ["OWNER", "ADMIN", "MANAGER", "RECRUITER"] as OrgRole[],
+    },
+    {
+      label: "Job Roles",
+      href: `/org/${slug}/job-roles`,
+      icon: Briefcase,
+      roles: ["OWNER", "ADMIN", "MANAGER", "RECRUITER"] as OrgRole[],
+    },
+    {
+      label: "Competencies",
+      href: `/org/${slug}/competencies`,
+      icon: Award,
+      roles: ["OWNER", "ADMIN", "MANAGER"] as OrgRole[],
+    },
+    {
+      label: "Analytics",
+      href: `/org/${slug}/analytics`,
+      icon: BarChart3,
+      roles: ["OWNER", "ADMIN", "MANAGER"] as OrgRole[],
+    },
+    {
+      label: "Settings",
+      href: `/org/${slug}/settings`,
+      icon: Settings,
+      roles: ["OWNER", "ADMIN"] as OrgRole[],
+    },
   ];
 
   const isActive = (href: string, exact?: boolean) =>
@@ -65,7 +126,9 @@ const OrgSidebar = () => {
             </span>
           </div>
         )}
-        <span className="text-xs font-mono font-medium truncate">{currentOrg?.name}</span>
+        <span className="text-xs font-mono font-medium truncate">
+          {currentOrg?.name}
+        </span>
       </div>
       {links
         .filter((link) => !link.hidden)
@@ -77,8 +140,8 @@ const OrgSidebar = () => {
             size="sm"
             className={`justify-start gap-2 font-mono text-xs ${
               isActive(link.href, link.exact)
-                ? 'bg-primary/10 text-primary'
-                : 'text-muted-foreground hover:text-foreground'
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:text-foreground"
             }`}
             onClick={() => navigate(link.href)}
           >

--- a/src/pages/org/OrgCompetencies.tsx
+++ b/src/pages/org/OrgCompetencies.tsx
@@ -1,0 +1,370 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useOrgStore } from "@/stores/org.store";
+import {
+  getCompetencies,
+  createCompetency,
+  updateCompetency,
+  deleteCompetency,
+} from "@/services/competency";
+import type {
+  Competency,
+  CreateCompetencyPayload,
+  UpdateCompetencyPayload,
+} from "@/services/competency";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Award,
+  Plus,
+  MoreVertical,
+  Pencil,
+  Trash2,
+  Loader2,
+  ToggleLeft,
+  ToggleRight,
+  Sliders,
+} from "lucide-react";
+import { toast } from "sonner";
+
+// ─── Form Modal ───────────────────────────────────────────────────────────────
+
+interface FormModalProps {
+  open: boolean;
+  onClose: () => void;
+  initial?: Competency | null;
+  onSave: (data: CreateCompetencyPayload | UpdateCompetencyPayload) => void;
+  isPending: boolean;
+}
+
+const CompetencyFormModal = ({
+  open,
+  onClose,
+  initial,
+  onSave,
+  isPending,
+}: FormModalProps) => {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [scaleMin, setScaleMin] = useState(String(initial?.scaleMin ?? 1));
+  const [scaleMax, setScaleMax] = useState(String(initial?.scaleMax ?? 5));
+
+  const handleOpen = () => {
+    setName(initial?.name ?? "");
+    setDescription(initial?.description ?? "");
+    setScaleMin(String(initial?.scaleMin ?? 1));
+    setScaleMax(String(initial?.scaleMax ?? 5));
+  };
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    onSave({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      scaleMin: Number(scaleMin),
+      scaleMax: Number(scaleMax),
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+        else handleOpen();
+      }}
+    >
+      <DialogContent className="max-w-md bg-card border-border">
+        <DialogHeader>
+          <DialogTitle className="font-mono flex items-center gap-2">
+            <Award className="h-4 w-4 text-primary" />
+            {initial ? "Edit Competency" : "New Competency"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <label className="text-[11px] font-mono text-muted-foreground uppercase tracking-wider">
+              Name *
+            </label>
+            <Input
+              className="mt-1 font-mono text-sm bg-muted/30 border-border"
+              placeholder="e.g. Problem Solving"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-mono text-muted-foreground uppercase tracking-wider">
+              Description
+            </label>
+            <Textarea
+              className="mt-1 font-mono text-xs bg-muted/30 border-border resize-none min-h-[72px]"
+              placeholder="Optional competency description…"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-[11px] font-mono text-muted-foreground uppercase tracking-wider">
+                Scale Min
+              </label>
+              <Input
+                type="number"
+                min={1}
+                className="mt-1 font-mono text-sm bg-muted/30 border-border"
+                value={scaleMin}
+                onChange={(e) => setScaleMin(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-[11px] font-mono text-muted-foreground uppercase tracking-wider">
+                Scale Max
+              </label>
+              <Input
+                type="number"
+                max={10}
+                className="mt-1 font-mono text-sm bg-muted/30 border-border"
+                value={scaleMax}
+                onChange={(e) => setScaleMax(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            className="glow-cyan"
+            onClick={handleSubmit}
+            disabled={isPending || !name.trim()}
+          >
+            {isPending ? "Saving…" : initial ? "Save changes" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+const OrgCompetencies = () => {
+  const queryClient = useQueryClient();
+  const currentOrg = useOrgStore((s) => s.currentOrg);
+  const orgId = currentOrg?.id || "";
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [editTarget, setEditTarget] = useState<Competency | null>(null);
+
+  const { data: competencies = [], isLoading } = useQuery({
+    queryKey: ["competencies", orgId],
+    queryFn: () => getCompetencies(orgId),
+    enabled: !!orgId,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateCompetencyPayload) =>
+      createCompetency(orgId, data),
+    onSuccess: () => {
+      toast.success("Competency created");
+      setShowCreate(false);
+      queryClient.invalidateQueries({ queryKey: ["competencies", orgId] });
+    },
+    onError: (e: any) =>
+      toast.error(e?.response?.data?.message || "Create failed"),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateCompetencyPayload }) =>
+      updateCompetency(orgId, id, data),
+    onSuccess: () => {
+      toast.success("Updated");
+      setEditTarget(null);
+      queryClient.invalidateQueries({ queryKey: ["competencies", orgId] });
+    },
+    onError: (e: any) =>
+      toast.error(e?.response?.data?.message || "Update failed"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteCompetency(orgId, id),
+    onSuccess: () => {
+      toast.success("Deleted");
+      queryClient.invalidateQueries({ queryKey: ["competencies", orgId] });
+    },
+    onError: (e: any) =>
+      toast.error(e?.response?.data?.message || "Delete failed"),
+  });
+
+  const toggleActive = (c: Competency) => {
+    updateMutation.mutate({ id: c.id, data: { isActive: !c.isActive } });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-mono font-bold flex items-center gap-2">
+            <Award className="h-6 w-6 text-primary" />
+            Competencies
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Define the competency framework for your organisation
+          </p>
+        </div>
+        <Button className="glow-cyan" onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4 mr-1.5" /> New Competency
+        </Button>
+      </div>
+
+      {competencies.length === 0 ? (
+        <div className="text-center py-16 space-y-3">
+          <Award className="h-12 w-12 text-muted-foreground mx-auto" />
+          <p className="text-muted-foreground font-mono text-sm">
+            No competencies yet
+          </p>
+          <Button onClick={() => setShowCreate(true)}>
+            <Plus className="h-4 w-4 mr-1.5" /> Create first competency
+          </Button>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {competencies.map((c) => (
+            <Card
+              key={c.id}
+              className={`bg-card border-border transition-opacity ${c.isActive ? "" : "opacity-50"}`}
+            >
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <h3 className="font-mono font-semibold text-sm truncate">
+                      {c.name}
+                    </h3>
+                    <p className="text-[11px] text-muted-foreground flex items-center gap-1 mt-0.5">
+                      <Sliders className="h-3 w-3 shrink-0" />
+                      Scale {c.scaleMin}–{c.scaleMax}
+                    </p>
+                  </div>
+
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+                      >
+                        <MoreVertical className="h-3.5 w-3.5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="end"
+                      className="text-xs font-mono w-40"
+                    >
+                      <DropdownMenuItem onClick={() => setEditTarget(c)}>
+                        <Pencil className="h-3.5 w-3.5 mr-2" /> Edit
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => toggleActive(c)}>
+                        {c.isActive ? (
+                          <>
+                            <ToggleLeft className="h-3.5 w-3.5 mr-2" />{" "}
+                            Deactivate
+                          </>
+                        ) : (
+                          <>
+                            <ToggleRight className="h-3.5 w-3.5 mr-2" />{" "}
+                            Activate
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-red-400 focus:text-red-400"
+                        onClick={() => {
+                          if (
+                            confirm(
+                              `Delete "${c.name}"? This cannot be undone.`,
+                            )
+                          ) {
+                            deleteMutation.mutate(c.id);
+                          }
+                        }}
+                      >
+                        <Trash2 className="h-3.5 w-3.5 mr-2" /> Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                {c.description && (
+                  <p className="text-[11px] text-muted-foreground line-clamp-2">
+                    {c.description}
+                  </p>
+                )}
+
+                <Badge
+                  className={
+                    c.isActive
+                      ? "bg-emerald-500/15 text-emerald-400 text-[10px]"
+                      : "bg-zinc-500/15 text-zinc-400 text-[10px]"
+                  }
+                >
+                  {c.isActive ? "Active" : "Inactive"}
+                </Badge>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <CompetencyFormModal
+        open={showCreate}
+        onClose={() => setShowCreate(false)}
+        onSave={(data) =>
+          createMutation.mutate(data as CreateCompetencyPayload)
+        }
+        isPending={createMutation.isPending}
+      />
+
+      <CompetencyFormModal
+        open={!!editTarget}
+        onClose={() => setEditTarget(null)}
+        initial={editTarget}
+        onSave={(data) =>
+          editTarget && updateMutation.mutate({ id: editTarget.id, data })
+        }
+        isPending={updateMutation.isPending}
+      />
+    </div>
+  );
+};
+
+export default OrgCompetencies;

--- a/src/services/competency.ts
+++ b/src/services/competency.ts
@@ -1,0 +1,62 @@
+import api from "./api";
+
+export interface Competency {
+  id: string;
+  orgId: string;
+  name: string;
+  description?: string;
+  scaleMin: number;
+  scaleMax: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCompetencyPayload {
+  name: string;
+  description?: string;
+  scaleMin?: number;
+  scaleMax?: number;
+}
+
+export interface UpdateCompetencyPayload {
+  name?: string;
+  description?: string;
+  scaleMin?: number;
+  scaleMax?: number;
+  isActive?: boolean;
+}
+
+const base = (orgId: string) => `/organizations/${orgId}/competencies`;
+
+export const getCompetencies = async (orgId: string): Promise<Competency[]> => {
+  const res = await api.get<Competency[]>(base(orgId));
+  return res.data;
+};
+
+export const createCompetency = async (
+  orgId: string,
+  data: CreateCompetencyPayload,
+): Promise<Competency> => {
+  const res = await api.post<Competency>(base(orgId), data);
+  return res.data;
+};
+
+export const updateCompetency = async (
+  orgId: string,
+  competencyId: string,
+  data: UpdateCompetencyPayload,
+): Promise<Competency> => {
+  const res = await api.patch<Competency>(
+    `${base(orgId)}/${competencyId}`,
+    data,
+  );
+  return res.data;
+};
+
+export const deleteCompetency = async (
+  orgId: string,
+  competencyId: string,
+): Promise<void> => {
+  await api.delete(`${base(orgId)}/${competencyId}`);
+};


### PR DESCRIPTION
## Summary

Sprint 0 foundation enablers implementing FR-1 through FR-4 from the [SRS](docs/specs/sprint-0-foundation-srs.md) and [Basic Design](docs/specs/sprint-0-foundation-basic-design.md).

### FR-1 — Competency data model (`schema.prisma`)
- New `CompetencyDomainSource` enum — disambiguates which `domainScores` namespace a key belongs to (`ORG_QUESTION_CATEGORY` for hiring flow, `PUBLIC_DOMAIN` for employee assessment flow)
- Four additive models: **Competency**, **CompetencyDomain**, **QuestionCompetency**, **JobRoleCompetency**
- All `@map()`/`@@map()` snake_case mapping, timestamps, correct FK delete rules (`Cascade` vs `Restrict`)
- No ALTER/DROP on existing tables — purely additive migration

### FR-2 — Scoring algorithm (`backend/src/competency/scoring/`)
- `inferCompetencyLevel()` — pure function, no I/O, deterministic
- Case-insensitive, whitespace-trimmed domain matching
- Configurable thresholds and scale (default 1–5)
- Returns `{ level, percentage, confidence, sampleSize, matchedDomains }`
- **10 unit tests** (TC1–TC10): happy path, no-match, boundary, empty inputs, division-by-zero guard, custom scale, whitespace trimming, HIGH confidence at exactly sample=20
- [ADR-028](docs/adr/028-competency-scoring.md) documents the algorithm decision

### FR-3 — Redis OTP store (`backend/src/assessments/candidate.service.ts`, `backend/src/redis/`)
- **Global `RedisModule`** — single shared `ioredis` instance, token `REDIS_CLIENT`, replaces scattered `new Redis()` anti-pattern
- **`requestOtp`**: lockout check → `SETEX` hash (TTL 10 min) → `MailService.sendOtp()`
- **`verifyOtp`**: lockout check → atomic `GETDEL` → `crypto.timingSafeEqual` comparison → brute-force counter with expiring TTL → lock after 5 failures (1h)
- Fail-CLOSED: `ServiceUnavailableException` if Redis is unavailable during security-critical path
- `MailService.sendOtp()`: branded HTML template, structured `OTP_MAIL_FAILED` log (no code/hash exposed)

### FR-4 — Competency module scaffold (`backend/src/competency/`)
- 5 CRUD endpoints under `POST|GET|GET/:id|PATCH/:id|DELETE/:id /orgs/:orgId/competencies`
- `JwtAuthGuard` → `OrgRoleGuard`: OWNER/ADMIN for writes, all org roles for reads
- `CompetencyService` with proper tenant isolation (all queries scoped to `orgId`)
- `CreateCompetencyDto` / `UpdateCompetencyDto` / `ListCompetenciesDto` with class-validator

### Docs
- `docs/specs/sprint-0-foundation-srs.md` — requirements specification
- `docs/specs/sprint-0-foundation-basic-design.md` — design with ERD, DDL, sequence diagrams
- `docs/adr/028-competency-scoring.md` — ADR for scoring algorithm choice
- `docs/adr/00-index.md` — updated with ADR-028 entry

## What a reviewer should know

- **No migration run yet** — `prisma migrate dev --name s0_competency_models` needs to be run before the backend can start. Prisma client types for the 4 new models won't exist until then.
- `REDIS_PASSWORD` env var is now required (can be empty string for local dev without auth).
- The `FEATURE_COMPETENCY` feature-flag gate mentioned in the SRS was deferred — endpoints are live once the migration runs. Flag can be added in Sprint 1 if needed.
- `worktree node_modules` not installed — run `cd backend && npm install` in the worktree before running tests.

## Test plan

- [ ] `cd backend && npm install && npx jest src/competency/scoring/infer-competency-level.spec.ts` — 10 tests should pass
- [ ] `npx prisma migrate dev --name s0_competency_models` — migration applies cleanly
- [ ] `npm run start:dev` — app starts without DI errors (RedisModule + CompetencyModule registered)
- [ ] `POST /orgs/:orgId/competencies` with OWNER token → 201
- [ ] `GET /orgs/:orgId/competencies` with MEMBER token → 200 list
- [ ] OTP flow: `POST /candidate/:token/otp/request` → email sent → `POST /candidate/:token/otp/verify` with correct code → `{ verified: true }`
- [ ] OTP brute-force: 5 wrong codes → 429 on 6th attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)