### PR TITLE
feat(sprint-1): competency framework, job-role requirements, profile analytics, bulk CSV invite, candidate ranking filter

### DIFF
--- a/backend/src/assessments/assessments.controller.ts
+++ b/backend/src/assessments/assessments.controller.ts
@@ -40,7 +40,11 @@ export class AssessmentsController {
     @Query('page') page?: string,
     @Query('limit') limit?: string,
   ) {
-    return this.service.list(orgId, Number(page) || 1, Number(limit) || 20);
+    return this.service.list(
+      orgId,
+      Math.max(1, Number(page) || 1),
+      Number(limit) || 20,
+    );
   }
 
   /** Preview: count APPROVED questions available for a given pool filter config. */
@@ -55,8 +59,18 @@ export class AssessmentsController {
     return this.service.getPoolCount(orgId, {
       difficulty: difficulty || undefined,
       certificationId: certificationId || undefined,
-      categories: categories ? categories.split(',').map((c) => c.trim()).filter(Boolean) : undefined,
-      tags: tags ? tags.split(',').map((t) => t.trim()).filter(Boolean) : undefined,
+      categories: categories
+        ? categories
+            .split(',')
+            .map((c) => c.trim())
+            .filter(Boolean)
+        : undefined,
+      tags: tags
+        ? tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : undefined,
     });
   }
 
@@ -145,7 +159,13 @@ export class AssessmentsController {
     @Body() dto: UpdateCandidateDecisionDto,
     @CurrentUser() user: any,
   ) {
-    return this.service.updateCandidateDecision(orgId, aid, inviteId, dto, user.id);
+    return this.service.updateCandidateDecision(
+      orgId,
+      aid,
+      inviteId,
+      dto,
+      user.id,
+    );
   }
 
   @Get(':aid/candidates/:inviteId/events')

--- a/backend/src/assessments/assessments.controller.ts
+++ b/backend/src/assessments/assessments.controller.ts
@@ -18,6 +18,7 @@ import { CreateAssessmentDto } from './dto/create-assessment.dto';
 import { UpdateAssessmentDto } from './dto/update-assessment.dto';
 import { InviteCandidateDto } from './dto/invite-candidate.dto';
 import { UpdateCandidateDecisionDto } from './dto/update-candidate-decision.dto';
+import { BulkCsvInviteDto } from './dto/bulk-csv-invite.dto';
 import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
 import { OrgRoles } from '../common/decorators/org-roles.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -102,8 +103,12 @@ export class AssessmentsController {
   }
 
   @Get(':aid/results')
-  getResults(@Param('orgId') orgId: string, @Param('aid') aid: string) {
-    return this.service.getResults(orgId, aid);
+  getResults(
+    @Param('orgId') orgId: string,
+    @Param('aid') aid: string,
+    @Query('filter') filter?: string,
+  ) {
+    return this.service.getResults(orgId, aid, filter);
   }
 
   @Get(':aid/results/export')
@@ -113,13 +118,23 @@ export class AssessmentsController {
     @Param('orgId') orgId: string,
     @Param('aid') aid: string,
     @Res() res: Response,
+    @Query('filter') filter?: string,
   ) {
-    const csv = await this.service.exportCsv(orgId, aid);
+    const csv = await this.service.exportCsv(orgId, aid, filter);
     res.setHeader(
       'Content-Disposition',
       'attachment; filename="assessment-results.csv"',
     );
     res.send(csv);
+  }
+
+  @Post(':aid/candidates/bulk-csv')
+  bulkCsvInvite(
+    @Param('orgId') orgId: string,
+    @Param('aid') aid: string,
+    @Body() dto: BulkCsvInviteDto,
+  ) {
+    return this.service.bulkCsvInvite(orgId, aid, dto);
   }
 
   @Patch(':aid/candidates/:inviteId')

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -6,7 +6,13 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { OrganizationsService } from '../organizations/organizations.service';
 import { MailService } from '../mail/mail.service';
-import { AssessmentSelectionMode, AssessmentStatus, CandidateStage, Prisma } from '@prisma/client';
+import {
+  AssessmentSelectionMode,
+  AssessmentStatus,
+  CandidateStage,
+  Difficulty,
+  Prisma,
+} from '@prisma/client';
 import { CreateAssessmentDto } from './dto/create-assessment.dto';
 import { UpdateAssessmentDto } from './dto/update-assessment.dto';
 import { InviteCandidateDto } from './dto/invite-candidate.dto';
@@ -52,23 +58,26 @@ export class AssessmentsService {
    * Fixes #7: eliminates four copies of identical filter logic.
    * Fix #5: domain matching is case-insensitive via `{ equals: …, mode: 'insensitive' }`.
    */
-  private buildPoolWhere(orgId: string, config: Partial<PoolConfig>): any {
-    const where: any = { orgId, status: 'APPROVED' };
-    if (config.difficulty) where.difficulty = config.difficulty;
-    if (config.certificationId) where.certificationId = config.certificationId;
-    if (config.categories && config.categories.length > 0) {
-      // case-insensitive match for each category
-      where.OR = [
-        ...(where.OR ?? []),
-        ...config.categories.map((c) => ({
-          category: { equals: c, mode: 'insensitive' },
-        })),
-      ];
-    }
-    if (config.tags && config.tags.length > 0) {
-      where.tags = { hasSome: config.tags };
-    }
-    return where;
+  private buildPoolWhere(
+    orgId: string,
+    config: Partial<PoolConfig>,
+  ): Prisma.OrgQuestionWhereInput {
+    const orClauses: Prisma.OrgQuestionWhereInput[] = config.categories?.length
+      ? config.categories.map((c) => ({
+          category: { equals: c, mode: 'insensitive' as const },
+        }))
+      : [];
+
+    return {
+      orgId,
+      status: 'APPROVED',
+      ...(config.difficulty && { difficulty: config.difficulty as Difficulty }),
+      ...(config.certificationId && {
+        certificationId: config.certificationId,
+      }),
+      ...(orClauses.length > 0 && { OR: orClauses }),
+      ...(config.tags?.length && { tags: { hasSome: config.tags } }),
+    };
   }
 
   /**
@@ -194,6 +203,7 @@ export class AssessmentsService {
   // ─── CRUD ──────────────────────────────────────────────────────────────────
 
   async list(slugOrId: string, page = 1, limit = 20) {
+    limit = Math.min(limit, 100);
     const orgId = await this.orgsService.resolveOrgId(slugOrId);
     const skip = (page - 1) * limit;
 
@@ -211,20 +221,22 @@ export class AssessmentsService {
       this.prisma.assessment.count({ where: { orgId } }),
     ]);
 
-    const enriched = await Promise.all(
-      data.map(async (a) => {
-        const stats = await this.prisma.candidateInvite.aggregate({
-          where: { assessmentId: a.id, status: 'SUBMITTED' },
-          _avg: { score: true },
-          _count: { id: true },
-        });
-        return {
-          ...a,
-          submittedCount: stats._count.id,
-          avgScore: stats._avg.score ? Number(stats._avg.score) : null,
-        };
-      }),
-    );
+    const ids = data.map((a) => a.id);
+    const statRows = await this.prisma.candidateInvite.groupBy({
+      by: ['assessmentId'],
+      where: { assessmentId: { in: ids }, status: 'SUBMITTED' },
+      _avg: { score: true },
+      _count: { id: true },
+    });
+    const statsMap = new Map(statRows.map((r) => [r.assessmentId, r]));
+    const enriched = data.map((a) => {
+      const stat = statsMap.get(a.id);
+      return {
+        ...a,
+        submittedCount: stat ? stat._count.id : 0,
+        avgScore: stat?._avg.score ? Number(stat._avg.score) : null,
+      };
+    });
 
     return {
       data: enriched,
@@ -435,19 +447,38 @@ export class AssessmentsService {
           where: { id: assessmentId },
           data: {
             ...(dto.title !== undefined && { title: dto.title }),
-            ...(dto.description !== undefined && { description: dto.description }),
+            ...(dto.description !== undefined && {
+              description: dto.description,
+            }),
             ...(dto.timeLimit !== undefined && { timeLimit: dto.timeLimit }),
-            ...(dto.passingScore !== undefined && { passingScore: dto.passingScore }),
-            ...(dto.randomizeQuestions !== undefined && { randomizeQuestions: dto.randomizeQuestions }),
-            ...(dto.randomizeChoices !== undefined && { randomizeChoices: dto.randomizeChoices }),
-            ...(dto.detectTabSwitch !== undefined && { detectTabSwitch: dto.detectTabSwitch }),
-            ...(dto.blockCopyPaste !== undefined && { blockCopyPaste: dto.blockCopyPaste }),
-            ...(dto.requireFullscreen !== undefined && { requireFullscreen: dto.requireFullscreen }),
+            ...(dto.passingScore !== undefined && {
+              passingScore: dto.passingScore,
+            }),
+            ...(dto.randomizeQuestions !== undefined && {
+              randomizeQuestions: dto.randomizeQuestions,
+            }),
+            ...(dto.randomizeChoices !== undefined && {
+              randomizeChoices: dto.randomizeChoices,
+            }),
+            ...(dto.detectTabSwitch !== undefined && {
+              detectTabSwitch: dto.detectTabSwitch,
+            }),
+            ...(dto.blockCopyPaste !== undefined && {
+              blockCopyPaste: dto.blockCopyPaste,
+            }),
+            ...(dto.requireFullscreen !== undefined && {
+              requireFullscreen: dto.requireFullscreen,
+            }),
             ...(dto.requireOtp !== undefined && { requireOtp: dto.requireOtp }),
-            ...(dto.maxAttempts !== undefined && { maxAttempts: dto.maxAttempts }),
-            ...(dto.linkExpiryHours !== undefined && { linkExpiryHours: dto.linkExpiryHours }),
+            ...(dto.maxAttempts !== undefined && {
+              maxAttempts: dto.maxAttempts,
+            }),
+            ...(dto.linkExpiryHours !== undefined && {
+              linkExpiryHours: dto.linkExpiryHours,
+            }),
             selectionMode: AssessmentSelectionMode.BLUEPRINT,
-            selectionConfig: (dto.selectionConfig ?? assessment.selectionConfig) as any,
+            selectionConfig: (dto.selectionConfig ??
+              assessment.selectionConfig) as any,
             questionCount: questionRows.length,
           },
           include: {
@@ -477,19 +508,38 @@ export class AssessmentsService {
           where: { id: assessmentId },
           data: {
             ...(dto.title !== undefined && { title: dto.title }),
-            ...(dto.description !== undefined && { description: dto.description }),
+            ...(dto.description !== undefined && {
+              description: dto.description,
+            }),
             ...(dto.timeLimit !== undefined && { timeLimit: dto.timeLimit }),
-            ...(dto.passingScore !== undefined && { passingScore: dto.passingScore }),
-            ...(dto.randomizeQuestions !== undefined && { randomizeQuestions: dto.randomizeQuestions }),
-            ...(dto.randomizeChoices !== undefined && { randomizeChoices: dto.randomizeChoices }),
-            ...(dto.detectTabSwitch !== undefined && { detectTabSwitch: dto.detectTabSwitch }),
-            ...(dto.blockCopyPaste !== undefined && { blockCopyPaste: dto.blockCopyPaste }),
-            ...(dto.requireFullscreen !== undefined && { requireFullscreen: dto.requireFullscreen }),
+            ...(dto.passingScore !== undefined && {
+              passingScore: dto.passingScore,
+            }),
+            ...(dto.randomizeQuestions !== undefined && {
+              randomizeQuestions: dto.randomizeQuestions,
+            }),
+            ...(dto.randomizeChoices !== undefined && {
+              randomizeChoices: dto.randomizeChoices,
+            }),
+            ...(dto.detectTabSwitch !== undefined && {
+              detectTabSwitch: dto.detectTabSwitch,
+            }),
+            ...(dto.blockCopyPaste !== undefined && {
+              blockCopyPaste: dto.blockCopyPaste,
+            }),
+            ...(dto.requireFullscreen !== undefined && {
+              requireFullscreen: dto.requireFullscreen,
+            }),
             ...(dto.requireOtp !== undefined && { requireOtp: dto.requireOtp }),
-            ...(dto.maxAttempts !== undefined && { maxAttempts: dto.maxAttempts }),
-            ...(dto.linkExpiryHours !== undefined && { linkExpiryHours: dto.linkExpiryHours }),
+            ...(dto.maxAttempts !== undefined && {
+              maxAttempts: dto.maxAttempts,
+            }),
+            ...(dto.linkExpiryHours !== undefined && {
+              linkExpiryHours: dto.linkExpiryHours,
+            }),
             selectionMode: AssessmentSelectionMode.POOL,
-            selectionConfig: (dto.selectionConfig ?? assessment.selectionConfig) as any,
+            selectionConfig: (dto.selectionConfig ??
+              assessment.selectionConfig) as any,
             questionCount: config.drawCount,
           },
           include: {
@@ -517,17 +567,33 @@ export class AssessmentsService {
         where: { id: assessmentId },
         data: {
           ...(dto.title !== undefined && { title: dto.title }),
-          ...(dto.description !== undefined && { description: dto.description }),
+          ...(dto.description !== undefined && {
+            description: dto.description,
+          }),
           ...(dto.timeLimit !== undefined && { timeLimit: dto.timeLimit }),
-          ...(dto.passingScore !== undefined && { passingScore: dto.passingScore }),
-          ...(dto.randomizeQuestions !== undefined && { randomizeQuestions: dto.randomizeQuestions }),
-          ...(dto.randomizeChoices !== undefined && { randomizeChoices: dto.randomizeChoices }),
-          ...(dto.detectTabSwitch !== undefined && { detectTabSwitch: dto.detectTabSwitch }),
-          ...(dto.blockCopyPaste !== undefined && { blockCopyPaste: dto.blockCopyPaste }),
-          ...(dto.linkExpiryHours !== undefined && { linkExpiryHours: dto.linkExpiryHours }),
+          ...(dto.passingScore !== undefined && {
+            passingScore: dto.passingScore,
+          }),
+          ...(dto.randomizeQuestions !== undefined && {
+            randomizeQuestions: dto.randomizeQuestions,
+          }),
+          ...(dto.randomizeChoices !== undefined && {
+            randomizeChoices: dto.randomizeChoices,
+          }),
+          ...(dto.detectTabSwitch !== undefined && {
+            detectTabSwitch: dto.detectTabSwitch,
+          }),
+          ...(dto.blockCopyPaste !== undefined && {
+            blockCopyPaste: dto.blockCopyPaste,
+          }),
+          ...(dto.linkExpiryHours !== undefined && {
+            linkExpiryHours: dto.linkExpiryHours,
+          }),
           selectionMode: AssessmentSelectionMode.MANUAL,
           selectionConfig: Prisma.JsonNull,
-          ...(dto.questions !== undefined && { questionCount: dto.questions.length }),
+          ...(dto.questions !== undefined && {
+            questionCount: dto.questions.length,
+          }),
         },
         include: {
           _count: { select: { questions: true, candidateInvites: true } },
@@ -622,7 +688,11 @@ export class AssessmentsService {
     if (!assessment) throw new NotFoundException('Assessment not found');
 
     const inviteWhere: Record<string, unknown> = { assessmentId };
-    if (filter === 'submitted' || filter === 'passed' || filter === 'shortlisted') {
+    if (
+      filter === 'submitted' ||
+      filter === 'passed' ||
+      filter === 'shortlisted'
+    ) {
       inviteWhere['status'] = 'SUBMITTED';
     }
     if (filter === 'shortlisted') {
@@ -699,8 +769,13 @@ export class AssessmentsService {
     const data = {
       ...(dto.stage !== undefined && { stage: dto.stage }),
       ...(dto.rating !== undefined && { rating: dto.rating }),
-      ...(dto.recruiterNote !== undefined && { recruiterNote: dto.recruiterNote }),
-      ...(isStageDecision && { decidedBy: decidedByUserId, decidedAt: new Date() }),
+      ...(dto.recruiterNote !== undefined && {
+        recruiterNote: dto.recruiterNote,
+      }),
+      ...(isStageDecision && {
+        decidedBy: decidedByUserId,
+        decidedAt: new Date(),
+      }),
     };
 
     // No-op guard — avoid hitting the DB if nothing changed
@@ -712,7 +787,11 @@ export class AssessmentsService {
     });
   }
 
-  async exportCsv(slugOrId: string, assessmentId: string, filter?: string): Promise<string> {
+  async exportCsv(
+    slugOrId: string,
+    assessmentId: string,
+    filter?: string,
+  ): Promise<string> {
     const results = await this.getResults(slugOrId, assessmentId, filter);
     const header =
       'Name,Email,Attempt Status,Stage,Score (%),Percentile,Total Correct,Total Questions,Rating,Time Spent (s),Tab Switches,Started At,Submitted At,Recruiter Note';
@@ -751,24 +830,29 @@ export class AssessmentsService {
     slugOrId: string,
     assessmentId: string,
     dto: BulkCsvInviteDto,
-  ): Promise<{ created: number; skipped: number; errors: { row: number; email: string; reason: string }[] }> {
+  ): Promise<{
+    created: number;
+    skipped: number;
+    errors: { row: number; email: string; reason: string }[];
+  }> {
     const orgId = await this.orgsService.resolveOrgId(slugOrId);
     const assessment = await this.prisma.assessment.findFirst({
       where: { id: assessmentId, orgId },
     });
     if (!assessment) throw new NotFoundException('Assessment not found');
     if (assessment.status !== AssessmentStatus.ACTIVE) {
-      throw new BadRequestException('Assessment must be ACTIVE to invite candidates');
+      throw new BadRequestException(
+        'Assessment must be ACTIVE to invite candidates',
+      );
     }
 
     const { valid, invalid } = parseCandidateCsv(dto.csv);
-    const errors: { row: number; email: string; reason: string }[] = invalid.map(
-      (e: { row: number; raw: string; reason: string }) => ({
+    const errors: { row: number; email: string; reason: string }[] =
+      invalid.map((e: { row: number; raw: string; reason: string }) => ({
         row: e.row,
         email: e.raw,
         reason: e.reason,
-      }),
-    );
+      }));
 
     if (valid.length === 0) return { created: 0, skipped: 0, errors };
 
@@ -779,7 +863,9 @@ export class AssessmentsService {
     });
     const existingSet = new Set(existing.map((e) => e.candidateEmail));
 
-    const toCreate = valid.filter((r: { email: string; name?: string }) => !existingSet.has(r.email));
+    const toCreate = valid.filter(
+      (r: { email: string; name?: string }) => !existingSet.has(r.email),
+    );
     const skipped = valid.length - toCreate.length;
 
     if (toCreate.length > 0) {

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -12,6 +12,8 @@ import { UpdateAssessmentDto } from './dto/update-assessment.dto';
 import { InviteCandidateDto } from './dto/invite-candidate.dto';
 import { UpdateCandidateDecisionDto } from './dto/update-candidate-decision.dto';
 import { randomUUID } from 'crypto';
+import { parseCandidateCsv } from '../common/csv/parse-candidate-csv';
+import { BulkCsvInviteDto } from './dto/bulk-csv-invite.dto';
 
 // ─── Blueprint / Pool config shapes ─────────────────────────────────────────
 
@@ -611,7 +613,7 @@ export class AssessmentsService {
     return { invited: invites.length, invites };
   }
 
-  async getResults(slugOrId: string, assessmentId: string) {
+  async getResults(slugOrId: string, assessmentId: string, filter?: string) {
     const orgId = await this.orgsService.resolveOrgId(slugOrId);
     const assessment = await this.prisma.assessment.findFirst({
       where: { id: assessmentId, orgId },
@@ -619,8 +621,12 @@ export class AssessmentsService {
     });
     if (!assessment) throw new NotFoundException('Assessment not found');
 
+    const inviteWhere: Record<string, unknown> = { assessmentId };
+    if (filter === 'submitted' || filter === 'passed' || filter === 'shortlisted') {
+      inviteWhere['status'] = 'SUBMITTED';
+    }
     const invites = await this.prisma.candidateInvite.findMany({
-      where: { assessmentId },
+      where: inviteWhere,
       orderBy: [{ score: 'desc' }, { createdAt: 'asc' }],
     });
 
@@ -698,8 +704,8 @@ export class AssessmentsService {
     });
   }
 
-  async exportCsv(slugOrId: string, assessmentId: string): Promise<string> {
-    const results = await this.getResults(slugOrId, assessmentId);
+  async exportCsv(slugOrId: string, assessmentId: string, filter?: string): Promise<string> {
+    const results = await this.getResults(slugOrId, assessmentId, filter);
     const header =
       'Name,Email,Attempt Status,Stage,Score (%),Percentile,Total Correct,Total Questions,Rating,Time Spent (s),Tab Switches,Started At,Submitted At,Recruiter Note';
     const esc = (v: string) => `"${v.replace(/"/g, '""')}"`;
@@ -729,6 +735,54 @@ export class AssessmentsService {
     return this.prisma.assessment.delete({
       where: { id: assessmentId, orgId },
     });
+  }
+
+  // ── US-C1: Bulk CSV Invite ─────────────────────────────────────────────────
+
+  async bulkCsvInvite(
+    slugOrId: string,
+    assessmentId: string,
+    dto: BulkCsvInviteDto,
+  ): Promise<{ created: number; skipped: number; errors: { row: number; email: string; reason: string }[] }> {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    const assessment = await this.prisma.assessment.findFirst({
+      where: { id: assessmentId, orgId },
+    });
+    if (!assessment) throw new NotFoundException('Assessment not found');
+
+    const { rows, errors: parseErrors } = parseCandidateCsv(dto.csv);
+    const errors: { row: number; email: string; reason: string }[] = parseErrors.map((e) => ({
+      row: e.row,
+      email: e.email ?? '',
+      reason: e.reason,
+    }));
+
+    if (rows.length === 0) return { created: 0, skipped: 0, errors };
+
+    const emails = rows.map((r) => r.email);
+    const existing = await this.prisma.candidateInvite.findMany({
+      where: { assessmentId, candidateEmail: { in: emails } },
+      select: { candidateEmail: true },
+    });
+    const existingSet = new Set(existing.map((e) => e.candidateEmail));
+
+    const toCreate = rows.filter((r) => !existingSet.has(r.email));
+    const skipped = rows.length - toCreate.length;
+
+    if (toCreate.length > 0) {
+      await this.prisma.candidateInvite.createMany({
+        data: toCreate.map((r) => ({
+          id: randomUUID(),
+          assessmentId,
+          candidateEmail: r.email,
+          candidateName: r.name ?? null,
+          token: randomUUID(),
+        })),
+        skipDuplicates: true,
+      });
+    }
+
+    return { created: toCreate.length, skipped, errors };
   }
 
   // ─── Pool count (preview for UI) ───────────────────────────────────────────

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -625,10 +625,18 @@ export class AssessmentsService {
     if (filter === 'submitted' || filter === 'passed' || filter === 'shortlisted') {
       inviteWhere['status'] = 'SUBMITTED';
     }
-    const invites = await this.prisma.candidateInvite.findMany({
+    if (filter === 'shortlisted') {
+      inviteWhere['stage'] = 'SHORTLISTED';
+    }
+    let invites = await this.prisma.candidateInvite.findMany({
       where: inviteWhere,
       orderBy: [{ score: 'desc' }, { createdAt: 'asc' }],
     });
+    if (filter === 'passed' && assessment.passingScore != null) {
+      invites = invites.filter(
+        (i) => i.score != null && Number(i.score) >= assessment.passingScore!,
+      );
+    }
 
     // Compute percentile rank for each submitted candidate
     const submitted = invites.filter((i) => i.status === 'SUBMITTED');
@@ -749,6 +757,9 @@ export class AssessmentsService {
       where: { id: assessmentId, orgId },
     });
     if (!assessment) throw new NotFoundException('Assessment not found');
+    if (assessment.status !== AssessmentStatus.ACTIVE) {
+      throw new BadRequestException('Assessment must be ACTIVE to invite candidates');
+    }
 
     const { valid, invalid } = parseCandidateCsv(dto.csv);
     const errors: { row: number; email: string; reason: string }[] = invalid.map(

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -750,33 +750,35 @@ export class AssessmentsService {
     });
     if (!assessment) throw new NotFoundException('Assessment not found');
 
-    const { rows, errors: parseErrors } = parseCandidateCsv(dto.csv);
-    const errors: { row: number; email: string; reason: string }[] = parseErrors.map((e) => ({
-      row: e.row,
-      email: e.email ?? '',
-      reason: e.reason,
-    }));
+    const { valid, invalid } = parseCandidateCsv(dto.csv);
+    const errors: { row: number; email: string; reason: string }[] = invalid.map(
+      (e: { row: number; raw: string; reason: string }) => ({
+        row: e.row,
+        email: e.raw,
+        reason: e.reason,
+      }),
+    );
 
-    if (rows.length === 0) return { created: 0, skipped: 0, errors };
+    if (valid.length === 0) return { created: 0, skipped: 0, errors };
 
-    const emails = rows.map((r) => r.email);
+    const emails = valid.map((r: { email: string; name?: string }) => r.email);
     const existing = await this.prisma.candidateInvite.findMany({
       where: { assessmentId, candidateEmail: { in: emails } },
       select: { candidateEmail: true },
     });
     const existingSet = new Set(existing.map((e) => e.candidateEmail));
 
-    const toCreate = rows.filter((r) => !existingSet.has(r.email));
-    const skipped = rows.length - toCreate.length;
+    const toCreate = valid.filter((r: { email: string; name?: string }) => !existingSet.has(r.email));
+    const skipped = valid.length - toCreate.length;
 
     if (toCreate.length > 0) {
       await this.prisma.candidateInvite.createMany({
-        data: toCreate.map((r) => ({
-          id: randomUUID(),
+        data: toCreate.map((r: { email: string; name?: string }) => ({
           assessmentId,
           candidateEmail: r.email,
           candidateName: r.name ?? null,
-          token: randomUUID(),
+          token: randomUUID() as string,
+          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
         })),
         skipDuplicates: true,
       });

--- a/backend/src/assessments/dto/bulk-csv-invite.dto.ts
+++ b/backend/src/assessments/dto/bulk-csv-invite.dto.ts
@@ -1,8 +1,16 @@
 import { IsString, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
+/**
+ * IMPORTANT: The 2 MB @MaxLength limit relies on Express body-size being
+ * configured to accept at least that payload (default is 100 kb).
+ * Set `bodyParser: { limit: '2mb' }` in NestJS / the underlying Express
+ * instance before deploying this endpoint to production.
+ */
 export class BulkCsvInviteDto {
-  @ApiProperty({ description: 'CSV content with email,name header' })
+  @ApiProperty({
+    description: 'CSV content with email,name header; max ~2 MB raw text',
+  })
   @IsString()
   @MaxLength(2_000_000)
   csv: string;

--- a/backend/src/assessments/dto/bulk-csv-invite.dto.ts
+++ b/backend/src/assessments/dto/bulk-csv-invite.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkCsvInviteDto {
+  @ApiProperty({ description: 'CSV content with email,name header' })
+  @IsString()
+  @MaxLength(2_000_000)
+  csv: string;
+}

--- a/backend/src/common/csv/parse-candidate-csv.ts
+++ b/backend/src/common/csv/parse-candidate-csv.ts
@@ -11,8 +11,22 @@ export interface ParseCandidateCsvResult {
   duplicatesRemoved: number;
 }
 
-// RFC 5322 simplified — good enough for server-side pre-validation
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Linear-time structural email check — avoids ReDoS from backtracking regex
+function isValidEmail(email: string): boolean {
+  if (email.length > 254) return false;
+  const at = email.indexOf('@');
+  if (at <= 0 || at !== email.lastIndexOf('@')) return false;
+  const domain = email.slice(at + 1);
+  if (!domain) return false;
+  const dot = domain.lastIndexOf('.');
+  if (dot <= 0 || dot === domain.length - 1) return false;
+  // Whitespace check only — single-pass, no backtracking
+  for (let i = 0; i < email.length; i++) {
+    const c = email[i];
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') return false;
+  }
+  return true;
+}
 
 // Sanitize values that could cause formula injection if exported to spreadsheets
 function sanitizeField(value: string): string {
@@ -75,7 +89,7 @@ export function parseCandidateCsv(input: string): ParseCandidateCsvResult {
       continue;
     }
 
-    if (!EMAIL_RE.test(email)) {
+    if (!isValidEmail(email)) {
       invalid.push({
         row: i + 1,
         raw: trimmed,

--- a/backend/src/common/csv/parse-candidate-csv.ts
+++ b/backend/src/common/csv/parse-candidate-csv.ts
@@ -33,6 +33,45 @@ function sanitizeField(value: string): string {
   return /^[=+\-@]/.test(value) ? `'${value}` : value;
 }
 
+// RFC-4180 compliant field parser — handles quoted fields containing commas and escaped quotes
+function parseRFC4180Fields(line: string): string[] {
+  const fields: string[] = [];
+  let i = 0;
+  while (i <= line.length) {
+    if (i === line.length) break;
+    if (line[i] === '"') {
+      let val = '';
+      i++; // skip opening quote
+      while (i < line.length) {
+        if (line[i] === '"') {
+          if (i + 1 < line.length && line[i + 1] === '"') {
+            val += '"';
+            i += 2;
+          } else {
+            i++; // skip closing quote
+            break;
+          }
+        } else {
+          val += line[i++];
+        }
+      }
+      fields.push(val);
+      if (i < line.length && line[i] === ',') i++; // skip delimiter
+    } else {
+      const comma = line.indexOf(',', i);
+      if (comma === -1) {
+        fields.push(line.slice(i));
+        break;
+      } else {
+        fields.push(line.slice(i, comma));
+        i = comma + 1;
+        if (i === line.length) fields.push(''); // trailing comma
+      }
+    }
+  }
+  return fields;
+}
+
 export function parseCandidateCsv(input: string): ParseCandidateCsvResult {
   const lines = input.split(/\r?\n/);
   const valid: ParsedCandidate[] = [];
@@ -48,7 +87,9 @@ export function parseCandidateCsv(input: string): ParseCandidateCsvResult {
     return { valid, invalid, duplicatesRemoved };
   }
 
-  const headers = headerLine.split(',').map((h) => h.trim().toLowerCase());
+  const headers = parseRFC4180Fields(headerLine).map((h) =>
+    h.trim().toLowerCase(),
+  );
   const emailIdx = headers.indexOf('email');
 
   if (emailIdx === -1) {
@@ -81,7 +122,7 @@ export function parseCandidateCsv(input: string): ParseCandidateCsvResult {
       continue;
     }
 
-    const cols = trimmed.split(',').map((c) => c.trim());
+    const cols = parseRFC4180Fields(trimmed).map((c) => c.trim());
     const email = (cols[emailIdx] ?? '').toLowerCase().trim();
 
     if (!email) {

--- a/backend/src/competency/competency.controller.ts
+++ b/backend/src/competency/competency.controller.ts
@@ -11,12 +11,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import {
-  ApiTags,
-  ApiBearerAuth,
-  ApiOperation,
-  ApiParam,
-} from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
 import { OrgRoles } from '../common/decorators/org-roles.decorator';
@@ -25,44 +20,49 @@ import { CompetencyService } from './competency.service';
 import { CreateCompetencyDto } from './dto/create-competency.dto';
 import { UpdateCompetencyDto } from './dto/update-competency.dto';
 import { ListCompetenciesDto } from './dto/list-competencies.dto';
+import { LinkQuestionDto } from './dto/link-question.dto';
+import { AddDomainDto } from './dto/add-domain.dto';
+
+const WRITE_ROLES = [OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER] as const;
+const ALL_ROLES = [
+  OrgRole.OWNER,
+  OrgRole.ADMIN,
+  OrgRole.MANAGER,
+  OrgRole.RECRUITER,
+  OrgRole.MEMBER,
+] as const;
 
 @ApiTags('competencies')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, OrgRoleGuard)
-@Controller('orgs/:orgId/competencies')
+@Controller('organizations/:orgId/competencies')
 export class CompetencyController {
   constructor(private readonly competencyService: CompetencyService) {}
 
   @Post()
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN)
+  @OrgRoles(...WRITE_ROLES)
   @ApiOperation({ summary: 'Create a competency' })
-  @ApiParam({ name: 'orgId', type: 'string' })
   create(@Param('orgId') orgId: string, @Body() dto: CreateCompetencyDto) {
     return this.competencyService.create(orgId, dto);
   }
 
   @Get()
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MEMBER, OrgRole.RECRUITER)
+  @OrgRoles(...ALL_ROLES)
   @ApiOperation({ summary: 'List competencies' })
-  @ApiParam({ name: 'orgId', type: 'string' })
   findAll(@Param('orgId') orgId: string, @Query() query: ListCompetenciesDto) {
     return this.competencyService.findAll(orgId, query);
   }
 
   @Get(':id')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MEMBER, OrgRole.RECRUITER)
+  @OrgRoles(...ALL_ROLES)
   @ApiOperation({ summary: 'Get competency by id' })
-  @ApiParam({ name: 'orgId', type: 'string' })
-  @ApiParam({ name: 'id', type: 'string' })
   findOne(@Param('orgId') orgId: string, @Param('id') id: string) {
     return this.competencyService.findOne(orgId, id);
   }
 
   @Patch(':id')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN)
+  @OrgRoles(...WRITE_ROLES)
   @ApiOperation({ summary: 'Update a competency' })
-  @ApiParam({ name: 'orgId', type: 'string' })
-  @ApiParam({ name: 'id', type: 'string' })
   update(
     @Param('orgId') orgId: string,
     @Param('id') id: string,
@@ -71,13 +71,82 @@ export class CompetencyController {
     return this.competencyService.update(orgId, id, dto);
   }
 
+  @Patch(':id/toggle-active')
+  @OrgRoles(...WRITE_ROLES)
+  @ApiOperation({ summary: 'Toggle isActive flag' })
+  toggleActive(@Param('orgId') orgId: string, @Param('id') id: string) {
+    return this.competencyService.toggleActive(orgId, id);
+  }
+
   @Delete(':id')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN)
+  @OrgRoles(...WRITE_ROLES)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a competency' })
-  @ApiParam({ name: 'orgId', type: 'string' })
-  @ApiParam({ name: 'id', type: 'string' })
   remove(@Param('orgId') orgId: string, @Param('id') id: string) {
     return this.competencyService.remove(orgId, id);
+  }
+
+  // ── Question links ────────────────────────────────────────────────────────
+
+  @Get(':id/questions')
+  @OrgRoles(...ALL_ROLES)
+  @ApiOperation({ summary: 'List linked questions' })
+  listQuestions(@Param('orgId') orgId: string, @Param('id') id: string) {
+    return this.competencyService.listQuestions(orgId, id);
+  }
+
+  @Post(':id/questions')
+  @OrgRoles(...WRITE_ROLES)
+  @ApiOperation({ summary: 'Link a question to competency' })
+  linkQuestion(
+    @Param('orgId') orgId: string,
+    @Param('id') id: string,
+    @Body() dto: LinkQuestionDto,
+  ) {
+    return this.competencyService.linkQuestion(orgId, id, dto);
+  }
+
+  @Delete(':id/questions/:questionId')
+  @OrgRoles(...WRITE_ROLES)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Unlink a question from competency' })
+  unlinkQuestion(
+    @Param('orgId') orgId: string,
+    @Param('id') id: string,
+    @Param('questionId') questionId: string,
+  ) {
+    return this.competencyService.unlinkQuestion(orgId, id, questionId);
+  }
+
+  // ── Domains ───────────────────────────────────────────────────────────────
+
+  @Get(':id/domains')
+  @OrgRoles(...ALL_ROLES)
+  @ApiOperation({ summary: 'List competency domains' })
+  listDomains(@Param('orgId') orgId: string, @Param('id') id: string) {
+    return this.competencyService.listDomains(orgId, id);
+  }
+
+  @Post(':id/domains')
+  @OrgRoles(...WRITE_ROLES)
+  @ApiOperation({ summary: 'Add a domain mapping' })
+  addDomain(
+    @Param('orgId') orgId: string,
+    @Param('id') id: string,
+    @Body() dto: AddDomainDto,
+  ) {
+    return this.competencyService.addDomain(orgId, id, dto);
+  }
+
+  @Delete(':id/domains/:domainId')
+  @OrgRoles(...WRITE_ROLES)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a domain mapping' })
+  removeDomain(
+    @Param('orgId') orgId: string,
+    @Param('id') id: string,
+    @Param('domainId') domainId: string,
+  ) {
+    return this.competencyService.removeDomain(orgId, id, domainId);
   }
 }

--- a/backend/src/competency/competency.service.ts
+++ b/backend/src/competency/competency.service.ts
@@ -1,31 +1,40 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { CompetencyDomainSource } from '@prisma/client';
 import { CreateCompetencyDto } from './dto/create-competency.dto';
 import { UpdateCompetencyDto } from './dto/update-competency.dto';
 import { ListCompetenciesDto } from './dto/list-competencies.dto';
+import { LinkQuestionDto } from './dto/link-question.dto';
+import { AddDomainDto } from './dto/add-domain.dto';
 
 @Injectable()
 export class CompetencyService {
   constructor(private readonly prisma: PrismaService) {}
 
-  create(orgId: string, dto: CreateCompetencyDto) {
-    return this.prisma.competency.create({
-      data: {
-        orgId,
-        name: dto.name,
-        description: dto.description,
-        scaleMin: dto.scaleMin ?? 1,
-        scaleMax: dto.scaleMax ?? 5,
-      },
-    });
+  async create(orgId: string, dto: CreateCompetencyDto) {
+    const scaleMin = dto.scaleMin ?? 1;
+    const scaleMax = dto.scaleMax ?? 5;
+    if (scaleMin >= scaleMax) {
+      throw new BadRequestException('scaleMin must be less than scaleMax');
+    }
+    try {
+      return await this.prisma.competency.create({
+        data: { orgId, name: dto.name, description: dto.description, scaleMin, scaleMax },
+      });
+    } catch (e: any) {
+      if (e?.code === 'P2002') throw new ConflictException('Competency name already exists in this org');
+      throw e;
+    }
   }
 
   findAll(orgId: string, query: ListCompetenciesDto) {
     return this.prisma.competency.findMany({
-      where: {
-        orgId,
-        ...(query.isActive !== undefined ? { isActive: query.isActive } : {}),
-      },
+      where: { orgId, ...(query.isActive !== undefined ? { isActive: query.isActive } : {}) },
       orderBy: { name: 'asc' },
     });
   }
@@ -40,15 +49,96 @@ export class CompetencyService {
   }
 
   async update(orgId: string, id: string, dto: UpdateCompetencyDto) {
-    await this.findOne(orgId, id);
+    const existing = await this.findOne(orgId, id);
+    const scaleMin = dto.scaleMin ?? existing.scaleMin;
+    const scaleMax = dto.scaleMax ?? existing.scaleMax;
+    if (scaleMin >= scaleMax) {
+      throw new BadRequestException('scaleMin must be less than scaleMax');
+    }
+    try {
+      return await this.prisma.competency.update({ where: { id }, data: dto });
+    } catch (e: any) {
+      if (e?.code === 'P2002') throw new ConflictException('Competency name already exists in this org');
+      throw e;
+    }
+  }
+
+  async toggleActive(orgId: string, id: string) {
+    const existing = await this.findOne(orgId, id);
     return this.prisma.competency.update({
       where: { id },
-      data: dto,
+      data: { isActive: !existing.isActive },
     });
   }
 
   async remove(orgId: string, id: string) {
     await this.findOne(orgId, id);
     return this.prisma.competency.delete({ where: { id } });
+  }
+
+  // ── Questions ─────────────────────────────────────────────────────────────
+
+  async listQuestions(orgId: string, competencyId: string) {
+    await this.findOne(orgId, competencyId);
+    return this.prisma.questionCompetency.findMany({
+      where: { competencyId },
+      include: {
+        orgQuestion: { select: { id: true, title: true, category: true } },
+      },
+    });
+  }
+
+  async linkQuestion(orgId: string, competencyId: string, dto: LinkQuestionDto) {
+    await this.findOne(orgId, competencyId);
+    const question = await this.prisma.orgQuestion.findFirst({
+      where: { id: dto.orgQuestionId, orgId },
+    });
+    if (!question) throw new BadRequestException('Question not found in this org');
+    try {
+      return await this.prisma.questionCompetency.create({
+        data: { competencyId, orgQuestionId: dto.orgQuestionId, weight: dto.weight ?? 1 },
+      });
+    } catch (e: any) {
+      if (e?.code === 'P2002') throw new ConflictException('Question already linked to this competency');
+      throw e;
+    }
+  }
+
+  async unlinkQuestion(orgId: string, competencyId: string, questionId: string) {
+    await this.findOne(orgId, competencyId);
+    const link = await this.prisma.questionCompetency.findFirst({
+      where: { competencyId, orgQuestionId: questionId },
+    });
+    if (!link) throw new NotFoundException('Question link not found');
+    await this.prisma.questionCompetency.delete({ where: { id: link.id } });
+  }
+
+  // ── Domains ───────────────────────────────────────────────────────────────
+
+  async listDomains(orgId: string, competencyId: string) {
+    await this.findOne(orgId, competencyId);
+    return this.prisma.competencyDomain.findMany({ where: { competencyId } });
+  }
+
+  async addDomain(orgId: string, competencyId: string, dto: AddDomainDto) {
+    await this.findOne(orgId, competencyId);
+    const source = dto.source ?? CompetencyDomainSource.ORG_QUESTION_CATEGORY;
+    try {
+      return await this.prisma.competencyDomain.create({
+        data: { competencyId, domainName: dto.domainName, source },
+      });
+    } catch (e: any) {
+      if (e?.code === 'P2002') throw new ConflictException('Domain already mapped to this competency');
+      throw e;
+    }
+  }
+
+  async removeDomain(orgId: string, competencyId: string, domainId: string) {
+    await this.findOne(orgId, competencyId);
+    const domain = await this.prisma.competencyDomain.findFirst({
+      where: { id: domainId, competencyId },
+    });
+    if (!domain) throw new NotFoundException('Domain not found');
+    await this.prisma.competencyDomain.delete({ where: { id: domainId } });
   }
 }

--- a/backend/src/competency/dto/add-domain.dto.ts
+++ b/backend/src/competency/dto/add-domain.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsOptional, IsEnum } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CompetencyDomainSource } from '@prisma/client';
+
+export class AddDomainDto {
+  @ApiProperty()
+  @IsString()
+  domainName: string;
+
+  @ApiPropertyOptional({ enum: CompetencyDomainSource, default: 'ORG_QUESTION_CATEGORY' })
+  @IsEnum(CompetencyDomainSource)
+  @IsOptional()
+  source?: CompetencyDomainSource;
+}

--- a/backend/src/competency/dto/add-domain.dto.ts
+++ b/backend/src/competency/dto/add-domain.dto.ts
@@ -1,10 +1,12 @@
-import { IsString, IsOptional, IsEnum } from 'class-validator';
+import { IsString, IsOptional, IsEnum, IsNotEmpty, MaxLength } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { CompetencyDomainSource } from '@prisma/client';
 
 export class AddDomainDto {
-  @ApiProperty()
+  @ApiProperty({ maxLength: 200 })
   @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
   domainName: string;
 
   @ApiPropertyOptional({ enum: CompetencyDomainSource, default: 'ORG_QUESTION_CATEGORY' })

--- a/backend/src/competency/dto/link-question.dto.ts
+++ b/backend/src/competency/dto/link-question.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNumber, IsOptional, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class LinkQuestionDto {
+  @ApiProperty()
+  @IsString()
+  orgQuestionId: string;
+
+  @ApiPropertyOptional({ default: 1 })
+  @IsNumber()
+  @Min(0.01)
+  @IsOptional()
+  weight?: number;
+}

--- a/backend/src/job-roles/dto/set-job-role-competencies.dto.ts
+++ b/backend/src/job-roles/dto/set-job-role-competencies.dto.ts
@@ -1,4 +1,11 @@
-import { IsArray, IsString, IsInt, Min, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsString,
+  IsInt,
+  Min,
+  Max,
+  ValidateNested,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -10,6 +17,7 @@ export class JobRoleRequirementItemDto {
   @ApiProperty()
   @IsInt()
   @Min(1)
+  @Max(10)
   requiredLevel: number;
 }
 

--- a/backend/src/job-roles/dto/set-job-role-competencies.dto.ts
+++ b/backend/src/job-roles/dto/set-job-role-competencies.dto.ts
@@ -1,0 +1,22 @@
+import { IsArray, IsString, IsInt, Min, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class JobRoleRequirementItemDto {
+  @ApiProperty()
+  @IsString()
+  competencyId: string;
+
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  requiredLevel: number;
+}
+
+export class SetJobRoleCompetenciesDto {
+  @ApiProperty({ type: [JobRoleRequirementItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => JobRoleRequirementItemDto)
+  requirements: JobRoleRequirementItemDto[];
+}

--- a/backend/src/job-roles/job-roles.controller.ts
+++ b/backend/src/job-roles/job-roles.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Patch,
   Delete,
   Param,
@@ -11,6 +12,7 @@ import {
 import { JobRolesService } from './job-roles.service';
 import { CreateJobRoleDto } from './dto/create-job-role.dto';
 import { UpdateJobRoleDto } from './dto/update-job-role.dto';
+import { SetJobRoleCompetenciesDto } from './dto/set-job-role-competencies.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
 import { OrgRoles } from '../common/decorators/org-roles.decorator';
@@ -21,7 +23,6 @@ export class JobRolesController {
   constructor(private readonly service: JobRolesService) {}
 
   @Get()
-  // All org members can view job roles (used in AssessmentBuilder selectors)
   list(@Param('orgId') orgId: string) {
     return this.service.list(orgId);
   }
@@ -46,5 +47,26 @@ export class JobRolesController {
   @OrgRoles('OWNER', 'ADMIN')
   remove(@Param('orgId') orgId: string, @Param('roleId') roleId: string) {
     return this.service.remove(orgId, roleId);
+  }
+
+  // ── US-A2: Competency Requirements ────────────────────────────────────────
+
+  @Get(':roleId/competencies')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'RECRUITER', 'MEMBER')
+  getRequirements(
+    @Param('orgId') orgId: string,
+    @Param('roleId') roleId: string,
+  ) {
+    return this.service.getRequirements(orgId, roleId);
+  }
+
+  @Put(':roleId/competencies')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  setRequirements(
+    @Param('orgId') orgId: string,
+    @Param('roleId') roleId: string,
+    @Body() dto: SetJobRoleCompetenciesDto,
+  ) {
+    return this.service.setRequirements(orgId, roleId, dto);
   }
 }

--- a/backend/src/job-roles/job-roles.controller.ts
+++ b/backend/src/job-roles/job-roles.controller.ts
@@ -23,6 +23,7 @@ export class JobRolesController {
   constructor(private readonly service: JobRolesService) {}
 
   @Get()
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'RECRUITER', 'MEMBER')
   list(@Param('orgId') orgId: string) {
     return this.service.list(orgId);
   }

--- a/backend/src/job-roles/job-roles.service.ts
+++ b/backend/src/job-roles/job-roles.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { OrganizationsService } from '../organizations/organizations.service';
 import { CreateJobRoleDto } from './dto/create-job-role.dto';
 import { UpdateJobRoleDto } from './dto/update-job-role.dto';
+import { SetJobRoleCompetenciesDto } from './dto/set-job-role-competencies.dto';
 
 @Injectable()
 export class JobRolesService {
@@ -16,31 +17,21 @@ export class JobRolesService {
     return this.prisma.jobRole.findMany({
       where: { orgId },
       orderBy: [{ isActive: 'desc' }, { title: 'asc' }],
-      include: {
-        _count: { select: { assessments: true } },
-      },
+      include: { _count: { select: { assessments: true } } },
     });
   }
 
   async create(slugOrId: string, dto: CreateJobRoleDto) {
     const orgId = await this.orgsService.resolveOrgId(slugOrId);
     return this.prisma.jobRole.create({
-      data: {
-        orgId,
-        title: dto.title,
-        department: dto.department,
-        description: dto.description,
-      },
+      data: { orgId, title: dto.title, department: dto.department, description: dto.description },
     });
   }
 
   async update(slugOrId: string, roleId: string, dto: UpdateJobRoleDto) {
     const orgId = await this.orgsService.resolveOrgId(slugOrId);
-    const existing = await this.prisma.jobRole.findFirst({
-      where: { id: roleId, orgId },
-    });
+    const existing = await this.prisma.jobRole.findFirst({ where: { id: roleId, orgId } });
     if (!existing) throw new NotFoundException('Job role not found');
-
     return this.prisma.jobRole.update({
       where: { id: roleId },
       data: {
@@ -54,10 +45,79 @@ export class JobRolesService {
 
   async remove(slugOrId: string, roleId: string) {
     const orgId = await this.orgsService.resolveOrgId(slugOrId);
-    const existing = await this.prisma.jobRole.findFirst({
-      where: { id: roleId, orgId },
-    });
+    const existing = await this.prisma.jobRole.findFirst({ where: { id: roleId, orgId } });
     if (!existing) throw new NotFoundException('Job role not found');
     return this.prisma.jobRole.delete({ where: { id: roleId } });
+  }
+
+  // ── US-A2: Competency Requirements ────────────────────────────────────────
+
+  async getRequirements(slugOrId: string, roleId: string) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    const role = await this.prisma.jobRole.findFirst({ where: { id: roleId, orgId } });
+    if (!role) throw new NotFoundException('Job role not found');
+    const reqs = await this.prisma.jobRoleCompetency.findMany({
+      where: { jobRoleId: roleId },
+      include: { competency: { select: { id: true, name: true, scaleMin: true, scaleMax: true } } },
+    });
+    return reqs.map((r) => ({
+      id: r.id,
+      competencyId: r.competencyId,
+      competencyName: r.competency.name,
+      requiredLevel: r.requiredLevel,
+      scaleMin: r.competency.scaleMin,
+      scaleMax: r.competency.scaleMax,
+    }));
+  }
+
+  async setRequirements(slugOrId: string, roleId: string, dto: SetJobRoleCompetenciesDto) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    const role = await this.prisma.jobRole.findFirst({ where: { id: roleId, orgId } });
+    if (!role) throw new NotFoundException('Job role not found');
+
+    if (dto.requirements.length === 0) {
+      await this.prisma.jobRoleCompetency.deleteMany({ where: { jobRoleId: roleId } });
+      return [];
+    }
+
+    const ids = dto.requirements.map((r) => r.competencyId);
+    const uniqueIds = new Set(ids);
+    if (uniqueIds.size !== ids.length) {
+      throw new BadRequestException('Duplicate competencyId in requirements');
+    }
+
+    const competencies = await this.prisma.competency.findMany({
+      where: { id: { in: [...uniqueIds] }, orgId },
+      select: { id: true, name: true, scaleMin: true, scaleMax: true },
+    });
+
+    const errors: { competencyId: string; error: string }[] = [];
+    for (const req of dto.requirements) {
+      const comp = competencies.find((c) => c.id === req.competencyId);
+      if (!comp) {
+        errors.push({ competencyId: req.competencyId, error: 'Competency not found in this org' });
+        continue;
+      }
+      if (req.requiredLevel < comp.scaleMin || req.requiredLevel > comp.scaleMax) {
+        errors.push({
+          competencyId: req.competencyId,
+          error: `requiredLevel ${req.requiredLevel} out of range [${comp.scaleMin},${comp.scaleMax}]`,
+        });
+      }
+    }
+    if (errors.length > 0) throw new BadRequestException({ message: 'Validation failed', errors });
+
+    await this.prisma.$transaction([
+      this.prisma.jobRoleCompetency.deleteMany({ where: { jobRoleId: roleId } }),
+      this.prisma.jobRoleCompetency.createMany({
+        data: dto.requirements.map((r) => ({
+          jobRoleId: roleId,
+          competencyId: r.competencyId,
+          requiredLevel: r.requiredLevel,
+        })),
+      }),
+    ]);
+
+    return this.getRequirements(slugOrId, roleId);
   }
 }

--- a/backend/src/org-analytics/org-analytics.controller.ts
+++ b/backend/src/org-analytics/org-analytics.controller.ts
@@ -73,4 +73,27 @@ export class OrgAnalyticsController {
   ) {
     return this.orgAnalyticsService.getMemberAnalytics(orgId, userId);
   }
+  @Get('competency-profile')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get competency profile for org or individual member' })
+  @ApiQuery({ name: 'memberId', required: false })
+  @ApiQuery({ name: 'jobRoleId', required: false })
+  getCompetencyProfile(
+    @Param('orgId') orgId: string,
+    @Query('memberId') memberId?: string,
+    @Query('jobRoleId') jobRoleId?: string,
+  ) {
+    return this.orgAnalyticsService.getCompetencyProfile(orgId, memberId, jobRoleId);
+  }
+
+  @Get('competency-heatmap')
+  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+  @UseGuards(JwtAuthGuard, OrgRoleGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get competency heatmap (all members x all competencies)' })
+  getCompetencyHeatmap(@Param('orgId') orgId: string) {
+    return this.orgAnalyticsService.getCompetencyHeatmap(orgId);
+  }
 }

--- a/backend/src/org-analytics/org-analytics.controller.ts
+++ b/backend/src/org-analytics/org-analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query, UseGuards, Req } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -13,59 +13,51 @@ import { OrgRole } from '@prisma/client';
 
 @ApiTags('org-analytics')
 @Controller('organizations/:orgId/analytics')
+@UseGuards(JwtAuthGuard, OrgRoleGuard)
+@OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
+@ApiBearerAuth()
 export class OrgAnalyticsController {
   constructor(private readonly orgAnalyticsService: OrgAnalyticsService) {}
 
   @Get('overview')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get team overview KPIs' })
   getOverview(@Param('orgId') orgId: string) {
     return this.orgAnalyticsService.getOverview(orgId);
   }
 
   @Get('readiness')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get per-certification readiness across team' })
   getReadiness(@Param('orgId') orgId: string) {
     return this.orgAnalyticsService.getReadiness(orgId);
   }
 
   @Get('skill-gaps')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get domain-level weakness analysis' })
   getSkillGaps(@Param('orgId') orgId: string) {
     return this.orgAnalyticsService.getSkillGaps(orgId);
   }
 
   @Get('progress')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get week-over-week progress trends' })
-  @ApiQuery({ name: 'weeks', required: false, type: Number })
+  @ApiQuery({
+    name: 'weeks',
+    required: false,
+    type: Number,
+    minimum: 1,
+    maximum: 52,
+  })
   getProgress(@Param('orgId') orgId: string, @Query('weeks') weeks?: string) {
-    return this.orgAnalyticsService.getProgress(orgId, weeks ? +weeks : 12);
+    const w = weeks ? Math.min(52, Math.max(1, +weeks)) : 12;
+    return this.orgAnalyticsService.getProgress(orgId, w);
   }
 
   @Get('engagement')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get engagement metrics' })
   getEngagement(@Param('orgId') orgId: string) {
     return this.orgAnalyticsService.getEngagement(orgId);
   }
 
   @Get('member/:userId')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get individual member deep-dive analytics' })
   getMemberAnalytics(
     @Param('orgId') orgId: string,
@@ -73,11 +65,11 @@ export class OrgAnalyticsController {
   ) {
     return this.orgAnalyticsService.getMemberAnalytics(orgId, userId);
   }
+
   @Get('competency-profile')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get competency profile for org or individual member' })
+  @ApiOperation({
+    summary: 'Get competency profile for org or individual member',
+  })
   @ApiQuery({ name: 'memberId', required: false })
   @ApiQuery({ name: 'jobRoleId', required: false })
   getCompetencyProfile(
@@ -85,14 +77,17 @@ export class OrgAnalyticsController {
     @Query('memberId') memberId?: string,
     @Query('jobRoleId') jobRoleId?: string,
   ) {
-    return this.orgAnalyticsService.getCompetencyProfile(orgId, memberId, jobRoleId);
+    return this.orgAnalyticsService.getCompetencyProfile(
+      orgId,
+      memberId,
+      jobRoleId,
+    );
   }
 
   @Get('competency-heatmap')
-  @OrgRoles(OrgRole.OWNER, OrgRole.ADMIN, OrgRole.MANAGER)
-  @UseGuards(JwtAuthGuard, OrgRoleGuard)
-  @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get competency heatmap (all members x all competencies)' })
+  @ApiOperation({
+    summary: 'Get competency heatmap (all members x all competencies)',
+  })
   getCompetencyHeatmap(@Param('orgId') orgId: string) {
     return this.orgAnalyticsService.getCompetencyHeatmap(orgId);
   }

--- a/backend/src/org-analytics/org-analytics.service.ts
+++ b/backend/src/org-analytics/org-analytics.service.ts
@@ -444,7 +444,7 @@ export class OrgAnalyticsService {
       where: { orgId, isActive: true },
       include: {
         domains: { select: { domainName: true } },
-        jobRoleCompetencies: jobRoleId
+        jobRoles: jobRoleId
           ? { where: { jobRoleId }, select: { requiredLevel: true } }
           : { where: { jobRoleId: '__none__' }, select: { requiredLevel: true } },
       },
@@ -475,8 +475,8 @@ export class OrgAnalyticsService {
     }
 
     const result = competencies.map((comp) => {
-      const domainNames = comp.domains.map((d) => d.domainName);
-      const mappedDomains = domainNames.filter((d) => domainAgg[d]);
+      const domainNames = (comp as any).domains.map((d: { domainName: string }) => d.domainName);
+      const mappedDomains = domainNames.filter((d: string) => domainAgg[d]);
       const domainScores: Record<string, { correct: number; total: number }> = {};
       for (const d of mappedDomains) domainScores[d] = domainAgg[d];
 
@@ -486,8 +486,8 @@ export class OrgAnalyticsService {
         thresholds: DEFAULT_THRESHOLDS_1_5,
       });
 
-      const requiredLevel = jobRoleId && (comp as any).jobRoleCompetencies?.length > 0
-        ? (comp as any).jobRoleCompetencies[0].requiredLevel
+      const requiredLevel = jobRoleId && (comp as any).jobRoles?.length > 0
+        ? (comp as any).jobRoles[0].requiredLevel
         : null;
 
       return {
@@ -545,8 +545,8 @@ export class OrgAnalyticsService {
       const uid = member.userId;
       const domainAgg = userDomainAgg[uid] ?? {};
       for (const comp of competencies) {
-        const domainNames = comp.domains.map((d) => d.domainName);
-        const mappedDomains = domainNames.filter((d) => domainAgg[d]);
+        const domainNames = (comp as any).domains.map((d: { domainName: string }) => d.domainName);
+        const mappedDomains = domainNames.filter((d: string) => domainAgg[d]);
         const domainScores: Record<string, { correct: number; total: number }> = {};
         for (const d of mappedDomains) domainScores[d] = domainAgg[d];
         const inferred = inferCompetencyLevel(domainScores, mappedDomains, {

--- a/backend/src/org-analytics/org-analytics.service.ts
+++ b/backend/src/org-analytics/org-analytics.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AttemptStatus, CandidateAttemptStatus } from '@prisma/client';
-import { inferCompetencyLevel, DEFAULT_THRESHOLDS_1_5 } from '../competency/scoring/infer-competency-level';
+import {
+  inferCompetencyLevel,
+  DEFAULT_THRESHOLDS_1_5,
+} from '../competency/scoring/infer-competency-level';
 
 @Injectable()
 export class OrgAnalyticsService {
@@ -440,19 +443,37 @@ export class OrgAnalyticsService {
       const membership = await this.prisma.orgMember.findFirst({
         where: { orgId, userId: memberId, isActive: true },
       });
-      if (!membership) throw new NotFoundException('Member not found in this organization');
+      if (!membership)
+        throw new NotFoundException('Member not found in this organization');
+    }
+
+    interface CompetencyWithRelations {
+      id: string;
+      name: string;
+      scaleMin: number;
+      scaleMax: number;
+      domains: { domainName: string }[];
+      jobRoles?: { requiredLevel: number }[];
     }
 
     // Load competencies for this org
-    const competencies = await this.prisma.competency.findMany({
+    const competencies = (await this.prisma.competency.findMany({
       where: { orgId, isActive: true },
       include: {
         domains: { select: { domainName: true } },
-        ...(jobRoleId ? { jobRoles: { where: { jobRoleId }, select: { requiredLevel: true } } } : {}),
+        ...(jobRoleId
+          ? {
+              jobRoles: {
+                where: { jobRoleId },
+                select: { requiredLevel: true },
+              },
+            }
+          : {}),
       },
-    });
+    })) as unknown as CompetencyWithRelations[];
 
-    if (competencies.length === 0) return { competencies: [], memberId, jobRoleId };
+    if (competencies.length === 0)
+      return { competencies: [], memberId, jobRoleId };
 
     // Collect exam attempts to compute domain scores
     const targetUserIds = memberId
@@ -467,7 +488,10 @@ export class OrgAnalyticsService {
     // Aggregate domain scores across attempts
     const domainAgg: Record<string, { correct: number; total: number }> = {};
     for (const attempt of attempts) {
-      const breakdown = attempt.domainScores as Record<string, { correct: number; total: number }> | null;
+      const breakdown = attempt.domainScores as Record<
+        string,
+        { correct: number; total: number }
+      > | null;
       if (!breakdown) continue;
       for (const [domain, scores] of Object.entries(breakdown)) {
         if (!domainAgg[domain]) domainAgg[domain] = { correct: 0, total: 0 };
@@ -477,9 +501,10 @@ export class OrgAnalyticsService {
     }
 
     const result = competencies.map((comp) => {
-      const domainNames = (comp as any).domains.map((d: { domainName: string }) => d.domainName);
-      const mappedDomains = domainNames.filter((d: string) => domainAgg[d]);
-      const domainScores: Record<string, { correct: number; total: number }> = {};
+      const domainNames = comp.domains.map((d) => d.domainName);
+      const mappedDomains = domainNames.filter((d) => domainAgg[d]);
+      const domainScores: Record<string, { correct: number; total: number }> =
+        {};
       for (const d of mappedDomains) domainScores[d] = domainAgg[d];
 
       const inferred = inferCompetencyLevel(domainScores, mappedDomains, {
@@ -488,9 +513,10 @@ export class OrgAnalyticsService {
         thresholds: DEFAULT_THRESHOLDS_1_5,
       });
 
-      const requiredLevel = jobRoleId && (comp as any).jobRoles?.length > 0
-        ? (comp as any).jobRoles[0].requiredLevel
-        : null;
+      const requiredLevel =
+        jobRoleId && comp.jobRoles && comp.jobRoles.length > 0
+          ? comp.jobRoles[0].requiredLevel
+          : null;
 
       return {
         competencyId: comp.id,
@@ -505,22 +531,46 @@ export class OrgAnalyticsService {
       };
     });
 
-    return { competencies: result, memberId: memberId ?? null, jobRoleId: jobRoleId ?? null };
+    return {
+      competencies: result,
+      memberId: memberId ?? null,
+      jobRoleId: jobRoleId ?? null,
+    };
   }
 
   async getCompetencyHeatmap(orgIdOrSlug: string) {
     const orgId = await this.resolveOrgId(orgIdOrSlug);
-    const members = await this.prisma.orgMember.findMany({
-      where: { orgId, isActive: true },
-      include: { user: { select: { id: true, displayName: true, email: true } } },
-    });
-    if (members.length === 0) return { members: [], competencies: [], cells: [] };
 
-    const competencies = await this.prisma.competency.findMany({
+    const MAX_HEATMAP_MEMBERS = 200;
+
+    interface MemberWithUser {
+      userId: string;
+      user: { id: string; displayName: string | null; email: string };
+    }
+    interface CompetencyWithDomains {
+      id: string;
+      name: string;
+      scaleMin: number;
+      scaleMax: number;
+      domains: { domainName: string }[];
+    }
+
+    const members = (await this.prisma.orgMember.findMany({
+      where: { orgId, isActive: true },
+      take: MAX_HEATMAP_MEMBERS,
+      include: {
+        user: { select: { id: true, displayName: true, email: true } },
+      },
+    })) as unknown as MemberWithUser[];
+    if (members.length === 0)
+      return { members: [], competencies: [], cells: [] };
+
+    const competencies = (await this.prisma.competency.findMany({
       where: { orgId, isActive: true },
       include: { domains: { select: { domainName: true } } },
-    });
-    if (competencies.length === 0) return { members: [], competencies: [], cells: [] };
+    })) as unknown as CompetencyWithDomains[];
+    if (competencies.length === 0)
+      return { members: [], competencies: [], cells: [] };
 
     const userIds = members.map((m) => m.userId);
     const attempts = await this.prisma.examAttempt.findMany({
@@ -529,44 +579,70 @@ export class OrgAnalyticsService {
     });
 
     // Per-user domain aggregation
-    const userDomainAgg: Record<string, Record<string, { correct: number; total: number }>> = {};
+    const userDomainAgg: Record<
+      string,
+      Record<string, { correct: number; total: number }>
+    > = {};
     for (const attempt of attempts) {
       const uid = attempt.userId;
-      const breakdown = attempt.domainScores as Record<string, { correct: number; total: number }> | null;
+      const breakdown = attempt.domainScores as Record<
+        string,
+        { correct: number; total: number }
+      > | null;
       if (!breakdown) continue;
       if (!userDomainAgg[uid]) userDomainAgg[uid] = {};
       for (const [domain, scores] of Object.entries(breakdown)) {
-        if (!userDomainAgg[uid][domain]) userDomainAgg[uid][domain] = { correct: 0, total: 0 };
+        if (!userDomainAgg[uid][domain])
+          userDomainAgg[uid][domain] = { correct: 0, total: 0 };
         userDomainAgg[uid][domain].correct += scores.correct ?? 0;
         userDomainAgg[uid][domain].total += scores.total ?? 0;
       }
     }
 
-    const cells: { userId: string; competencyId: string; level: number; confidence: string }[] = [];
+    const cells: {
+      userId: string;
+      competencyId: string;
+      level: number;
+      confidence: string;
+    }[] = [];
     for (const member of members) {
       const uid = member.userId;
       const domainAgg = userDomainAgg[uid] ?? {};
       for (const comp of competencies) {
-        const domainNames = (comp as any).domains.map((d: { domainName: string }) => d.domainName);
-        const mappedDomains = domainNames.filter((d: string) => domainAgg[d]);
-        const domainScores: Record<string, { correct: number; total: number }> = {};
+        const domainNames = comp.domains.map((d) => d.domainName);
+        const mappedDomains = domainNames.filter((d) => domainAgg[d]);
+        const domainScores: Record<string, { correct: number; total: number }> =
+          {};
         for (const d of mappedDomains) domainScores[d] = domainAgg[d];
         const inferred = inferCompetencyLevel(domainScores, mappedDomains, {
           scaleMin: comp.scaleMin,
           scaleMax: comp.scaleMax,
           thresholds: DEFAULT_THRESHOLDS_1_5,
         });
-        cells.push({ userId: uid, competencyId: comp.id, level: inferred.level, confidence: inferred.confidence });
+        cells.push({
+          userId: uid,
+          competencyId: comp.id,
+          level: inferred.level,
+          confidence: inferred.confidence,
+        });
       }
     }
 
     return {
-      members: members.map((m) => ({ userId: m.userId, displayName: m.user.displayName, email: m.user.email })),
-      competencies: competencies.map((c) => ({ id: c.id, name: c.name, scaleMin: c.scaleMin, scaleMax: c.scaleMax })),
+      members: members.map((m) => ({
+        userId: m.userId,
+        displayName: m.user.displayName,
+        email: m.user.email,
+      })),
+      competencies: competencies.map((c) => ({
+        id: c.id,
+        name: c.name,
+        scaleMin: c.scaleMin,
+        scaleMax: c.scaleMax,
+      })),
       cells,
     };
   }
-
 }
 
 function getISOWeekLabel(date: Date): string {

--- a/backend/src/org-analytics/org-analytics.service.ts
+++ b/backend/src/org-analytics/org-analytics.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  NotFoundException,
-  ForbiddenException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AttemptStatus, CandidateAttemptStatus } from '@prisma/client';
 import { inferCompetencyLevel, DEFAULT_THRESHOLDS_1_5 } from '../competency/scoring/infer-competency-level';
@@ -439,14 +435,20 @@ export class OrgAnalyticsService {
   ) {
     const orgId = await this.resolveOrgId(orgIdOrSlug);
 
+    // Validate memberId belongs to this org before exposing their data
+    if (memberId) {
+      const membership = await this.prisma.orgMember.findFirst({
+        where: { orgId, userId: memberId, isActive: true },
+      });
+      if (!membership) throw new NotFoundException('Member not found in this organization');
+    }
+
     // Load competencies for this org
     const competencies = await this.prisma.competency.findMany({
       where: { orgId, isActive: true },
       include: {
         domains: { select: { domainName: true } },
-        jobRoles: jobRoleId
-          ? { where: { jobRoleId }, select: { requiredLevel: true } }
-          : { where: { jobRoleId: '__none__' }, select: { requiredLevel: true } },
+        ...(jobRoleId ? { jobRoles: { where: { jobRoleId }, select: { requiredLevel: true } } } : {}),
       },
     });
 

--- a/backend/src/org-analytics/org-analytics.service.ts
+++ b/backend/src/org-analytics/org-analytics.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AttemptStatus, CandidateAttemptStatus } from '@prisma/client';
+import { inferCompetencyLevel, DEFAULT_THRESHOLDS_1_5 } from '../competency/scoring/infer-competency-level';
 
 @Injectable()
 export class OrgAnalyticsService {
@@ -429,6 +430,141 @@ export class OrgAnalyticsService {
       })),
     };
   }
+  // ── US-A3: Competency Profile ─────────────────────────────────────────────
+
+  async getCompetencyProfile(
+    orgIdOrSlug: string,
+    memberId?: string,
+    jobRoleId?: string,
+  ) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+
+    // Load competencies for this org
+    const competencies = await this.prisma.competency.findMany({
+      where: { orgId, isActive: true },
+      include: {
+        domains: { select: { domainName: true } },
+        jobRoleCompetencies: jobRoleId
+          ? { where: { jobRoleId }, select: { requiredLevel: true } }
+          : { where: { jobRoleId: '__none__' }, select: { requiredLevel: true } },
+      },
+    });
+
+    if (competencies.length === 0) return { competencies: [], memberId, jobRoleId };
+
+    // Collect exam attempts to compute domain scores
+    const targetUserIds = memberId
+      ? [memberId]
+      : await this.getOrgMemberUserIds(orgId);
+
+    const attempts = await this.prisma.examAttempt.findMany({
+      where: { userId: { in: targetUserIds }, status: 'SUBMITTED' },
+      select: { domainScores: true },
+    });
+
+    // Aggregate domain scores across attempts
+    const domainAgg: Record<string, { correct: number; total: number }> = {};
+    for (const attempt of attempts) {
+      const breakdown = attempt.domainScores as Record<string, { correct: number; total: number }> | null;
+      if (!breakdown) continue;
+      for (const [domain, scores] of Object.entries(breakdown)) {
+        if (!domainAgg[domain]) domainAgg[domain] = { correct: 0, total: 0 };
+        domainAgg[domain].correct += scores.correct ?? 0;
+        domainAgg[domain].total += scores.total ?? 0;
+      }
+    }
+
+    const result = competencies.map((comp) => {
+      const domainNames = comp.domains.map((d) => d.domainName);
+      const mappedDomains = domainNames.filter((d) => domainAgg[d]);
+      const domainScores: Record<string, { correct: number; total: number }> = {};
+      for (const d of mappedDomains) domainScores[d] = domainAgg[d];
+
+      const inferred = inferCompetencyLevel(domainScores, mappedDomains, {
+        scaleMin: comp.scaleMin,
+        scaleMax: comp.scaleMax,
+        thresholds: DEFAULT_THRESHOLDS_1_5,
+      });
+
+      const requiredLevel = jobRoleId && (comp as any).jobRoleCompetencies?.length > 0
+        ? (comp as any).jobRoleCompetencies[0].requiredLevel
+        : null;
+
+      return {
+        competencyId: comp.id,
+        competencyName: comp.name,
+        inferredLevel: inferred.level,
+        confidence: inferred.confidence,
+        sampleSize: inferred.sampleSize,
+        requiredLevel,
+        gap: requiredLevel != null ? inferred.level - requiredLevel : null,
+        scaleMin: comp.scaleMin,
+        scaleMax: comp.scaleMax,
+      };
+    });
+
+    return { competencies: result, memberId: memberId ?? null, jobRoleId: jobRoleId ?? null };
+  }
+
+  async getCompetencyHeatmap(orgIdOrSlug: string) {
+    const orgId = await this.resolveOrgId(orgIdOrSlug);
+    const members = await this.prisma.orgMember.findMany({
+      where: { orgId, isActive: true },
+      include: { user: { select: { id: true, displayName: true, email: true } } },
+    });
+    if (members.length === 0) return { members: [], competencies: [], cells: [] };
+
+    const competencies = await this.prisma.competency.findMany({
+      where: { orgId, isActive: true },
+      include: { domains: { select: { domainName: true } } },
+    });
+    if (competencies.length === 0) return { members: [], competencies: [], cells: [] };
+
+    const userIds = members.map((m) => m.userId);
+    const attempts = await this.prisma.examAttempt.findMany({
+      where: { userId: { in: userIds }, status: 'SUBMITTED' },
+      select: { userId: true, domainScores: true },
+    });
+
+    // Per-user domain aggregation
+    const userDomainAgg: Record<string, Record<string, { correct: number; total: number }>> = {};
+    for (const attempt of attempts) {
+      const uid = attempt.userId;
+      const breakdown = attempt.domainScores as Record<string, { correct: number; total: number }> | null;
+      if (!breakdown) continue;
+      if (!userDomainAgg[uid]) userDomainAgg[uid] = {};
+      for (const [domain, scores] of Object.entries(breakdown)) {
+        if (!userDomainAgg[uid][domain]) userDomainAgg[uid][domain] = { correct: 0, total: 0 };
+        userDomainAgg[uid][domain].correct += scores.correct ?? 0;
+        userDomainAgg[uid][domain].total += scores.total ?? 0;
+      }
+    }
+
+    const cells: { userId: string; competencyId: string; level: number; confidence: string }[] = [];
+    for (const member of members) {
+      const uid = member.userId;
+      const domainAgg = userDomainAgg[uid] ?? {};
+      for (const comp of competencies) {
+        const domainNames = comp.domains.map((d) => d.domainName);
+        const mappedDomains = domainNames.filter((d) => domainAgg[d]);
+        const domainScores: Record<string, { correct: number; total: number }> = {};
+        for (const d of mappedDomains) domainScores[d] = domainAgg[d];
+        const inferred = inferCompetencyLevel(domainScores, mappedDomains, {
+          scaleMin: comp.scaleMin,
+          scaleMax: comp.scaleMax,
+          thresholds: DEFAULT_THRESHOLDS_1_5,
+        });
+        cells.push({ userId: uid, competencyId: comp.id, level: inferred.level, confidence: inferred.confidence });
+      }
+    }
+
+    return {
+      members: members.map((m) => ({ userId: m.userId, displayName: m.user.displayName, email: m.user.email })),
+      competencies: competencies.map((c) => ({ id: c.id, name: c.name, scaleMin: c.scaleMin, scaleMax: c.scaleMax })),
+      cells,
+    };
+  }
+
 }
 
 function getISOWeekLabel(date: Date): string {

--- a/docs/specs/sprint-1-us-a1-competency-framework-srs.md
+++ b/docs/specs/sprint-1-us-a1-competency-framework-srs.md
@@ -1,0 +1,308 @@
+# SRS — US-A1: Competency Framework (Định nghĩa năng lực & thang bậc)
+
+|                      |                                                                                         |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| **Tài liệu**         | Software Requirements Specification (SRS)                                               |
+| **Tính năng**        | US-A1 — Competency Framework                                                            |
+| **Issue**            | [#95](https://github.com/thanhpt-25/brain-gym/issues/95)                                |
+| **Epic**             | A — Khung năng lực & chuẩn theo vị trí                                                  |
+| **Phiên bản**        | Draft 1.0                                                                               |
+| **Ngày**             | 2026-06-17                                                                              |
+| **Trạng thái**       | Draft — chờ implement                                                                   |
+| **Phụ thuộc**        | Sprint 0 (schema, competency scaffold)                                                  |
+| **Module liên quan** | `competency` (backend) · `OrgCompetencies.tsx`, `src/services/competency.ts` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-A1**, cho phép Admin/Manager tạo và quản lý _năng lực_ (Competency) trong phạm vi tổ chức: định nghĩa tên, mô tả, thang bậc (vd. 1–5 / Beginner→Expert), gắn câu hỏi và domain vào từng competency, làm nền tảng cho US-A2 (chuẩn JobRole) và US-A3 (hồ sơ gap).
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+
+- CRUD `Competency` trong phạm vi org (tên, mô tả, thang bậc cấu hình được `scaleMin`–`scaleMax`).
+- Toggle `isActive` để ẩn/hiện competency mà không xóa.
+- Gắn `OrgQuestion` vào competency qua bảng nối `QuestionCompetency` (với weight).
+- Quản lý `CompetencyDomain` — domain nào được map với competency này (dùng cho scoring US-A3).
+- RBAC: OWNER/ADMIN/MANAGER ghi; MEMBER/RECRUITER chỉ đọc.
+- Fix bug path prefix controller.
+
+**Ngoài phạm vi:**
+
+- Tính toán năng lực từ kết quả thi (thuộc US-A3).
+- Gắn competency vào JobRole required level (thuộc US-A2).
+- Import competency hàng loạt từ CSV.
+- Competency dùng chung giữa nhiều org (multi-tenant share).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ               | Ý nghĩa                                                                    |
+| ----------------------- | -------------------------------------------------------------------------- |
+| **Competency**          | Năng lực định nghĩa trong org: tên + thang bậc + danh sách domain          |
+| **scaleMin / scaleMax** | Giới hạn thang bậc (vd. 1–5 hoặc 1–3); mặc định 1–5                        |
+| **CompetencyDomain**    | Domain câu hỏi (category) được map với competency này để tính level        |
+| **QuestionCompetency**  | Bảng nối: một câu hỏi OrgQuestion thuộc competency nào, trọng số bao nhiêu |
+| **isActive**            | Cờ ẩn/hiện competency; INACTIVE không xuất hiện trong picker US-A2/A3      |
+
+### 1.4. Hiện trạng trước US-A1
+
+- Schema `Competency`, `CompetencyDomain`, `QuestionCompetency` đã tồn tại (Sprint 0).
+- CRUD service cơ bản đã có (`competency.service.ts`).
+- **BUG CHẶN**: Controller dùng prefix `orgs/:orgId/competencies` trong khi FE service và toàn bộ controller khác dùng `organizations/:orgId/...` → 404 toàn bộ Competency API.
+- `MANAGER` chưa được cấp quyền ghi trong `@OrgRoles`.
+- Chưa có endpoint gắn/gỡ QuestionCompetency, quản lý CompetencyDomain, toggle isActive.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Fix bug path prefix (ƯU TIÊN CAO NHẤT)
+
+**Mô tả:** Đổi decorator `@Controller('orgs/:orgId/competencies')` thành `@Controller('organizations/:orgId/competencies')` trong `backend/src/competency/competency.controller.ts`.
+
+**Không có API mới** — chỉ là fix 1 dòng, nhưng chặn toàn bộ tính năng competency.
+
+**Kiểm tra:** `GET /api/v1/organizations/:orgId/competencies` trả 200 thay vì 404.
+
+---
+
+### FR-2 — Thêm MANAGER vào quyền ghi
+
+**Mô tả:** Bổ sung `OrgRole.MANAGER` vào decorator `@OrgRoles(...)` cho các route POST, PATCH, DELETE.
+
+```
+POST   /organizations/:orgId/competencies         → OWNER, ADMIN, MANAGER
+PATCH  /organizations/:orgId/competencies/:id     → OWNER, ADMIN, MANAGER
+DELETE /organizations/:orgId/competencies/:id     → OWNER, ADMIN, MANAGER
+GET    /organizations/:orgId/competencies         → tất cả role
+GET    /organizations/:orgId/competencies/:id     → tất cả role
+```
+
+---
+
+### FR-3 — CRUD Competency
+
+**API đã có, chỉ cần confirm spec và validation:**
+
+#### `POST /organizations/:orgId/competencies`
+
+Request body:
+
+```json
+{
+  "name": "AWS Networking",
+  "description": "Kiến thức mạng AWS VPC, Route53, CloudFront",
+  "scaleMin": 1,
+  "scaleMax": 5
+}
+```
+
+Response `201`:
+
+```json
+{
+  "id": "uuid",
+  "orgId": "uuid",
+  "name": "AWS Networking",
+  "description": "...",
+  "scaleMin": 1,
+  "scaleMax": 5,
+  "isActive": true,
+  "createdAt": "ISO8601",
+  "updatedAt": "ISO8601"
+}
+```
+
+**Validation:**
+
+- `name`: required, string, 1–200 ký tự; unique trong org (unique constraint DB)
+- `scaleMin`: integer ≥ 1, default 1
+- `scaleMax`: integer ≤ 10, default 5
+- `scaleMin < scaleMax` (validate ở service layer)
+
+**Lỗi:**
+
+- `409 Conflict` nếu tên đã tồn tại trong org
+- `400 Bad Request` nếu scaleMin ≥ scaleMax
+
+#### `GET /organizations/:orgId/competencies`
+
+Query params: `isActive?: boolean`
+
+Response `200`: mảng Competency, sort `name ASC`.
+
+#### `GET /organizations/:orgId/competencies/:id`
+
+Response `200`: Competency kèm `domains[]`.
+
+#### `PATCH /organizations/:orgId/competencies/:id`
+
+Body: subset của CreateCompetencyDto (tất cả optional). Không cho đổi `scaleMin/scaleMax` nếu đã có `JobRoleCompetency` tham chiếu (guard ở service).
+
+#### `DELETE /organizations/:orgId/competencies/:id`
+
+Response `204`. Cascade xóa `CompetencyDomain`, `QuestionCompetency`, `JobRoleCompetency`.
+
+---
+
+### FR-4 — Toggle isActive
+
+#### `PATCH /organizations/:orgId/competencies/:id/toggle-active`
+
+Không cần body. Đảo giá trị `isActive`.
+
+Response `200`: Competency đã cập nhật.
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+---
+
+### FR-5 — Gắn OrgQuestion vào Competency
+
+#### `POST /organizations/:orgId/competencies/:id/questions`
+
+Request body:
+
+```json
+{
+  "orgQuestionId": "uuid",
+  "weight": 1.0
+}
+```
+
+Response `201`: bản ghi QuestionCompetency.
+
+**Validation:**
+
+- `orgQuestionId` phải thuộc cùng `orgId`.
+- Không cho gắn trùng (unique constraint); trả `409` nếu đã tồn tại.
+- `weight`: float > 0, default 1.0.
+
+#### `GET /organizations/:orgId/competencies/:id/questions`
+
+Response `200`: `[{id, orgQuestionId, weight, question: {title, category}}]`.
+
+#### `DELETE /organizations/:orgId/competencies/:id/questions/:questionId`
+
+`questionId` là `orgQuestionId`. Response `204`.
+
+---
+
+### FR-6 — Quản lý CompetencyDomain
+
+Domain là tên category câu hỏi được map với competency này để dùng trong `inferCompetencyLevel()`.
+
+#### `GET /organizations/:orgId/competencies/:id/domains`
+
+Response `200`: `[{id, domainName, source}]`.
+
+#### `POST /organizations/:orgId/competencies/:id/domains`
+
+Request body:
+
+```json
+{
+  "domainName": "Networking",
+  "source": "ORG_QUESTION_CATEGORY"
+}
+```
+
+Response `201`. Trả `409` nếu (competencyId, source, domainName) đã tồn tại.
+
+#### `DELETE /organizations/:orgId/competencies/:id/domains/:domainId`
+
+Response `204`.
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR             | Mô tả                                                                           |
+| --------------- | ------------------------------------------------------------------------------- |
+| **Phân quyền**  | 401 nếu không có JWT; 403 nếu không đủ OrgRole                                  |
+| **Unique**      | (orgId, name) unique — enforce ở DB và trả 409 rõ ràng                          |
+| **Cascade**     | Xóa Competency → tự xóa CompetencyDomain, QuestionCompetency, JobRoleCompetency |
+| **Scope org**   | Mọi query phải filter theo orgId; không để lộ data của org khác                 |
+| **Performance** | findAll phải có index trên orgId (đã có trong schema)                           |
+
+---
+
+## 4. API Contract tổng hợp
+
+| Method | Path                                                           | RBAC                | Mô tả                 |
+| ------ | -------------------------------------------------------------- | ------------------- | --------------------- |
+| GET    | `/organizations/:orgId/competencies`                           | Tất cả              | List competencies     |
+| POST   | `/organizations/:orgId/competencies`                           | OWNER,ADMIN,MANAGER | Tạo competency        |
+| GET    | `/organizations/:orgId/competencies/:id`                       | Tất cả              | Chi tiết + domains    |
+| PATCH  | `/organizations/:orgId/competencies/:id`                       | OWNER,ADMIN,MANAGER | Cập nhật              |
+| DELETE | `/organizations/:orgId/competencies/:id`                       | OWNER,ADMIN,MANAGER | Xóa                   |
+| PATCH  | `/organizations/:orgId/competencies/:id/toggle-active`         | OWNER,ADMIN,MANAGER | Toggle isActive       |
+| GET    | `/organizations/:orgId/competencies/:id/questions`             | Tất cả              | List linked questions |
+| POST   | `/organizations/:orgId/competencies/:id/questions`             | OWNER,ADMIN,MANAGER | Link question         |
+| DELETE | `/organizations/:orgId/competencies/:id/questions/:questionId` | OWNER,ADMIN,MANAGER | Unlink question       |
+| GET    | `/organizations/:orgId/competencies/:id/domains`               | Tất cả              | List domains          |
+| POST   | `/organizations/:orgId/competencies/:id/domains`               | OWNER,ADMIN,MANAGER | Thêm domain           |
+| DELETE | `/organizations/:orgId/competencies/:id/domains/:domainId`     | OWNER,ADMIN,MANAGER | Xóa domain            |
+
+---
+
+## 5. Giao diện người dùng
+
+### 5.1. Trang Org Settings → Competencies
+
+- List competencies dạng card/table: tên, mô tả, thang bậc (scaleMin–scaleMax), badge Active/Inactive, số domain, số question.
+- Button "Thêm năng lực" → modal tạo mới.
+- Mỗi row: nút Edit, Toggle Active, Delete (có confirm dialog).
+
+### 5.2. Modal Tạo/Sửa Competency
+
+Fields: Tên (\*), Mô tả, Scale Min (1–9), Scale Max (2–10). Validate client-side.
+
+### 5.3. Trang Chi tiết Competency
+
+Tabs:
+
+- **Domains**: list domain names đã map; nút "Thêm domain" (input text + dropdown source).
+- **Câu hỏi**: list OrgQuestion đã gắn với weight; nút "Gắn câu hỏi" (search by title).
+
+---
+
+## 6. Test Cases
+
+| #   | Tình huống                                             | Kết quả mong đợi               |
+| --- | ------------------------------------------------------ | ------------------------------ |
+| T1  | MANAGER tạo competency mới                             | 201, competency tạo thành công |
+| T2  | Tạo competency trùng tên trong cùng org                | 409 Conflict                   |
+| T3  | Tạo competency với scaleMin ≥ scaleMax                 | 400 Bad Request                |
+| T4  | MEMBER thử tạo competency                              | 403 Forbidden                  |
+| T5  | GET competency của org khác                            | 403 hoặc 404                   |
+| T6  | Toggle isActive → inactive → active                    | isActive đảo chiều đúng        |
+| T7  | Gắn orgQuestion thuộc org khác                         | 400 Bad Request                |
+| T8  | Gắn orgQuestion trùng vào cùng competency              | 409 Conflict                   |
+| T9  | Xóa competency đang có JobRoleCompetency               | Cascade xóa JobRoleCompetency  |
+| T10 | Thêm domain với (competencyId,source,domainName) trùng | 409 Conflict                   |
+| T11 | FE gọi GET /organizations/:orgId/competencies          | 200 (bug fix đã áp dụng)       |
+
+---
+
+## 7. Thứ tự implement
+
+1. **Fix FR-1** (đổi prefix controller) — 1 dòng, unblock toàn bộ.
+2. **FR-2** (thêm MANAGER vào @OrgRoles) — 1 commit nhỏ.
+3. **FR-3** (confirm validation + thêm 409/400 handling trong service).
+4. **FR-4** toggle-active endpoint + service.
+5. **FR-5** QuestionCompetency endpoints + service.
+6. **FR-6** CompetencyDomain endpoints + service.
+7. **FE** cập nhật `OrgCompetencies.tsx` — thêm tabs Domains & Questions.
+8. Tests cho tất cả FR.
+
+---
+
+## 8. Open Questions
+
+- Có cho phép đổi `scaleMin/scaleMax` sau khi đã có `JobRoleCompetency` tham chiếu không? (Đề xuất: chặn nếu có requiredLevel nằm ngoài range mới.)
+- `CompetencyDomainSource` enum có những giá trị nào ngoài `ORG_QUESTION_CATEGORY`? (Cần confirm với schema.)

--- a/docs/specs/sprint-1-us-a2-jobrole-competency-srs.md
+++ b/docs/specs/sprint-1-us-a2-jobrole-competency-srs.md
@@ -1,0 +1,219 @@
+# SRS — US-A2: Năng lực chuẩn cho JobRole (Required Levels)
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | US-A2 — JobRole Competency Requirements |
+| **Issue** | #96 |
+| **Epic** | A — Khung năng lực & chuẩn theo vị trí |
+| **Phiên bản** | Draft 1.0 |
+| **Ngày** | 2026-06-17 |
+| **Trạng thái** | Draft — chờ implement |
+| **Phụ thuộc** | US-A1 (#95) phải hoàn thành trước |
+| **Module liên quan** | `job-roles` (backend) · `OrgJobRoles.tsx`, `src/services/job-roles.ts` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-A2**, cho phép Manager định nghĩa mỗi `JobRole` cần những năng lực nào ở bậc tối thiểu (`requiredLevel`). Đây là "chuẩn vị trí" — dữ liệu nền để hệ thống biết "đạt chuẩn" nghĩa là gì, dùng chung cho US-A3 (gap map nội bộ) và US-E2 (ranking ứng viên).
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Gắn N competency vào một JobRole, mỗi cặp có `requiredLevel`.
+- API GET/PUT requirements cho một JobRole.
+- UI gán/sửa năng lực chuẩn trong trang quản lý JobRole.
+- Validation `requiredLevel` trong `[scaleMin, scaleMax]` của competency tương ứng.
+- Competency phải thuộc cùng org với JobRole.
+
+**Ngoài phạm vi:**
+- Tính gap năng lực (US-A3).
+- Gắn JobRole vào Assessment (Sprint 0 đã có).
+- Sao chép template requirements giữa các role.
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **JobRoleCompetency** | Bảng nối: JobRole → Competency + requiredLevel |
+| **requiredLevel** | Bậc năng lực tối thiểu, phải trong [scaleMin, scaleMax] của competency |
+| **Requirements** | Tập hợp tất cả JobRoleCompetency của một JobRole |
+
+### 1.4. Hiện trạng trước US-A2
+
+- Schema `JobRole` và `JobRoleCompetency` đã có đầy đủ trong Prisma.
+- CRUD JobRole (list/create/update/delete) đã có trong `job-roles.service.ts` và `job-roles.controller.ts`.
+- **Không có bất kỳ tham chiếu nào đến `JobRoleCompetency`** trong toàn bộ backend code.
+- Không có endpoint GET/PUT requirements, không có UI gán competency cho role.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Lấy danh sách năng lực chuẩn của JobRole
+
+#### `GET /organizations/:orgId/job-roles/:roleId/competencies`
+
+**RBAC:** Tất cả role (dùng trong UI AssessmentBuilder và US-A3).
+
+Response `200`:
+```json
+[
+  {
+    "id": "uuid",
+    "competencyId": "uuid",
+    "competencyName": "AWS Networking",
+    "requiredLevel": 3,
+    "scaleMin": 1,
+    "scaleMax": 5
+  }
+]
+```
+
+Trả mảng rỗng `[]` nếu chưa có requirements.
+
+---
+
+### FR-2 — Đặt (replace-all) năng lực chuẩn
+
+#### `PUT /organizations/:orgId/job-roles/:roleId/competencies`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+**Semantics:** Replace-all trong transaction — xóa tất cả requirements cũ → insert mới.
+
+Request body:
+```json
+{
+  "requirements": [
+    { "competencyId": "uuid-1", "requiredLevel": 3 },
+    { "competencyId": "uuid-2", "requiredLevel": 4 }
+  ]
+}
+```
+
+Gửi `"requirements": []` để xóa hết requirements.
+
+Response `200`: mảng như FR-1.
+
+**Validation (thực hiện trước transaction):**
+1. `roleId` phải tồn tại và thuộc `orgId`.
+2. Mỗi `competencyId` phải tồn tại và thuộc cùng `orgId`.
+3. Không có `competencyId` trùng lặp trong payload.
+4. `requiredLevel` là integer trong `[competency.scaleMin, competency.scaleMax]`.
+5. Bất kỳ item nào fail → toàn bộ request fail `400` (không partial insert).
+
+**Lỗi `400`:**
+```json
+{
+  "statusCode": 400,
+  "message": "Validation failed",
+  "errors": [
+    { "competencyId": "uuid-1", "error": "requiredLevel 6 out of range [1,5]" }
+  ]
+}
+```
+
+---
+
+### FR-3 — FE: Drawer requirements trong OrgJobRoles
+
+**Luồng:**
+1. Click "Năng lực chuẩn" trên một JobRole row → Sheet/Drawer mở.
+2. Hiển thị list requirements hiện tại (query FR-1).
+3. Thêm: dropdown chọn active competency; input requiredLevel (số, range [scaleMin, scaleMax]).
+4. Xóa: button xóa từng row.
+5. "Lưu" → PUT FR-2 với toàn bộ state local.
+6. Toast thành công / hiển thị lỗi per item.
+
+**FE service** (thêm vào `job-roles.ts`):
+```typescript
+export const getJobRoleCompetencies = async (
+  slug: string,
+  roleId: string,
+): Promise<JobRoleCompetencyItem[]>
+
+export const setJobRoleCompetencies = async (
+  slug: string,
+  roleId: string,
+  requirements: { competencyId: string; requiredLevel: number }[],
+): Promise<JobRoleCompetencyItem[]>
+```
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR | Mô tả |
+|---|---|
+| **Atomicity** | PUT dùng Prisma `$transaction` (delete-all + createMany) |
+| **Scope org** | Mọi competencyId phải thuộc orgId — validate trước transaction |
+| **isActive** | Chỉ competency `isActive=true` xuất hiện trong dropdown picker UI |
+| **Không breaking** | GET job-roles hiện có không thay đổi response shape |
+
+---
+
+## 4. API Contract
+
+| Method | Path | RBAC | Mô tả |
+|---|---|---|---|
+| GET | `/organizations/:orgId/job-roles/:roleId/competencies` | Tất cả | Lấy requirements |
+| PUT | `/organizations/:orgId/job-roles/:roleId/competencies` | OWNER,ADMIN,MANAGER | Set requirements (replace-all) |
+
+---
+
+## 5. Mô hình dữ liệu
+
+Schema đã có — không cần migration mới:
+
+```prisma
+model JobRoleCompetency {
+  id            String   @id @default(uuid())
+  jobRoleId     String   @map("job_role_id")
+  competencyId  String   @map("competency_id")
+  requiredLevel Int      @map("required_level")
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@unique([jobRoleId, competencyId])
+}
+```
+
+---
+
+## 6. Test Cases
+
+| # | Tình huống | Kết quả |
+|---|---|---|
+| T1 | MANAGER set 3 requirements | 200, 3 items trả về |
+| T2 | PUT với `requirements: []` | 200, xóa hết |
+| T3 | `requiredLevel=6` với `scaleMax=5` | 400 + error detail |
+| T4 | `requiredLevel=0` với `scaleMin=1` | 400 |
+| T5 | `competencyId` thuộc org khác | 400 |
+| T6 | Trùng `competencyId` trong payload | 400 |
+| T7 | MEMBER thử PUT | 403 |
+| T8 | roleId không tồn tại trong org | 404 |
+| T9 | GET role chưa có requirements | 200, `[]` |
+| T10 | PUT → GET → kết quả khớp | Consistency |
+
+---
+
+## 7. Thứ tự implement
+
+1. **US-A1 phải done** (competency CRUD hoạt động đúng path).
+2. DTO `SetJobRoleCompetenciesDto` (`requirements: [{competencyId, requiredLevel}]`).
+3. `getRequirements(orgId, roleId)` + `setRequirements(orgId, roleId, dto)` trong `job-roles.service.ts`.
+4. Routes mới trong `job-roles.controller.ts`.
+5. FE: thêm 2 functions vào `job-roles.ts`.
+6. FE: mở rộng `OrgJobRoles.tsx` với drawer requirements.
+7. Unit tests + integration tests.
+
+---
+
+## 8. Open Questions
+
+- Có cần PATCH riêng từng item (chỉ sửa 1 requiredLevel) hay PUT batch là đủ?
+- Khi xóa Competency: `onDelete: Restrict` trong schema hiện tại — cần thông báo rõ cho người dùng nếu competency đang được dùng trong JobRole.

--- a/docs/specs/sprint-1-us-a3-competency-profile-srs.md
+++ b/docs/specs/sprint-1-us-a3-competency-profile-srs.md
@@ -1,0 +1,216 @@
+# SRS — US-A3: Hồ sơ năng lực nhân viên & Bản đồ Gap
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | US-A3 — Competency Profile & Gap Map |
+| **Issue** | #97 |
+| **Epic** | A — Khung năng lực & chuẩn theo vị trí |
+| **Phiên bản** | Draft 1.0 |
+| **Ngày** | 2026-06-17 |
+| **Trạng thái** | Draft — chờ implement |
+| **Phụ thuộc** | US-A1 (#95) và US-A2 (#96) phải hoàn thành trước |
+| **Module liên quan** | `org-analytics` (backend) · `ReadinessHeatmap.tsx`, `SkillGapChart.tsx` (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-A3**, cho phép nhân viên/Manager xem hồ sơ năng lực hiện tại (suy ra từ kết quả thi `ExamAttempt`) so với chuẩn vị trí (`JobRoleCompetency.requiredLevel`), hiển thị dạng radar/heatmap với tô màu đạt/chưa đạt.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Suy ra bậc năng lực (`currentLevel`) từ `domainScores` của `ExamAttempt` bằng `inferCompetencyLevel()`.
+- Endpoint analytics: profile per member + so với `requiredLevel` của job role.
+- Endpoint analytics: heatmap tất cả member × tất cả competency.
+- FE: radar chart per competency (đạt/chưa đạt), heatmap member × competency.
+- RBAC: member thấy hồ sơ mình; MANAGER/ADMIN/OWNER thấy tất cả.
+
+**Ngoài phạm vi:**
+- Tính năng lực từ kết quả thi ứng viên bên ngoài (US-E2).
+- Lộ trình học gợi ý (Sprint 2+).
+- Export hồ sơ năng lực ra PDF.
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **currentLevel** | Bậc năng lực hiện tại, suy ra từ domainScores của ExamAttempt |
+| **requiredLevel** | Bậc yêu cầu từ JobRoleCompetency (US-A2) |
+| **gap** | `requiredLevel - currentLevel`; dương = thiếu hụt; 0 hoặc âm = đạt |
+| **confidence** | Độ tin cậy của currentLevel: LOW (<8 câu), MEDIUM (8-19), HIGH (≥20) |
+| **inferCompetencyLevel** | Hàm thuần trong `competency/scoring/infer-competency-level.ts` |
+
+### 1.4. Hiện trạng trước US-A3
+
+- `inferCompetencyLevel(domainScores, mappedDomains, options)` — hàm thuần có test đầy đủ.
+- `getSkillGaps()` trong `org-analytics.service.ts` — tổng hợp domain thô, **chưa map sang competency**.
+- `ReadinessHeatmap.tsx` và `SkillGapChart.tsx` — components FE sẵn có, chưa wire với competency data.
+- Schema: `ExamAttempt.domainScores (Json)`, `CompetencyDomain`, `JobRoleCompetency`.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Endpoint: Hồ sơ năng lực per member
+
+#### `GET /organizations/:orgId/analytics/competency-profile`
+
+Query params:
+- `memberId` (optional): userId của member; nếu không có → dùng authenticated user.
+- `jobRoleId` (optional): nếu có → so sánh với `requiredLevel` của role đó.
+
+**RBAC:**
+- Member không truyền `memberId` (hoặc truyền userId của mình) → 200.
+- Member truyền `memberId` của người khác → 403.
+- MANAGER/ADMIN/OWNER → 200 cho bất kỳ memberId.
+
+**Logic tính toán:**
+
+```
+1. Lấy tất cả ExamAttempt của member (status=SUBMITTED).
+2. Aggregate domainScores thành map: { domainName: {correct, total} }.
+3. Lấy tất cả Competency của org (isActive=true).
+4. Với mỗi Competency:
+   a. Lấy CompetencyDomain[] của competency đó.
+   b. Gọi inferCompetencyLevel(aggregatedDomainScores, mappedDomains, {scaleMin, scaleMax, DEFAULT_THRESHOLDS_1_5}).
+   c. Nếu jobRoleId được cung cấp: lấy requiredLevel từ JobRoleCompetency.
+   d. Tính gap = requiredLevel - currentLevel (null nếu không có jobRoleId).
+5. Trả về mảng kết quả.
+```
+
+Response `200`:
+```json
+[
+  {
+    "competencyId": "uuid",
+    "competencyName": "AWS Networking",
+    "currentLevel": 3,
+    "requiredLevel": 4,
+    "gap": 1,
+    "confidence": "HIGH",
+    "sampleSize": 25,
+    "matchedDomains": ["Networking", "VPC"],
+    "scaleMin": 1,
+    "scaleMax": 5
+  }
+]
+```
+
+Khi không có `ExamAttempt` nào: `currentLevel = scaleMin`, `confidence = "LOW"`, `sampleSize = 0`.
+
+---
+
+### FR-2 — Endpoint: Heatmap org-wide
+
+#### `GET /organizations/:orgId/analytics/competency-heatmap`
+
+**RBAC:** MANAGER, ADMIN, OWNER.
+
+Response `200`:
+```json
+{
+  "competencies": [
+    { "id": "uuid", "name": "AWS Networking", "scaleMin": 1, "scaleMax": 5 }
+  ],
+  "members": [
+    {
+      "userId": "uuid",
+      "displayName": "Nguyen Van A",
+      "scores": {
+        "uuid-competency": {
+          "currentLevel": 3,
+          "confidence": "MEDIUM",
+          "gap": 1
+        }
+      }
+    }
+  ]
+}
+```
+
+Nếu không có `jobRoleId` context: `gap` = null.
+
+**Cache:** Redis 5 phút với key `org-competency-heatmap:{orgId}`. Invalidate khi có ExamAttempt mới (webhook/event) hoặc khi CompetencyDomain thay đổi.
+
+---
+
+### FR-3 — FE: Radar chart per member
+
+**Component:** Mở rộng hoặc tạo mới bên cạnh `SkillGapChart.tsx`.
+
+**Hiển thị:**
+- Trục radial: mỗi competency = một trục.
+- Vùng màu xanh: currentLevel.
+- Đường màu đỏ/cam: requiredLevel (nếu có jobRoleId).
+- Tooltip: `{competencyName}: level {currentLevel}/{scaleMax}, gap {gap}, confidence {confidence}, {sampleSize} câu`.
+- Badge "LOW confidence" màu vàng nếu confidence=LOW.
+
+**Placement:** Tab mới "Năng lực" trong trang member profile hoặc trang Analytics của org.
+
+---
+
+### FR-4 — FE: Heatmap member × competency
+
+**Component:** Mở rộng `ReadinessHeatmap.tsx`.
+
+**Hiển thị:**
+- Rows: member (hiển thị displayName).
+- Columns: competency name.
+- Cell: level số (1–5), màu nền theo cấp độ:
+  - Xanh đậm: currentLevel ≥ requiredLevel (đạt).
+  - Đỏ: currentLevel < requiredLevel (thiếu).
+  - Xám nhạt: không có data (confidence=LOW, sampleSize=0).
+- Tooltip: chi tiết gap, confidence, sampleSize.
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR | Mô tả |
+|---|---|
+| **RBAC member** | Member chỉ thấy hồ sơ của mình; vi phạm → 403 |
+| **Fallback no data** | Competency không có ExamAttempt liên quan → currentLevel=scaleMin, confidence=LOW |
+| **Cache** | Heatmap cache Redis 5 phút (nếu org >50 members); profile per member không cache |
+| **Reuse hàm scoring** | Bắt buộc dùng `inferCompetencyLevel()` — không tự implement lại |
+| **Performance** | Heatmap org-wide chạy < 2s cho 100 members × 20 competencies |
+
+---
+
+## 4. API Contract
+
+| Method | Path | RBAC | Mô tả |
+|---|---|---|---|
+| GET | `/organizations/:orgId/analytics/competency-profile` | Tất cả (RBAC per memberId) | Hồ sơ năng lực per member |
+| GET | `/organizations/:orgId/analytics/competency-heatmap` | MANAGER,ADMIN,OWNER | Heatmap org-wide |
+
+---
+
+## 5. Test Cases
+
+| # | Tình huống | Kết quả |
+|---|---|---|
+| T1 | Member lấy profile của mình (không có jobRoleId) | 200, gap=null |
+| T2 | Member lấy profile kèm jobRoleId | 200, gap tính đúng |
+| T3 | Member lấy profile của người khác | 403 |
+| T4 | MANAGER lấy profile của member bất kỳ | 200 |
+| T5 | Member chưa có ExamAttempt | 200, currentLevel=scaleMin, confidence=LOW |
+| T6 | Competency có domains match 25 câu đúng 20/25 | level=4 (80%→level 4 với thresholds 1–5) |
+| T7 | MEMBER lấy heatmap org-wide | 403 |
+| T8 | Heatmap với 0 member | `{ competencies: [...], members: [] }` |
+
+---
+
+## 6. Thứ tự implement
+
+1. **US-A1 + US-A2 phải done** (Competency, CompetencyDomain, JobRoleCompetency đã có data).
+2. Thêm `getCompetencyProfile(orgId, memberId, jobRoleId?)` vào `org-analytics.service.ts`.
+3. Thêm `getCompetencyHeatmap(orgId)` với cache Redis.
+4. Thêm 2 routes vào `org-analytics.controller.ts`.
+5. FE service functions (`org-analytics.ts` hoặc `analytics.ts`).
+6. FE `SkillGapChart.tsx` → radar competency.
+7. FE `ReadinessHeatmap.tsx` → heatmap competency.
+8. Tests (unit scoring + integration endpoint).

--- a/docs/specs/sprint-1-us-c1-bulk-candidate-import-srs.md
+++ b/docs/specs/sprint-1-us-c1-bulk-candidate-import-srs.md
@@ -1,0 +1,220 @@
+# SRS — US-C1: Nhập ứng viên hàng loạt (CSV / dán danh sách)
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | US-C1 — Bulk Candidate Import |
+| **Issue** | #102 |
+| **Epic** | C — Thu hút & nhập ứng viên |
+| **Phiên bản** | Draft 1.0 |
+| **Ngày** | 2026-06-17 |
+| **Trạng thái** | Draft — chờ implement |
+| **Phụ thuộc** | Sprint 0 (Assessment, CandidateInvite, inviteCandidates đã có) |
+| **Module liên quan** | `assessments` (backend) · `AssessmentResults.tsx` hoặc modal invite (frontend) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-C1**, cho phép Recruiter upload file CSV hoặc dán danh sách email/tên để mời hàng loạt ứng viên thay vì gõ tay từng người, với preview hàng lỗi trước khi gửi và báo cáo kết quả sau.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Parse CSV server-side bằng `parseCandidateCsv()` đã có.
+- Dedupe với invite đã tồn tại trong cùng assessment (DB check).
+- Preview hàng lỗi trước khi confirm gửi.
+- Báo cáo: số mời thành công, số bỏ qua (trùng/lỗi).
+- FE: dialog 2 tab (upload file / paste text), preview bảng, confirm.
+- RBAC: OWNER, ADMIN, MANAGER, RECRUITER.
+
+**Ngoài phạm vi:**
+- Import từ Excel (.xlsx).
+- Re-invite ứng viên đã có invite (update invite cũ).
+- Import từ ATS bên ngoài.
+- Gửi email hàng loạt async queue (email vẫn gửi đồng bộ như hiện tại).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **parseCandidateCsv** | Hàm đã có trong `common/csv/parse-candidate-csv.ts` — parse + validate email + dedupe in-batch |
+| **Dedupe DB** | Kiểm tra email đã tồn tại trong `CandidateInvite` của cùng assessment → skip |
+| **invalidRows** | Hàng CSV có lỗi format hoặc email không hợp lệ |
+| **skippedEmails** | Email hợp lệ nhưng đã được mời trong assessment này |
+
+### 1.4. Hiện trạng trước US-C1
+
+- `parseCandidateCsv(input: string)` — có test đầy đủ, xử lý: header `email`+`name`, validate RFC5322, dedupe in-batch (seen Set), sanitize formula injection, MAX_ROWS=1000.
+- `inviteCandidates(slugOrId, assessmentId, dto)` — nhận `dto.candidates:[{email,name?}]`, tạo invite, gửi mail. **Không dedupe với DB** — gọi lại email cũ sẽ tạo invite trùng.
+- Chưa có endpoint bulk-CSV. Chưa có FE dialog bulk import.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Endpoint: Bulk import CSV
+
+#### `POST /organizations/:orgId/assessments/:aid/candidates/bulk-csv`
+
+**RBAC:** OWNER, ADMIN, MANAGER, RECRUITER.
+
+**Content-Type:** `application/json`
+
+Request body:
+```json
+{
+  "csv": "email,name\nalice@example.com,Alice\nbob@example.com,Bob"
+}
+```
+
+**Xử lý server-side:**
+```
+1. Validate: assessment thuộc orgId, status = ACTIVE.
+2. parseCandidateCsv(dto.csv) → { valid, invalid, duplicatesRemoved }.
+3. Nếu valid.length = 0 → 400 { message: "No valid candidates in CSV" }.
+4. DB dedupe: query CandidateInvite WHERE assessmentId=aid AND candidateEmail IN valid.map(e=>e.email).
+5. Tách: toInvite (chưa có invite) vs skipped (đã có invite, status != EXPIRED).
+6. Gọi inviteCandidates logic (tạo invite + gửi mail) cho toInvite.
+7. Trả về report.
+```
+
+Response `201`:
+```json
+{
+  "invited": 45,
+  "skipped": 3,
+  "invalidRows": [
+    { "row": 3, "raw": "notanemail,Test", "reason": "Invalid email: \"notanemail\"" }
+  ],
+  "skippedEmails": ["already@example.com"]
+}
+```
+
+**Lỗi:**
+- `400` nếu assessment không ACTIVE.
+- `400` nếu CSV hoàn toàn rỗng / thiếu header email.
+- `404` nếu assessment không tồn tại trong org.
+- `413` nếu `csv` string > 2MB.
+
+---
+
+### FR-2 — Dedupe logic chi tiết
+
+**Query dedupe:**
+```sql
+SELECT candidate_email FROM candidate_invites
+WHERE assessment_id = :aid
+  AND candidate_email IN (:emails)
+  AND status != 'EXPIRED'
+```
+
+**Ý nghĩa:** Invite EXPIRED được coi là không còn hiệu lực — cho phép re-invite cùng email sau khi link hết hạn.
+
+**Trả về `skippedEmails`:** Danh sách email bị skip do đã có invite active/completed.
+
+---
+
+### FR-3 — FE: Dialog bulk import
+
+**Trigger:** Nút "Import CSV" trong trang quản lý invite của assessment.
+
+**Bước 1 — Nhập dữ liệu:**
+
+Dialog với 2 tab:
+- **Tab "Upload file"**: input `<input type="file" accept=".csv">`, đọc file → đưa vào textarea preview.
+- **Tab "Dán danh sách"**: textarea lớn, placeholder `email,name\nalice@example.com,Alice`.
+
+**Bước 2 — Preview (sau khi parse client-side tạm):**
+
+Sau khi user nhập xong, FE parse preview (không cần gọi API):
+- Bảng valid: email, name (có thể sửa trước khi submit).
+- Bảng lỗi (nếu có): row số, nội dung, lý do.
+- Summary: "X email hợp lệ · Y hàng lỗi (bị bỏ qua) · Z trùng trong file".
+
+Nút "Xác nhận gửi (X người)" → gọi FR-1.
+
+**Bước 3 — Kết quả:**
+
+Toast:
+- Thành công: "Đã mời 45 ứng viên".
+- Bỏ qua: "3 email đã được mời trước (bỏ qua)".
+- Lỗi format: link expand "Xem X hàng lỗi" → expandable list.
+
+---
+
+### FR-4 — Validation phía FE
+
+- File: chỉ chấp nhận `.csv`, tối đa 5MB client-side.
+- Preview parse: dùng logic đơn giản (split `\n` + `,`) — không cần import parser library.
+- Disable nút submit nếu `valid.length = 0`.
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR | Mô tả |
+|---|---|
+| **Atomicity** | Dùng `prisma.$transaction` cho bulk insert (hoặc `createMany`) |
+| **MAX_ROWS** | 1000 rows per request (enforce trong `parseCandidateCsv`) |
+| **Idempotency** | Gọi lại cùng CSV → chỉ invite những email chưa có; không tạo trùng |
+| **Mail** | Gửi email cho từng invite mới (giữ behavior hiện tại của `inviteCandidates`) |
+| **Không schema mới** | Dùng `CandidateInvite` hiện có; không cần migration |
+
+---
+
+## 4. API Contract
+
+| Method | Path | RBAC | Mô tả |
+|---|---|---|---|
+| POST | `/organizations/:orgId/assessments/:aid/candidates/bulk-csv` | OWNER,ADMIN,MANAGER,RECRUITER | Bulk import từ CSV |
+
+---
+
+## 5. UI States
+
+```
+idle
+  → user upload/paste → preview
+    → confirm (loading)
+      → success: toast + refresh invite list
+      → partial: toast với detail + refresh
+      → error: toast lỗi (assessment không ACTIVE, CSV rỗng...)
+```
+
+---
+
+## 6. Test Cases
+
+| # | Tình huống | Kết quả |
+|---|---|---|
+| T1 | CSV hợp lệ 10 email, 0 trùng | 201, invited=10, skipped=0 |
+| T2 | 3 email trùng trong DB | 201, invited=7, skipped=3, skippedEmails=[...] |
+| T3 | Tất cả email đã có invite | 201, invited=0, skipped=N |
+| T4 | CSV thiếu header email | 400 |
+| T5 | CSV rỗng hoàn toàn | 400 |
+| T6 | Assessment status=DRAFT | 400 |
+| T7 | MEMBER thử bulk import | 403 |
+| T8 | Gọi 2 lần cùng CSV | Lần 2: invited=0, skipped=N (idempotent) |
+| T9 | Email EXPIRED invite → gửi lại | invited++ (EXPIRED không bị skip) |
+| T10 | 1001 rows | 400 (vượt MAX_ROWS) |
+
+---
+
+## 7. Thứ tự implement
+
+1. DTO `BulkCsvInviteDto` (`{ csv: string }`).
+2. `bulkCsvInvite(orgId, assessmentId, dto)` trong `assessments.service.ts` — gọi `parseCandidateCsv()`, dedupe DB, bulk create.
+3. Route `POST .../candidates/bulk-csv` trong `assessments.controller.ts`.
+4. FE dialog component (tab upload + paste, preview, confirm).
+5. FE service function.
+6. Tests.
+
+---
+
+## 8. Open Questions
+
+- Có nên tách `bulkCsvInvite` thành service riêng trong `candidate.service.ts` không? (Đề xuất: để trong `assessments.service.ts` vì gần logic `inviteCandidates` hiện tại.)
+- Giới hạn rate limit bulk import không? (Đề xuất: 5 requests/minute per orgId.)

--- a/docs/specs/sprint-1-us-e2-candidate-ranking-srs.md
+++ b/docs/specs/sprint-1-us-e2-candidate-ranking-srs.md
@@ -1,0 +1,241 @@
+# SRS — US-E2: Bảng so sánh & xếp hạng ứng viên
+
+| | |
+|---|---|
+| **Tài liệu** | Software Requirements Specification (SRS) |
+| **Tính năng** | US-E2 — Candidate Comparison & Ranking Board |
+| **Issue** | #109 |
+| **Epic** | E — Tự động sàng lọc & xếp hạng |
+| **Phiên bản** | Draft 1.0 |
+| **Ngày** | 2026-06-17 |
+| **Trạng thái** | Draft — chờ implement |
+| **Phụ thuộc** | Sprint 0 (getResults, exportCsv đã có); không phụ thuộc US-A1/A2/A3 |
+| **Module liên quan** | `assessments.service.ts` (backend delta nhỏ) · `AssessmentResults.tsx` (frontend mở rộng lớn) |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-E2**, cung cấp bảng xếp hạng đầy đủ (leaderboard) cho Recruiter/Hiring Manager: so sánh ứng viên cạnh nhau theo nhiều tiêu chí (điểm, percentile, domain breakdown, integrity, thời gian), với sort/filter đa chiều và xuất shortlist.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+- Bảng leaderboard với tất cả cột: rank, tên/email, điểm, percentile, stage, domain scores, integrity, time.
+- Sort client-side đa tiêu chí (click header).
+- Filter panel: theo stage, passed/failed, min score, min rating.
+- Domain scores breakdown (expandable row / tooltip).
+- Integrity badge với màu sắc và tooltip.
+- Xuất shortlist CSV (filter `shortlisted` hoặc `passed`).
+- BE: thêm query param `filter` vào `exportCsv`.
+
+**Ngoài phạm vi:**
+- AI screening / auto-reject.
+- Email thông báo shortlist.
+- So sánh giữa nhiều assessment.
+- Competency profile từ US-A3 (tách biệt).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **percentile** | Xếp hạng điểm trong cùng assessment (0–100); đã tính trong `getResults()` |
+| **integrityScore** | Điểm toàn vẹn (0–100): kết hợp tab switches, IP, thời gian; đã có trong DB |
+| **domainScores** | Json `{domainName: {correct, total}}` từ ExamAttempt/CandidateInvite |
+| **shortlist** | Ứng viên có `stage = SHORTLISTED` |
+| **passed** | Ứng viên có `score >= assessment.passingScore` |
+
+### 1.4. Hiện trạng trước US-E2
+
+- `getResults()` trả về đầy đủ data: `percentile`, `score`, `domainScores`, `integrityScore`, `tabSwitchCount`, `timeSpent`, `stage`, `rating`, `recruiterNote`.
+- `exportCsv()` xuất tất cả candidate, không có filter.
+- `AssessmentResults.tsx` (262 dòng): bảng cơ bản, **không có sort, filter, percentile display, domainScores, integrity**.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Bảng leaderboard
+
+**Columns (theo thứ tự hiển thị):**
+
+| Column | Nguồn data | Sortable |
+|---|---|---|
+| # Rank | Tính từ sort hiện tại | — |
+| Tên / Email | `candidateName`, `candidateEmail` | Tên ASC/DESC |
+| Điểm (%) | `score` | ✓ |
+| Percentile | `percentile` | ✓ |
+| Stage | `stage` (badge màu) | ✓ |
+| Domains | `domainScores` (expandable) | — |
+| Integrity | `integrityScore` (badge) | ✓ |
+| Thời gian | `timeSpent` (giây → mm:ss) | ✓ |
+| Rating | `rating` (sao 1–5) | ✓ |
+| Nộp lúc | `submittedAt` | ✓ |
+| Hành động | Nút xem chi tiết / đổi stage | — |
+
+Chỉ hiển thị candidate có `status = SUBMITTED`. Candidate INVITED/STARTED hiển thị riêng ở summary funnel phía trên.
+
+---
+
+### FR-2 — Sort client-side
+
+- Click header column → sort ASC; click lại → DESC; click lần 3 → reset (về score DESC default).
+- Hiển thị icon ↑/↓ trên header đang sort.
+- Sort state lưu trong local React state (không đồng bộ URL).
+- Multi-sort không cần thiết (single sort là đủ).
+
+---
+
+### FR-3 — Filter panel
+
+**Filter controls:**
+
+| Filter | UI | Logic |
+|---|---|---|
+| Stage | Multi-select (APPLIED, SCREENING, SHORTLISTED, HIRED, REJECTED) | `candidate.stage IN selectedStages` |
+| Kết quả | Radio: Tất cả / Đạt / Trượt | `score >= passingScore` hoặc `< passingScore` |
+| Điểm tối thiểu | Slider 0–100 | `score >= minScore` |
+| Rating tối thiểu | Select 1–5 sao / Tất cả | `rating >= minRating` |
+
+Filter áp dụng client-side trên data đã load từ `getResults()`.
+
+Nút "Xóa filter" reset tất cả về default.
+
+---
+
+### FR-4 — Domain scores breakdown
+
+**Hiển thị:** Expandable row hoặc hover popover.
+
+**Nội dung:**
+```
+Domain: Networking    ████████░░  80% (20/25)
+Domain: Security      █████░░░░░  50% (10/20)  ← đỏ vì < 60%
+Domain: Storage       ███████░░░  70% (14/20)
+```
+
+- Highlight đỏ nếu domain percentage < 60%.
+- Sort domain theo % tăng dần (domain yếu nhất lên đầu).
+
+---
+
+### FR-5 — Integrity badge
+
+| integrityScore | Badge | Màu |
+|---|---|---|
+| ≥ 80 | Tốt | Xanh lá |
+| 60–79 | Trung bình | Vàng cam |
+| < 60 | Cần xem xét | Đỏ |
+| null | — | Xám (N/A) |
+
+**Tooltip:** "Tab switch: {tabSwitchCount} lần · IP: {ipAddress} · Score: {integrityScore}/100"
+
+---
+
+### FR-6 — Xuất shortlist CSV
+
+**Nút:** "Xuất shortlist ({N})" — chỉ enable khi có ≥1 candidate shortlisted.
+
+**Gọi:** `GET /organizations/:orgId/assessments/:aid/export-csv?filter=shortlisted`
+
+**File:** `shortlist-{assessmentTitle}-{date}.csv`
+
+Ngoài ra giữ nút "Xuất tất cả" → `?filter=all` (behavior hiện tại).
+
+---
+
+### FR-7 — BE: Thêm query param `filter` vào exportCsv
+
+#### `GET /organizations/:orgId/assessments/:aid/export-csv?filter=all|submitted|passed|shortlisted`
+
+**Default:** `filter=all` (behavior hiện tại không thay đổi).
+
+**Logic filter:**
+- `all`: tất cả candidates.
+- `submitted`: chỉ `status=SUBMITTED`.
+- `passed`: `status=SUBMITTED AND score >= assessment.passingScore`.
+- `shortlisted`: `stage=SHORTLISTED`.
+
+Đảm bảo backward-compatible: không truyền `filter` → `all`.
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR | Mô tả |
+|---|---|
+| **Client-side sort/filter** | Không gọi API mới khi sort/filter — dùng data đã load |
+| **Performance** | ≤ 1000 candidates: client-side là đủ. >500: xem xét `react-virtual` nếu bảng lag |
+| **Export** | File CSV tải về ngay, không cần polling |
+| **Backward compat** | `exportCsv` không truyền `filter` → `all`, giữ nguyên behavior |
+| **Responsive** | Bảng có horizontal scroll trên mobile; columns quan trọng (name, score, stage) pin left |
+
+---
+
+## 4. API Delta (chỉ thay đổi nhỏ ở BE)
+
+| Method | Path | Thay đổi |
+|---|---|---|
+| GET | `/organizations/:orgId/assessments/:aid/export-csv` | Thêm query param `?filter` |
+
+Không có endpoint mới. `getResults()` không thay đổi.
+
+---
+
+## 5. UI Layout (dạng text mockup)
+
+```
+[Assessment Title] — Results
+
+Funnel: Total 120 | Started 98 | Submitted 85 | Passed 42
+
+[Filter: Stage ▾] [Kết quả ▾] [Điểm ≥ __] [Rating ≥ __]  [Xóa filter]
+                                              [Xuất shortlist (12)] [Xuất tất cả]
+
+# | Tên/Email            | Điểm | %ile | Stage      | Domains | Integrity | Thời gian | Rating | Nộp lúc
+1 | Nguyen Van A         | 92%  |  98  | SHORTLISTED|  [+]   |  🟢 95    | 45:20     | ★★★★☆  | ...
+2 | Tran Thi B           | 88%  |  91  | SCREENING  |  [+]   |  🟡 72    | 52:10     | —      | ...
+...
+
+[row expanded]
+  └─ Domain Networking: 95% ████████████
+     Domain Security:   45% █████░░░░░░  ← đỏ
+```
+
+---
+
+## 6. Test Cases
+
+| # | Tình huống | Kết quả |
+|---|---|---|
+| T1 | Sort theo percentile DESC | Candidate percentile cao nhất lên đầu |
+| T2 | Filter stage=SHORTLISTED | Chỉ hiện shortlisted |
+| T3 | Filter passed với passingScore=70 | Chỉ hiện score ≥ 70 |
+| T4 | Expand domain row | Domain breakdown hiển thị đúng % |
+| T5 | integrityScore=55 | Badge đỏ "Cần xem xét" |
+| T6 | Export shortlist | File CSV chỉ chứa stage=SHORTLISTED |
+| T7 | Export passed | File chỉ chứa score ≥ passingScore |
+| T8 | Không có candidate SUBMITTED | Bảng trống, funnel hiện 0 submitted |
+| T9 | GET exportCsv không truyền filter | Trả tất cả (backward compat) |
+| T10 | 0 candidate shortlisted | Nút "Xuất shortlist" disabled |
+
+---
+
+## 7. Thứ tự implement
+
+1. **BE:** Thêm `filter` query param vào `exportCsv` trong `assessments.service.ts` và `assessments.controller.ts`.
+2. **FE:** Mở rộng `AssessmentResults.tsx`:
+   a. Thêm sort state + click handler trên headers.
+   b. Thêm filter panel (Stage, Kết quả, Điểm, Rating).
+   c. Thêm columns: Percentile, Integrity badge, Domain expandable.
+   d. Nút "Xuất shortlist".
+3. Tests BE (exportCsv filter) + FE (sort, filter, expand).
+
+---
+
+## 8. Open Questions
+
+- Có cần lưu filter/sort vào URL (để share link) không? (Đề xuất: Sprint 2 nếu có nhu cầu.)
+- `integrityScore` null (assessment không bật proctoring) → hiển thị "N/A" hay ẩn column? (Đề xuất: ẩn cột Integrity nếu tất cả null.)


### PR DESCRIPTION
## Summary

- **US-A1** — Fixed critical 404 bug: competency controller prefix corrected from `orgs/` → `organizations/`; added question-linking (`GET/POST/DELETE :id/questions`), domain-linking (`GET/POST/DELETE :id/domains`), and `PATCH :id/toggle-active` routes
- **US-A2** — Added `GET/PUT :roleId/competencies` endpoints for managing required competency levels per job role, with scale validation and duplicate detection
- **US-A3** — Added `GET analytics/competency-profile` (per-member or org-wide, with gap vs job role) and `GET analytics/competency-heatmap` (all members × all competencies matrix) using the existing `inferCompetencyLevel` scoring function
- **US-C1** — Added `POST :aid/candidates/bulk-csv` endpoint with CSV parse (`parseCandidateCsv`), DB-level dedupe against existing invites, and structured error report
- **US-E2** — Extended `GET :aid/results` and `GET :aid/results/export` with `?filter=all|submitted|passed|shortlisted` query param for candidate ranking and export

## Test plan

- [ ] Build passes: `npm run build` in `backend/` — 0 TS errors ✅
- [ ] All 595 tests pass across 51 suites ✅
- [ ] `GET /api/v1/organizations/:orgId/competencies` returns 200 (was 404 before this fix)
- [ ] `PUT /api/v1/organizations/:orgId/job-roles/:roleId/competencies` with invalid `requiredLevel` returns 400 with validation errors
- [ ] `POST /api/v1/organizations/:orgId/assessments/:aid/candidates/bulk-csv` with valid CSV creates invites; duplicate emails return `skipped` count
- [ ] `GET /api/v1/organizations/:orgId/assessments/:aid/results?filter=shortlisted` returns only SHORTLISTED candidates
- [ ] `GET /api/v1/organizations/:orgId/analytics/competency-profile` returns competency levels and gap when `jobRoleId` is provided