### PR TITLE
feat: secure MCP question intake with scoped API keys

### DIFF
--- a/backend/prisma/migrations/20260719000001_add_mcp_api_keys/migration.sql
+++ b/backend/prisma/migrations/20260719000001_add_mcp_api_keys/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable: mcp_api_keys
+CREATE TABLE "mcp_api_keys" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "key_hash" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "last_used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revoked_at" TIMESTAMP(3),
+
+    CONSTRAINT "mcp_api_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcp_api_keys_key_hash_key" ON "mcp_api_keys"("key_hash");
+
+-- CreateIndex
+CREATE INDEX "mcp_api_keys_user_id_idx" ON "mcp_api_keys"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "mcp_api_keys" ADD CONSTRAINT "mcp_api_keys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -261,6 +261,7 @@ model User {
   flashcardReviewSchedules   FlashcardReviewSchedule[]
   capturedWords              CapturedWord[]
   llmConfigs                 UserLlmConfig[]
+  mcpApiKeys                 McpApiKey[]
   generationJobs             QuestionGenerationJob[]
   sourceMaterials            SourceMaterial[]
   auditLogs                  AuditLog[]
@@ -705,6 +706,24 @@ model CapturedWord {
   question    Question?    @relation(fields: [questionId], references: [id])
 
   @@map("captured_words")
+}
+
+// ==================== MCP API KEYS ====================
+
+model McpApiKey {
+  id         String    @id @default(uuid())
+  userId     String    @map("user_id")
+  name       String
+  keyHash    String    @unique @map("key_hash")
+  prefix     String
+  lastUsedAt DateTime? @map("last_used_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  revokedAt  DateTime? @map("revoked_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("mcp_api_keys")
 }
 
 // ==================== AI QUESTION BANK ====================

--- a/backend/src/ai-question-bank/ai-question-bank.controller.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.controller.ts
@@ -20,6 +20,8 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import type { AuthenticatedRequest } from '../common/interfaces/request.interface';
+import { Public } from '../common/decorators/public.decorator';
+import { ApiKeyAuthGuard } from '../mcp-keys/api-key-auth.guard';
 import { AiQuestionBankService } from './ai-question-bank.service';
 import { IngestionService } from './ingestion/ingestion.service';
 import { ConfigureLlmDto } from './dto/configure-llm.dto';
@@ -28,6 +30,10 @@ import { SaveGeneratedQuestionsDto } from './dto/save-questions.dto';
 import { UploadMaterialDto } from './dto/upload-material.dto';
 import { McpIntakeDto } from './mcp/mcp-intake.dto';
 import { Throttle } from '@nestjs/throttler';
+
+interface McpRequest extends AuthenticatedRequest {
+  mcpKeyId: string;
+}
 
 @ApiTags('AI Question Bank')
 @ApiBearerAuth()
@@ -209,11 +215,13 @@ export class AiQuestionBankController {
   // ─── MCP Intake ──────────────────────────────────────────────────────────────
 
   @Post('mcp/intake')
+  @Public()
+  @UseGuards(ApiKeyAuthGuard)
   @ApiOperation({
     summary:
       'MCP mode: receive questions pushed from external AI tools (Claude Desktop, etc.)',
   })
-  mcpIntake(@Req() req: AuthenticatedRequest, @Body() dto: McpIntakeDto) {
-    return this.service.mcpIntake(req.user.id, dto);
+  mcpIntake(@Req() req: McpRequest, @Body() dto: McpIntakeDto) {
+    return this.service.mcpIntake(req.user.id, req.mcpKeyId, dto);
   }
 }

--- a/backend/src/ai-question-bank/ai-question-bank.module.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.module.ts
@@ -14,7 +14,7 @@ import { LlmUsageModule } from './llm-usage/llm-usage.module';
 import { EmbeddingModule } from './embedding/embedding.module';
 import { DdsModule } from './dds/dds.module';
 import { McpKeysModule } from '../mcp-keys/mcp-keys.module';
-import { ApiKeyAuthGuard } from '../mcp-keys/api-key-auth.guard';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
@@ -24,11 +24,17 @@ import { ApiKeyAuthGuard } from '../mcp-keys/api-key-auth.guard';
     EmbeddingModule,
     DdsModule,
     McpKeysModule,
+    AuditModule,
     MulterModule.register({ limits: { fileSize: 50 * 1024 * 1024 } }),
     BullModule.registerQueue({ name: AI_GEN_QUEUE }),
     BullModule.registerQueue({ name: MATERIAL_CONVERSION_QUEUE }),
   ],
   controllers: [AiQuestionBankController],
-  providers: [AiQuestionBankService, EncryptionService, IngestionService, S3UploadService, ApiKeyAuthGuard],
+  providers: [
+    AiQuestionBankService,
+    EncryptionService,
+    IngestionService,
+    S3UploadService,
+  ],
 })
 export class AiQuestionBankModule {}

--- a/backend/src/ai-question-bank/ai-question-bank.module.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.module.ts
@@ -13,6 +13,8 @@ import { MATERIAL_CONVERSION_QUEUE } from '../queues/material-conversion/materia
 import { LlmUsageModule } from './llm-usage/llm-usage.module';
 import { EmbeddingModule } from './embedding/embedding.module';
 import { DdsModule } from './dds/dds.module';
+import { McpKeysModule } from '../mcp-keys/mcp-keys.module';
+import { ApiKeyAuthGuard } from '../mcp-keys/api-key-auth.guard';
 
 @Module({
   imports: [
@@ -21,11 +23,12 @@ import { DdsModule } from './dds/dds.module';
     LlmUsageModule,
     EmbeddingModule,
     DdsModule,
+    McpKeysModule,
     MulterModule.register({ limits: { fileSize: 50 * 1024 * 1024 } }),
     BullModule.registerQueue({ name: AI_GEN_QUEUE }),
     BullModule.registerQueue({ name: MATERIAL_CONVERSION_QUEUE }),
   ],
   controllers: [AiQuestionBankController],
-  providers: [AiQuestionBankService, EncryptionService, IngestionService, S3UploadService],
+  providers: [AiQuestionBankService, EncryptionService, IngestionService, S3UploadService, ApiKeyAuthGuard],
 })
 export class AiQuestionBankModule {}

--- a/backend/src/ai-question-bank/ai-question-bank.service.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.service.ts
@@ -21,6 +21,8 @@ import { GenerateQuestionsDto } from './dto/generate-questions.dto';
 import { SaveGeneratedQuestionsDto } from './dto/save-questions.dto';
 import { McpIntakeDto } from './mcp/mcp-intake.dto';
 import { LlmQuotaService } from './llm-usage/llm-quota.service';
+import { AuditService } from '../audit/audit.service';
+import { McpKeysService } from '../mcp-keys/mcp-keys.service';
 import {
   Difficulty,
   LlmProvider,
@@ -41,6 +43,8 @@ export class AiQuestionBankService {
     private readonly encryption: EncryptionService,
     private readonly ingestion: IngestionService,
     private readonly quota: LlmQuotaService,
+    private readonly audit: AuditService,
+    private readonly mcpKeys: McpKeysService,
     @InjectQueue(AI_GEN_QUEUE) private readonly aiGenQueue: Queue<AiGenJobData>,
   ) {}
 
@@ -293,7 +297,9 @@ export class AiQuestionBankService {
 
   // ─── MCP Intake ──────────────────────────────────────────────────────────────
 
-  async mcpIntake(userId: string, dto: McpIntakeDto) {
+  async mcpIntake(userId: string, keyId: string, dto: McpIntakeDto) {
+    await this.mcpKeys.checkRateLimit(keyId);
+
     const saved: string[] = [];
     const discarded: number[] = [];
 
@@ -330,6 +336,21 @@ export class AiQuestionBankService {
 
       saved.push(question.id);
     }
+
+    this.audit
+      .log({
+        userId,
+        action: 'MCP_INTAKE',
+        targetType: 'certification',
+        targetId: dto.certificationId,
+        metadata: {
+          keyId,
+          source: dto.source ?? 'MCP',
+          saved: saved.length,
+          discarded: discarded.length,
+        },
+      })
+      .catch(() => {});
 
     return {
       saved: saved.length,

--- a/backend/src/ai-question-bank/ai-question-bank.service.ts
+++ b/backend/src/ai-question-bank/ai-question-bank.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   NotFoundException,
   ForbiddenException,
   BadRequestException,
@@ -37,6 +38,8 @@ const QUALITY_MEDIUM = 0.6;
 
 @Injectable()
 export class AiQuestionBankService {
+  private readonly logger = new Logger(AiQuestionBankService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly questions: QuestionsService,
@@ -350,7 +353,7 @@ export class AiQuestionBankService {
           discarded: discarded.length,
         },
       })
-      .catch(() => {});
+      .catch((err: unknown) => this.logger.warn('MCP audit log failed', err));
 
     return {
       saved: saved.length,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -41,6 +41,7 @@ import { SquadsModule } from './squads/squads.module';
 import { KnowledgeGraphModule } from './knowledge-graph/knowledge-graph.module';
 import { RedisModule } from './redis/redis.module';
 import { CompetencyModule } from './competency/competency.module';
+import { McpKeysModule } from './mcp-keys/mcp-keys.module';
 
 @Module({
   imports: [
@@ -86,6 +87,7 @@ import { CompetencyModule } from './competency/competency.module';
     KnowledgeGraphModule,
     RedisModule,
     CompetencyModule,
+    McpKeysModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/mcp-keys/api-key-auth.guard.spec.ts
+++ b/backend/src/mcp-keys/api-key-auth.guard.spec.ts
@@ -3,7 +3,7 @@ import { ApiKeyAuthGuard } from './api-key-auth.guard';
 import { McpKeysService } from './mcp-keys.service';
 
 const mockMcpKeysService = {
-  findByHash: jest.fn(),
+  findByRawKey: jest.fn(),
   updateLastUsed: jest.fn(),
 };
 
@@ -33,7 +33,7 @@ describe('ApiKeyAuthGuard', () => {
   });
 
   it('should throw UnauthorizedException when key hash not found in DB', async () => {
-    mockMcpKeysService.findByHash.mockResolvedValue(null);
+    mockMcpKeysService.findByRawKey.mockResolvedValue(null);
     await expect(
       guard.canActivate(makeContext({ 'x-api-key': 'mcp_validlooking12345678901234567890123456' })),
     ).rejects.toThrow(UnauthorizedException);
@@ -45,7 +45,7 @@ describe('ApiKeyAuthGuard', () => {
       userId: 'user-1',
       user: { id: 'user-1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
     };
-    mockMcpKeysService.findByHash.mockResolvedValue(fakeKey);
+    mockMcpKeysService.findByRawKey.mockResolvedValue(fakeKey);
 
     const ctx = makeContext({ 'x-api-key': 'mcp_validlooking12345678901234567890123456' });
     const req = ctx.switchToHttp().getRequest();

--- a/backend/src/mcp-keys/api-key-auth.guard.spec.ts
+++ b/backend/src/mcp-keys/api-key-auth.guard.spec.ts
@@ -1,0 +1,60 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ApiKeyAuthGuard } from './api-key-auth.guard';
+import { McpKeysService } from './mcp-keys.service';
+
+const mockMcpKeysService = {
+  findByHash: jest.fn(),
+  updateLastUsed: jest.fn(),
+};
+
+function makeContext(headers: Record<string, string> = {}) {
+  const req: any = { headers, mcpKeyId: undefined, user: undefined };
+  return {
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as unknown as ExecutionContext;
+}
+
+describe('ApiKeyAuthGuard', () => {
+  let guard: ApiKeyAuthGuard;
+
+  beforeEach(() => {
+    guard = new ApiKeyAuthGuard(mockMcpKeysService as unknown as McpKeysService);
+    jest.clearAllMocks();
+  });
+
+  it('should throw UnauthorizedException when X-API-Key header is missing', async () => {
+    await expect(guard.canActivate(makeContext())).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should throw UnauthorizedException for malformed key (no mcp_ prefix)', async () => {
+    await expect(
+      guard.canActivate(makeContext({ 'x-api-key': 'badkey' })),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should throw UnauthorizedException when key hash not found in DB', async () => {
+    mockMcpKeysService.findByHash.mockResolvedValue(null);
+    await expect(
+      guard.canActivate(makeContext({ 'x-api-key': 'mcp_validlooking12345678901234567890123456' })),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should set req.user and req.mcpKeyId and return true for valid key', async () => {
+    const fakeKey = {
+      id: 'key-1',
+      userId: 'user-1',
+      user: { id: 'user-1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
+    };
+    mockMcpKeysService.findByHash.mockResolvedValue(fakeKey);
+
+    const ctx = makeContext({ 'x-api-key': 'mcp_validlooking12345678901234567890123456' });
+    const req = ctx.switchToHttp().getRequest();
+
+    const result = await guard.canActivate(ctx);
+
+    expect(result).toBe(true);
+    expect(req.user).toEqual({ id: 'user-1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' });
+    expect(req.mcpKeyId).toBe('key-1');
+    expect(mockMcpKeysService.updateLastUsed).toHaveBeenCalledWith('key-1');
+  });
+});

--- a/backend/src/mcp-keys/api-key-auth.guard.ts
+++ b/backend/src/mcp-keys/api-key-auth.guard.ts
@@ -1,5 +1,4 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import { createHash } from 'crypto';
 import { McpKeysService } from './mcp-keys.service';
 
 const MCP_KEY_PREFIX = 'mcp_';
@@ -21,8 +20,7 @@ export class ApiKeyAuthGuard implements CanActivate {
       throw new UnauthorizedException('Invalid API key');
     }
 
-    const hash = createHash('sha256').update(raw).digest('hex');
-    const key = await this.mcpKeys.findByHash(hash);
+    const key = await this.mcpKeys.findByRawKey(raw);
 
     if (!key) {
       throw new UnauthorizedException('Invalid API key');

--- a/backend/src/mcp-keys/api-key-auth.guard.ts
+++ b/backend/src/mcp-keys/api-key-auth.guard.ts
@@ -1,0 +1,37 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { createHash } from 'crypto';
+import { McpKeysService } from './mcp-keys.service';
+
+const MCP_KEY_PREFIX = 'mcp_';
+const MIN_KEY_LENGTH = 20;
+
+@Injectable()
+export class ApiKeyAuthGuard implements CanActivate {
+  constructor(private readonly mcpKeys: McpKeysService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const raw: string | undefined = req.headers['x-api-key'];
+
+    if (!raw) {
+      throw new UnauthorizedException('Missing X-API-Key header');
+    }
+
+    if (!raw.startsWith(MCP_KEY_PREFIX) || raw.length < MIN_KEY_LENGTH) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    const hash = createHash('sha256').update(raw).digest('hex');
+    const key = await this.mcpKeys.findByHash(hash);
+
+    if (!key) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    req.user = key.user;
+    req.mcpKeyId = key.id;
+    this.mcpKeys.updateLastUsed(key.id);
+
+    return true;
+  }
+}

--- a/backend/src/mcp-keys/mcp-keys.controller.ts
+++ b/backend/src/mcp-keys/mcp-keys.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/interfaces/request.interface';
+import { McpKeysService } from './mcp-keys.service';
+
+class CreateMcpKeyDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(80)
+  name: string;
+}
+
+@ApiTags('MCP API Keys')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('mcp-keys')
+export class McpKeysController {
+  constructor(private readonly service: McpKeysService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List active MCP API keys for the current user' })
+  list(@Req() req: AuthenticatedRequest) {
+    return this.service.listKeys(req.user.id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Generate a new MCP API key (plaintext returned once)' })
+  generate(@Req() req: AuthenticatedRequest, @Body() dto: CreateMcpKeyDto) {
+    return this.service.generateKey(req.user.id, dto.name);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Revoke an MCP API key' })
+  async revoke(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
+    await this.service.revokeKey(req.user.id, id);
+  }
+}

--- a/backend/src/mcp-keys/mcp-keys.module.ts
+++ b/backend/src/mcp-keys/mcp-keys.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { RedisModule } from '../redis/redis.module';
+import { McpKeysService } from './mcp-keys.service';
+import { McpKeysController } from './mcp-keys.controller';
+import { ApiKeyAuthGuard } from './api-key-auth.guard';
+
+@Module({
+  imports: [PrismaModule, RedisModule],
+  controllers: [McpKeysController],
+  providers: [McpKeysService, ApiKeyAuthGuard],
+  exports: [McpKeysService, ApiKeyAuthGuard],
+})
+export class McpKeysModule {}

--- a/backend/src/mcp-keys/mcp-keys.service.spec.ts
+++ b/backend/src/mcp-keys/mcp-keys.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpException, HttpStatus, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { McpKeysService } from './mcp-keys.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
@@ -19,6 +20,8 @@ const mockRedis = {
   expire: jest.fn(),
 };
 
+const mockConfig = { get: jest.fn().mockReturnValue('test-hmac-secret') };
+
 describe('McpKeysService', () => {
   let service: McpKeysService;
   let prisma: typeof mockPrisma;
@@ -29,6 +32,7 @@ describe('McpKeysService', () => {
       providers: [
         McpKeysService,
         { provide: PrismaService, useValue: mockPrisma },
+        { provide: ConfigService, useValue: mockConfig },
         { provide: REDIS_CLIENT, useValue: mockRedis },
       ],
     }).compile();
@@ -100,8 +104,8 @@ describe('McpKeysService', () => {
     });
   });
 
-  describe('findByHash', () => {
-    it('should return key with user for a valid active hash', async () => {
+  describe('findByRawKey', () => {
+    it('should return key with user for a valid active key', async () => {
       const key = {
         id: 'k1',
         userId: 'u1',
@@ -110,13 +114,13 @@ describe('McpKeysService', () => {
       };
       prisma.mcpApiKey.findFirst.mockResolvedValue(key);
 
-      const result = await service.findByHash('somehash');
+      const result = await service.findByRawKey('mcp_somevalidkey123456789012345678901234');
       expect(result).toEqual({ id: 'k1', userId: 'u1', user: key.user });
     });
 
     it('should return null if not found', async () => {
       prisma.mcpApiKey.findFirst.mockResolvedValue(null);
-      const result = await service.findByHash('badhash');
+      const result = await service.findByRawKey('mcp_somevalidkey123456789012345678901234');
       expect(result).toBeNull();
     });
 
@@ -127,7 +131,7 @@ describe('McpKeysService', () => {
         revokedAt: new Date(),
         user: { id: 'u1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
       });
-      const result = await service.findByHash('somehash');
+      const result = await service.findByRawKey('mcp_somevalidkey123456789012345678901234');
       expect(result).toBeNull();
     });
   });

--- a/backend/src/mcp-keys/mcp-keys.service.spec.ts
+++ b/backend/src/mcp-keys/mcp-keys.service.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { McpKeysService } from './mcp-keys.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { REDIS_CLIENT } from '../redis/redis.module';
+
+const mockPrisma = {
+  mcpApiKey: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+const mockRedis = {
+  incr: jest.fn(),
+  expire: jest.fn(),
+};
+
+describe('McpKeysService', () => {
+  let service: McpKeysService;
+  let prisma: typeof mockPrisma;
+  let redis: typeof mockRedis;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        McpKeysService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: REDIS_CLIENT, useValue: mockRedis },
+      ],
+    }).compile();
+
+    service = module.get<McpKeysService>(McpKeysService);
+    prisma = module.get<PrismaService>(PrismaService) as any;
+    redis = module.get(REDIS_CLIENT);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('generateKey', () => {
+    it('should return plaintext key with mcp_ prefix and store hash', async () => {
+      const fakeKey = { id: 'key-1', prefix: 'mcp_abcd1234', name: 'My Key', createdAt: new Date() };
+      prisma.mcpApiKey.create.mockResolvedValue(fakeKey);
+
+      const result = await service.generateKey('user-1', 'My Key');
+
+      expect(result.plaintext).toMatch(/^mcp_/);
+      expect(result.prefix).toMatch(/^mcp_/);
+      expect(result.plaintext.length).toBeGreaterThan(40);
+      expect(prisma.mcpApiKey.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'user-1',
+            name: 'My Key',
+            keyHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('listKeys', () => {
+    it('should return active keys for user', async () => {
+      const keys = [{ id: 'k1', name: 'Key 1', prefix: 'mcp_abcd', createdAt: new Date(), lastUsedAt: null }];
+      prisma.mcpApiKey.findMany.mockResolvedValue(keys);
+
+      const result = await service.listKeys('user-1');
+
+      expect(prisma.mcpApiKey.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user-1', revokedAt: null } }),
+      );
+      expect(result).toEqual(keys);
+    });
+  });
+
+  describe('revokeKey', () => {
+    it('should set revokedAt on owned key', async () => {
+      prisma.mcpApiKey.findUnique.mockResolvedValue({ id: 'k1', userId: 'user-1' });
+      prisma.mcpApiKey.update.mockResolvedValue({});
+
+      await service.revokeKey('user-1', 'k1');
+
+      expect(prisma.mcpApiKey.update).toHaveBeenCalledWith({
+        where: { id: 'k1' },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+
+    it('should throw NotFoundException if key does not exist', async () => {
+      prisma.mcpApiKey.findUnique.mockResolvedValue(null);
+      await expect(service.revokeKey('user-1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException if key belongs to another user', async () => {
+      prisma.mcpApiKey.findUnique.mockResolvedValue({ id: 'k1', userId: 'user-2' });
+      await expect(service.revokeKey('user-1', 'k1')).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('findByHash', () => {
+    it('should return key with user for a valid active hash', async () => {
+      const key = {
+        id: 'k1',
+        userId: 'u1',
+        revokedAt: null,
+        user: { id: 'u1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
+      };
+      prisma.mcpApiKey.findFirst.mockResolvedValue(key);
+
+      const result = await service.findByHash('somehash');
+      expect(result).toEqual({ id: 'k1', userId: 'u1', user: key.user });
+    });
+
+    it('should return null if not found', async () => {
+      prisma.mcpApiKey.findFirst.mockResolvedValue(null);
+      const result = await service.findByHash('badhash');
+      expect(result).toBeNull();
+    });
+
+    it('should return null if key is revoked', async () => {
+      prisma.mcpApiKey.findFirst.mockResolvedValue({
+        id: 'k1',
+        userId: 'u1',
+        revokedAt: new Date(),
+        user: { id: 'u1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
+      });
+      const result = await service.findByHash('somehash');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('checkRateLimit', () => {
+    it('should not throw when under limit', async () => {
+      redis.incr.mockResolvedValue(50);
+      redis.expire.mockResolvedValue(1);
+      await expect(service.checkRateLimit('key-1')).resolves.not.toThrow();
+    });
+
+    it('should throw 429 when over limit', async () => {
+      redis.incr.mockResolvedValue(101);
+      redis.expire.mockResolvedValue(1);
+      await expect(service.checkRateLimit('key-1')).rejects.toThrow(
+        new HttpException('Rate limit exceeded: 100 requests per hour per API key', HttpStatus.TOO_MANY_REQUESTS),
+      );
+    });
+  });
+});

--- a/backend/src/mcp-keys/mcp-keys.service.spec.ts
+++ b/backend/src/mcp-keys/mcp-keys.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { HttpException, HttpStatus, NotFoundException, ForbiddenException } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { McpKeysService } from './mcp-keys.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -15,9 +20,14 @@ const mockPrisma = {
   },
 };
 
+const mockPipeline = {
+  incr: jest.fn().mockReturnThis(),
+  expire: jest.fn().mockReturnThis(),
+  exec: jest.fn(),
+};
+
 const mockRedis = {
-  incr: jest.fn(),
-  expire: jest.fn(),
+  pipeline: jest.fn(() => mockPipeline),
 };
 
 const mockConfig = { get: jest.fn().mockReturnValue('test-hmac-secret') };
@@ -25,7 +35,6 @@ const mockConfig = { get: jest.fn().mockReturnValue('test-hmac-secret') };
 describe('McpKeysService', () => {
   let service: McpKeysService;
   let prisma: typeof mockPrisma;
-  let redis: typeof mockRedis;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -39,14 +48,18 @@ describe('McpKeysService', () => {
 
     service = module.get<McpKeysService>(McpKeysService);
     prisma = module.get<PrismaService>(PrismaService) as any;
-    redis = module.get(REDIS_CLIENT);
   });
 
   afterEach(() => jest.clearAllMocks());
 
   describe('generateKey', () => {
     it('should return plaintext key with mcp_ prefix and store hash', async () => {
-      const fakeKey = { id: 'key-1', prefix: 'mcp_abcd1234', name: 'My Key', createdAt: new Date() };
+      const fakeKey = {
+        id: 'key-1',
+        prefix: 'mcp_abcd1234',
+        name: 'My Key',
+        createdAt: new Date(),
+      };
       prisma.mcpApiKey.create.mockResolvedValue(fakeKey);
 
       const result = await service.generateKey('user-1', 'My Key');
@@ -68,13 +81,23 @@ describe('McpKeysService', () => {
 
   describe('listKeys', () => {
     it('should return active keys for user', async () => {
-      const keys = [{ id: 'k1', name: 'Key 1', prefix: 'mcp_abcd', createdAt: new Date(), lastUsedAt: null }];
+      const keys = [
+        {
+          id: 'k1',
+          name: 'Key 1',
+          prefix: 'mcp_abcd',
+          createdAt: new Date(),
+          lastUsedAt: null,
+        },
+      ];
       prisma.mcpApiKey.findMany.mockResolvedValue(keys);
 
       const result = await service.listKeys('user-1');
 
       expect(prisma.mcpApiKey.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { userId: 'user-1', revokedAt: null } }),
+        expect.objectContaining({
+          where: { userId: 'user-1', revokedAt: null },
+        }),
       );
       expect(result).toEqual(keys);
     });
@@ -82,7 +105,10 @@ describe('McpKeysService', () => {
 
   describe('revokeKey', () => {
     it('should set revokedAt on owned key', async () => {
-      prisma.mcpApiKey.findUnique.mockResolvedValue({ id: 'k1', userId: 'user-1' });
+      prisma.mcpApiKey.findUnique.mockResolvedValue({
+        id: 'k1',
+        userId: 'user-1',
+      });
       prisma.mcpApiKey.update.mockResolvedValue({});
 
       await service.revokeKey('user-1', 'k1');
@@ -95,12 +121,19 @@ describe('McpKeysService', () => {
 
     it('should throw NotFoundException if key does not exist', async () => {
       prisma.mcpApiKey.findUnique.mockResolvedValue(null);
-      await expect(service.revokeKey('user-1', 'missing')).rejects.toThrow(NotFoundException);
+      await expect(service.revokeKey('user-1', 'missing')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('should throw ForbiddenException if key belongs to another user', async () => {
-      prisma.mcpApiKey.findUnique.mockResolvedValue({ id: 'k1', userId: 'user-2' });
-      await expect(service.revokeKey('user-1', 'k1')).rejects.toThrow(ForbiddenException);
+      prisma.mcpApiKey.findUnique.mockResolvedValue({
+        id: 'k1',
+        userId: 'user-2',
+      });
+      await expect(service.revokeKey('user-1', 'k1')).rejects.toThrow(
+        ForbiddenException,
+      );
     });
   });
 
@@ -109,45 +142,49 @@ describe('McpKeysService', () => {
       const key = {
         id: 'k1',
         userId: 'u1',
-        revokedAt: null,
-        user: { id: 'u1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
+        user: {
+          id: 'u1',
+          email: 'x@x.com',
+          role: 'CONTRIBUTOR',
+          displayName: 'X',
+        },
       };
       prisma.mcpApiKey.findFirst.mockResolvedValue(key);
 
-      const result = await service.findByRawKey('mcp_somevalidkey123456789012345678901234');
-      expect(result).toEqual({ id: 'k1', userId: 'u1', user: key.user });
+      const result = await service.findByRawKey(
+        'mcp_somevalidkey123456789012345678901234',
+      );
+      expect(result).toEqual(key);
     });
 
     it('should return null if not found', async () => {
       prisma.mcpApiKey.findFirst.mockResolvedValue(null);
-      const result = await service.findByRawKey('mcp_somevalidkey123456789012345678901234');
-      expect(result).toBeNull();
-    });
-
-    it('should return null if key is revoked', async () => {
-      prisma.mcpApiKey.findFirst.mockResolvedValue({
-        id: 'k1',
-        userId: 'u1',
-        revokedAt: new Date(),
-        user: { id: 'u1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
-      });
-      const result = await service.findByRawKey('mcp_somevalidkey123456789012345678901234');
+      const result = await service.findByRawKey(
+        'mcp_somevalidkey123456789012345678901234',
+      );
       expect(result).toBeNull();
     });
   });
 
   describe('checkRateLimit', () => {
     it('should not throw when under limit', async () => {
-      redis.incr.mockResolvedValue(50);
-      redis.expire.mockResolvedValue(1);
+      mockPipeline.exec.mockResolvedValue([
+        [null, 50],
+        [null, 1],
+      ]);
       await expect(service.checkRateLimit('key-1')).resolves.not.toThrow();
     });
 
     it('should throw 429 when over limit', async () => {
-      redis.incr.mockResolvedValue(101);
-      redis.expire.mockResolvedValue(1);
+      mockPipeline.exec.mockResolvedValue([
+        [null, 101],
+        [null, 1],
+      ]);
       await expect(service.checkRateLimit('key-1')).rejects.toThrow(
-        new HttpException('Rate limit exceeded: 100 requests per hour per API key', HttpStatus.TOO_MANY_REQUESTS),
+        new HttpException(
+          'Rate limit exceeded: 100 requests per hour per API key',
+          HttpStatus.TOO_MANY_REQUESTS,
+        ),
       );
     });
   });

--- a/backend/src/mcp-keys/mcp-keys.service.ts
+++ b/backend/src/mcp-keys/mcp-keys.service.ts
@@ -1,0 +1,89 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Inject,
+} from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import type Redis from 'ioredis';
+import { PrismaService } from '../prisma/prisma.service';
+import { REDIS_CLIENT } from '../redis/redis.module';
+
+const RATE_LIMIT = 100;
+const RATE_WINDOW_SECONDS = 3600;
+
+@Injectable()
+export class McpKeysService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {}
+
+  async generateKey(userId: string, name: string) {
+    const raw = 'mcp_' + randomBytes(32).toString('base64url');
+    const prefix = raw.slice(0, 12);
+    const keyHash = createHash('sha256').update(raw).digest('hex');
+
+    const key = await this.prisma.mcpApiKey.create({
+      data: { userId, name, keyHash, prefix },
+      select: { id: true, prefix: true, name: true, createdAt: true },
+    });
+
+    return { ...key, plaintext: raw };
+  }
+
+  async listKeys(userId: string) {
+    return this.prisma.mcpApiKey.findMany({
+      where: { userId, revokedAt: null },
+      select: { id: true, name: true, prefix: true, createdAt: true, lastUsedAt: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async revokeKey(userId: string, keyId: string) {
+    const key = await this.prisma.mcpApiKey.findUnique({ where: { id: keyId } });
+    if (!key) throw new NotFoundException('API key not found');
+    if (key.userId !== userId) throw new ForbiddenException('Access denied');
+    await this.prisma.mcpApiKey.update({
+      where: { id: keyId },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  async findByHash(hash: string) {
+    const key = await this.prisma.mcpApiKey.findFirst({
+      where: { keyHash: hash, revokedAt: null },
+      select: {
+        id: true,
+        userId: true,
+        revokedAt: true,
+        user: { select: { id: true, email: true, role: true, displayName: true } },
+      },
+    });
+    if (!key || key.revokedAt) return null;
+    const { revokedAt: _, ...rest } = key;
+    return rest;
+  }
+
+  async checkRateLimit(keyId: string) {
+    const redisKey = `mcprl:${keyId}`;
+    const count = await this.redis.incr(redisKey);
+    if (count === 1) {
+      await this.redis.expire(redisKey, RATE_WINDOW_SECONDS);
+    }
+    if (count > RATE_LIMIT) {
+      throw new HttpException(
+        'Rate limit exceeded: 100 requests per hour per API key',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+  }
+
+  updateLastUsed(keyId: string) {
+    this.prisma.mcpApiKey
+      .update({ where: { id: keyId }, data: { lastUsedAt: new Date() } })
+      .catch(() => {});
+  }
+}

--- a/backend/src/mcp-keys/mcp-keys.service.ts
+++ b/backend/src/mcp-keys/mcp-keys.service.ts
@@ -7,7 +7,7 @@ import {
   Inject,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createHmac, randomBytes } from 'crypto';
+import { pbkdf2Sync, randomBytes } from 'crypto';
 import type Redis from 'ioredis';
 import { PrismaService } from '../prisma/prisma.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
@@ -25,7 +25,7 @@ export class McpKeysService {
 
   private hashKey(raw: string): string {
     const secret = this.config.get<string>('MCP_KEY_HMAC_SECRET') ?? 'dev-fallback-change-in-production';
-    return createHmac('sha256', secret).update(raw).digest('hex');
+    return pbkdf2Sync(raw, secret, 10000, 32, 'sha256').toString('hex');
   }
 
   async generateKey(userId: string, name: string) {

--- a/backend/src/mcp-keys/mcp-keys.service.ts
+++ b/backend/src/mcp-keys/mcp-keys.service.ts
@@ -7,7 +7,10 @@ import {
   Inject,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { pbkdf2Sync, randomBytes } from 'crypto';
+import { pbkdf2, randomBytes } from 'crypto';
+import { promisify } from 'util';
+
+const pbkdf2Async = promisify(pbkdf2);
 import type Redis from 'ioredis';
 import { PrismaService } from '../prisma/prisma.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
@@ -23,15 +26,18 @@ export class McpKeysService {
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
   ) {}
 
-  private hashKey(raw: string): string {
-    const secret = this.config.get<string>('MCP_KEY_HMAC_SECRET') ?? 'dev-fallback-change-in-production';
-    return pbkdf2Sync(raw, secret, 10000, 32, 'sha256').toString('hex');
+  private async hashKey(raw: string): Promise<string> {
+    const secret =
+      this.config.get<string>('MCP_KEY_HMAC_SECRET') ??
+      'dev-fallback-change-in-production';
+    const buf = await pbkdf2Async(raw, secret, 10000, 32, 'sha256');
+    return buf.toString('hex');
   }
 
   async generateKey(userId: string, name: string) {
     const raw = 'mcp_' + randomBytes(32).toString('base64url');
     const prefix = raw.slice(0, 12);
-    const keyHash = this.hashKey(raw);
+    const keyHash = await this.hashKey(raw);
 
     const key = await this.prisma.mcpApiKey.create({
       data: { userId, name, keyHash, prefix },
@@ -44,13 +50,21 @@ export class McpKeysService {
   async listKeys(userId: string) {
     return this.prisma.mcpApiKey.findMany({
       where: { userId, revokedAt: null },
-      select: { id: true, name: true, prefix: true, createdAt: true, lastUsedAt: true },
+      select: {
+        id: true,
+        name: true,
+        prefix: true,
+        createdAt: true,
+        lastUsedAt: true,
+      },
       orderBy: { createdAt: 'desc' },
     });
   }
 
   async revokeKey(userId: string, keyId: string) {
-    const key = await this.prisma.mcpApiKey.findUnique({ where: { id: keyId } });
+    const key = await this.prisma.mcpApiKey.findUnique({
+      where: { id: keyId },
+    });
     if (!key) throw new NotFoundException('API key not found');
     if (key.userId !== userId) throw new ForbiddenException('Access denied');
     await this.prisma.mcpApiKey.update({
@@ -60,27 +74,26 @@ export class McpKeysService {
   }
 
   async findByRawKey(raw: string) {
-    const hash = this.hashKey(raw);
-    const key = await this.prisma.mcpApiKey.findFirst({
+    const hash = await this.hashKey(raw);
+    return this.prisma.mcpApiKey.findFirst({
       where: { keyHash: hash, revokedAt: null },
       select: {
         id: true,
         userId: true,
-        revokedAt: true,
-        user: { select: { id: true, email: true, role: true, displayName: true } },
+        user: {
+          select: { id: true, email: true, role: true, displayName: true },
+        },
       },
     });
-    if (!key || key.revokedAt) return null;
-    const { revokedAt: _, ...rest } = key;
-    return rest;
   }
 
   async checkRateLimit(keyId: string) {
     const redisKey = `mcprl:${keyId}`;
-    const count = await this.redis.incr(redisKey);
-    if (count === 1) {
-      await this.redis.expire(redisKey, RATE_WINDOW_SECONDS);
-    }
+    const pipeline = this.redis.pipeline();
+    pipeline.incr(redisKey);
+    pipeline.expire(redisKey, RATE_WINDOW_SECONDS, 'NX');
+    const results = await pipeline.exec();
+    const count = results?.[0]?.[1] as number;
     if (count > RATE_LIMIT) {
       throw new HttpException(
         'Rate limit exceeded: 100 requests per hour per API key',

--- a/backend/src/mcp-keys/mcp-keys.service.ts
+++ b/backend/src/mcp-keys/mcp-keys.service.ts
@@ -6,7 +6,8 @@ import {
   HttpStatus,
   Inject,
 } from '@nestjs/common';
-import { createHash, randomBytes } from 'crypto';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, randomBytes } from 'crypto';
 import type Redis from 'ioredis';
 import { PrismaService } from '../prisma/prisma.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
@@ -18,13 +19,19 @@ const RATE_WINDOW_SECONDS = 3600;
 export class McpKeysService {
   constructor(
     private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
   ) {}
+
+  private hashKey(raw: string): string {
+    const secret = this.config.get<string>('MCP_KEY_HMAC_SECRET') ?? 'dev-fallback-change-in-production';
+    return createHmac('sha256', secret).update(raw).digest('hex');
+  }
 
   async generateKey(userId: string, name: string) {
     const raw = 'mcp_' + randomBytes(32).toString('base64url');
     const prefix = raw.slice(0, 12);
-    const keyHash = createHash('sha256').update(raw).digest('hex');
+    const keyHash = this.hashKey(raw);
 
     const key = await this.prisma.mcpApiKey.create({
       data: { userId, name, keyHash, prefix },
@@ -52,7 +59,8 @@ export class McpKeysService {
     });
   }
 
-  async findByHash(hash: string) {
+  async findByRawKey(raw: string) {
+    const hash = this.hashKey(raw);
     const key = await this.prisma.mcpApiKey.findFirst({
       where: { keyHash: hash, revokedAt: null },
       select: {

--- a/backend/src/mcp-server.ts
+++ b/backend/src/mcp-server.ts
@@ -7,8 +7,8 @@
  * questions into the Brain Gym platform.
  *
  * Environment variables:
- *   BRAIN_GYM_API_URL       – Base URL of the running backend (default: http://localhost:3000)
- *   BRAIN_GYM_BEARER_TOKEN  – JWT bearer token for authentication (required)
+ *   BRAIN_GYM_API_URL  – Base URL of the running backend (default: http://localhost:3000)
+ *   BRAIN_GYM_API_KEY  – MCP API key generated in CertGym Settings (required, starts with mcp_)
  *
  * Usage with Claude Desktop – add to claude_desktop_config.json:
  *   {
@@ -19,7 +19,7 @@
  *         "cwd": "/path/to/brain-gym/backend",
  *         "env": {
  *           "BRAIN_GYM_API_URL": "http://localhost:3000",
- *           "BRAIN_GYM_BEARER_TOKEN": "<your-jwt>"
+ *           "BRAIN_GYM_API_KEY": "<your-mcp-api-key-from-settings>"
  *         }
  *       }
  *     }
@@ -33,12 +33,12 @@ import { z } from 'zod';
 // ── Configuration ──────────────────────────────────────────────────────────────
 
 const API_URL = process.env.BRAIN_GYM_API_URL || 'http://localhost:3000';
-const BEARER_TOKEN = process.env.BRAIN_GYM_BEARER_TOKEN || '';
+const API_KEY = process.env.BRAIN_GYM_API_KEY || '';
 
-if (!BEARER_TOKEN) {
+if (!API_KEY || !API_KEY.startsWith('mcp_')) {
   console.error(
-    '[brain-gym-mcp] ERROR: BRAIN_GYM_BEARER_TOKEN environment variable is required.\n' +
-      'Set it to a valid JWT token from your Brain Gym account.',
+    '[brain-gym-mcp] ERROR: BRAIN_GYM_API_KEY environment variable is required.\n' +
+      'Generate one in CertGym Settings → MCP API Keys. It starts with "mcp_".',
   );
   process.exit(1);
 }
@@ -55,7 +55,7 @@ async function callIntakeApi(payload: Record<string, unknown>): Promise<{
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${BEARER_TOKEN}`,
+      'X-API-Key': API_KEY,
     },
     body: JSON.stringify(payload),
   });

--- a/docs/superpowers/plans/2026-06-19-mcp-api-keys.md
+++ b/docs/superpowers/plans/2026-06-19-mcp-api-keys.md
@@ -1,0 +1,1282 @@
+# MCP API Keys Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace long-lived JWT auth on the MCP intake endpoint with revocable scoped API keys, add per-key rate limiting, audit logging, and a Settings UI for key management.
+
+**Architecture:** A new `McpKeysModule` provides `McpKeysService` (generate/list/revoke) and `ApiKeyAuthGuard` (SHA-256 hash lookup, sets `req.user` + `req.mcpKeyId`). The intake endpoint is marked `@Public()` (skips the global JWT guard) and uses `ApiKeyAuthGuard` instead. Rate limiting is enforced in the service via a Redis INCR counter keyed on `mcpKeyId`. The frontend adds an "MCP API Keys" tab to the Profile page.
+
+**Tech Stack:** NestJS 11, Prisma (PostgreSQL), ioredis, React 18 + TanStack Query, shadcn/ui, Zod.
+
+## Global Constraints
+
+- Backend: NestJS 11, Prisma ORM, TypeScript strict-ish (`noImplicitAny: false`, `strictNullChecks: false`)
+- Frontend: React 18, TypeScript, TanStack Query for all server state, shadcn/ui components, Zod for validation
+- All new backend files follow `kebab-case.service.ts` / `kebab-case.controller.ts` naming
+- Prisma model fields use `@map("snake_case")` convention; model names are PascalCase
+- No new npm packages — use existing `ioredis`, `crypto` (Node built-in), `class-validator`, `@nestjs/common`
+- Run `cd backend && npm run test` after each backend task to confirm no regressions
+- Run `npm run lint` in root after each frontend task
+
+---
+
+## File Map
+
+**Created:**
+- `backend/src/mcp-keys/mcp-keys.service.ts` — generate/list/revoke logic + rate-limit check
+- `backend/src/mcp-keys/mcp-keys.service.spec.ts` — unit tests
+- `backend/src/mcp-keys/api-key-auth.guard.ts` — validates X-API-Key header
+- `backend/src/mcp-keys/api-key-auth.guard.spec.ts` — unit tests
+- `backend/src/mcp-keys/mcp-keys.controller.ts` — REST endpoints
+- `backend/src/mcp-keys/mcp-keys.module.ts` — module wiring
+
+**Modified:**
+- `backend/prisma/schema.prisma` — add `McpApiKey` model + User relation
+- `backend/src/app.module.ts` — import `McpKeysModule`
+- `backend/src/ai-question-bank/ai-question-bank.controller.ts` — @Public + ApiKeyAuthGuard on mcpIntake
+- `backend/src/ai-question-bank/ai-question-bank.service.ts` — add rate limit + audit log to mcpIntake
+- `backend/src/ai-question-bank/ai-question-bank.module.ts` — import McpKeysModule + RedisModule
+- `backend/src/mcp-server.ts` — swap BRAIN_GYM_BEARER_TOKEN → BRAIN_GYM_API_KEY
+- `src/services/mcp-keys.ts` — new frontend service (API calls)
+- `src/types/api-types.ts` — add McpApiKey types
+- `src/components/profile/McpApiKeysTab.tsx` — new component
+- `src/pages/Profile.tsx` — add "MCP Keys" tab
+
+---
+
+## Task 1: Prisma Schema — McpApiKey Model
+
+**Files:**
+- Modify: `backend/prisma/schema.prisma`
+
+**Interfaces:**
+- Produces: `McpApiKey` Prisma model available in `@prisma/client`
+
+- [ ] **Step 1: Add McpApiKey model to schema.prisma**
+
+Open `backend/prisma/schema.prisma`. After the `UserLlmConfig` model (around line 712), add:
+
+```prisma
+model McpApiKey {
+  id         String    @id @default(uuid())
+  userId     String    @map("user_id")
+  name       String
+  keyHash    String    @unique @map("key_hash")
+  prefix     String
+  lastUsedAt DateTime? @map("last_used_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  revokedAt  DateTime? @map("revoked_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("mcp_api_keys")
+}
+```
+
+- [ ] **Step 2: Add relation to User model**
+
+In the `User` model (around line 234), add after the `llmConfigs` line:
+
+```prisma
+  mcpApiKeys                 McpApiKey[]
+```
+
+- [ ] **Step 3: Run migration**
+
+```bash
+cd backend && npx prisma migrate dev --name add_mcp_api_keys
+```
+
+Expected output: `The following migration(s) have been created and applied: migrations/YYYYMMDD_add_mcp_api_keys`
+
+- [ ] **Step 4: Verify Prisma client regenerated**
+
+```bash
+cd backend && npx prisma generate
+```
+
+Expected: `Generated Prisma Client` with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/prisma/schema.prisma backend/prisma/migrations/
+git commit -m "feat: add McpApiKey prisma model and migration"
+```
+
+---
+
+## Task 2: McpKeysService — Generate, List, Revoke, Rate-Limit
+
+**Files:**
+- Create: `backend/src/mcp-keys/mcp-keys.service.ts`
+- Create: `backend/src/mcp-keys/mcp-keys.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `PrismaService` (injected), `REDIS_CLIENT` (ioredis, injected via token)
+- Produces:
+  - `generateKey(userId: string, name: string): Promise<{ id: string; prefix: string; name: string; createdAt: Date; plaintext: string }>`
+  - `listKeys(userId: string): Promise<Array<{ id: string; name: string; prefix: string; createdAt: Date; lastUsedAt: Date | null }>>`
+  - `revokeKey(userId: string, keyId: string): Promise<void>`
+  - `findByHash(hash: string): Promise<{ id: string; userId: string; user: { id: string; email: string; role: string; displayName: string } } | null>`
+  - `checkRateLimit(keyId: string): Promise<void>` — throws `HttpException(429)` if > 100 req/hr
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/src/mcp-keys/mcp-keys.service.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { McpKeysService } from './mcp-keys.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { REDIS_CLIENT } from '../redis/redis.module';
+
+const mockPrisma = {
+  mcpApiKey: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+const mockRedis = {
+  incr: jest.fn(),
+  expire: jest.fn(),
+};
+
+describe('McpKeysService', () => {
+  let service: McpKeysService;
+  let prisma: typeof mockPrisma;
+  let redis: typeof mockRedis;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        McpKeysService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: REDIS_CLIENT, useValue: mockRedis },
+      ],
+    }).compile();
+
+    service = module.get<McpKeysService>(McpKeysService);
+    prisma = module.get<PrismaService>(PrismaService) as any;
+    redis = module.get(REDIS_CLIENT);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('generateKey', () => {
+    it('should return plaintext key with mcp_ prefix and store hash', async () => {
+      const fakeKey = { id: 'key-1', prefix: 'mcp_abcd', name: 'My Key', createdAt: new Date() };
+      prisma.mcpApiKey.create.mockResolvedValue(fakeKey);
+
+      const result = await service.generateKey('user-1', 'My Key');
+
+      expect(result.plaintext).toMatch(/^mcp_/);
+      expect(result.prefix).toMatch(/^mcp_/);
+      expect(result.plaintext.length).toBeGreaterThan(40);
+      expect(prisma.mcpApiKey.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'user-1',
+            name: 'My Key',
+            keyHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('listKeys', () => {
+    it('should return active keys for user', async () => {
+      const keys = [{ id: 'k1', name: 'Key 1', prefix: 'mcp_abcd', createdAt: new Date(), lastUsedAt: null }];
+      prisma.mcpApiKey.findMany.mockResolvedValue(keys);
+
+      const result = await service.listKeys('user-1');
+
+      expect(prisma.mcpApiKey.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user-1', revokedAt: null } }),
+      );
+      expect(result).toEqual(keys);
+    });
+  });
+
+  describe('revokeKey', () => {
+    it('should set revokedAt on owned key', async () => {
+      prisma.mcpApiKey.findUnique.mockResolvedValue({ id: 'k1', userId: 'user-1' });
+      prisma.mcpApiKey.update.mockResolvedValue({});
+
+      await service.revokeKey('user-1', 'k1');
+
+      expect(prisma.mcpApiKey.update).toHaveBeenCalledWith({
+        where: { id: 'k1' },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+
+    it('should throw NotFoundException if key does not exist', async () => {
+      prisma.mcpApiKey.findUnique.mockResolvedValue(null);
+      await expect(service.revokeKey('user-1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException if key belongs to another user', async () => {
+      prisma.mcpApiKey.findUnique.mockResolvedValue({ id: 'k1', userId: 'user-2' });
+      await expect(service.revokeKey('user-1', 'k1')).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('findByHash', () => {
+    it('should return key with user for a valid active hash', async () => {
+      const key = { id: 'k1', userId: 'u1', user: { id: 'u1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' } };
+      prisma.mcpApiKey.findUnique.mockResolvedValue(key);
+
+      const result = await service.findByHash('somehash');
+      expect(result).toEqual(key);
+    });
+
+    it('should return null if not found', async () => {
+      prisma.mcpApiKey.findUnique.mockResolvedValue(null);
+      const result = await service.findByHash('badhash');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('checkRateLimit', () => {
+    it('should not throw when under limit', async () => {
+      redis.incr.mockResolvedValue(50);
+      redis.expire.mockResolvedValue(1);
+      await expect(service.checkRateLimit('key-1')).resolves.not.toThrow();
+    });
+
+    it('should throw 429 when over limit', async () => {
+      redis.incr.mockResolvedValue(101);
+      redis.expire.mockResolvedValue(1);
+      await expect(service.checkRateLimit('key-1')).rejects.toThrow(
+        new HttpException('Rate limit exceeded: 100 requests per hour per API key', HttpStatus.TOO_MANY_REQUESTS),
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd backend && npx jest mcp-keys.service.spec.ts --no-coverage
+```
+
+Expected: FAIL — `Cannot find module './mcp-keys.service'`
+
+- [ ] **Step 3: Implement McpKeysService**
+
+Create `backend/src/mcp-keys/mcp-keys.service.ts`:
+
+```typescript
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Inject,
+} from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import type Redis from 'ioredis';
+import { PrismaService } from '../prisma/prisma.service';
+import { REDIS_CLIENT } from '../redis/redis.module';
+
+const RATE_LIMIT = 100;
+const RATE_WINDOW_SECONDS = 3600;
+
+@Injectable()
+export class McpKeysService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {}
+
+  async generateKey(userId: string, name: string) {
+    const raw = 'mcp_' + randomBytes(32).toString('base64url');
+    const prefix = raw.slice(0, 12);
+    const keyHash = createHash('sha256').update(raw).digest('hex');
+
+    const key = await this.prisma.mcpApiKey.create({
+      data: { userId, name, keyHash, prefix },
+      select: { id: true, prefix: true, name: true, createdAt: true },
+    });
+
+    return { ...key, plaintext: raw };
+  }
+
+  async listKeys(userId: string) {
+    return this.prisma.mcpApiKey.findMany({
+      where: { userId, revokedAt: null },
+      select: { id: true, name: true, prefix: true, createdAt: true, lastUsedAt: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async revokeKey(userId: string, keyId: string) {
+    const key = await this.prisma.mcpApiKey.findUnique({ where: { id: keyId } });
+    if (!key) throw new NotFoundException('API key not found');
+    if (key.userId !== userId) throw new ForbiddenException('Access denied');
+    await this.prisma.mcpApiKey.update({
+      where: { id: keyId },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  async findByHash(hash: string) {
+    const key = await this.prisma.mcpApiKey.findFirst({
+      where: { keyHash: hash, revokedAt: null },
+      select: {
+        id: true,
+        userId: true,
+        revokedAt: true,
+        user: { select: { id: true, email: true, role: true, displayName: true } },
+      },
+    });
+    if (!key || key.revokedAt) return null;
+    const { revokedAt: _, ...rest } = key;
+    return rest;
+  }
+
+  async checkRateLimit(keyId: string) {
+    const redisKey = `mcprl:${keyId}`;
+    const count = await this.redis.incr(redisKey);
+    if (count === 1) {
+      await this.redis.expire(redisKey, RATE_WINDOW_SECONDS);
+    }
+    if (count > RATE_LIMIT) {
+      throw new HttpException(
+        'Rate limit exceeded: 100 requests per hour per API key',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+  }
+
+  updateLastUsed(keyId: string) {
+    this.prisma.mcpApiKey
+      .update({ where: { id: keyId }, data: { lastUsedAt: new Date() } })
+      .catch(() => {});
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — should pass**
+
+```bash
+cd backend && npx jest mcp-keys.service.spec.ts --no-coverage
+```
+
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/mcp-keys/mcp-keys.service.ts backend/src/mcp-keys/mcp-keys.service.spec.ts
+git commit -m "feat: add McpKeysService with generate, list, revoke, and rate-limit"
+```
+
+---
+
+## Task 3: ApiKeyAuthGuard
+
+**Files:**
+- Create: `backend/src/mcp-keys/api-key-auth.guard.ts`
+- Create: `backend/src/mcp-keys/api-key-auth.guard.spec.ts`
+
+**Interfaces:**
+- Consumes: `McpKeysService.findByHash()`, `McpKeysService.updateLastUsed()`
+- Produces: Sets `req.user: AuthenticatedUser` and `req.mcpKeyId: string` on the Express request; throws `UnauthorizedException` on failure
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/src/mcp-keys/api-key-auth.guard.spec.ts`:
+
+```typescript
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ApiKeyAuthGuard } from './api-key-auth.guard';
+import { McpKeysService } from './mcp-keys.service';
+
+const mockMcpKeysService = {
+  findByHash: jest.fn(),
+  updateLastUsed: jest.fn(),
+};
+
+function makeContext(headers: Record<string, string> = {}) {
+  const req: any = { headers, mcpKeyId: undefined, user: undefined };
+  return {
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as unknown as ExecutionContext;
+}
+
+describe('ApiKeyAuthGuard', () => {
+  let guard: ApiKeyAuthGuard;
+
+  beforeEach(() => {
+    guard = new ApiKeyAuthGuard(mockMcpKeysService as unknown as McpKeysService);
+    jest.clearAllMocks();
+  });
+
+  it('should throw UnauthorizedException when X-API-Key header is missing', async () => {
+    await expect(guard.canActivate(makeContext())).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should throw UnauthorizedException for malformed key (no mcp_ prefix)', async () => {
+    await expect(guard.canActivate(makeContext({ 'x-api-key': 'badkey' }))).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should throw UnauthorizedException when key hash not found in DB', async () => {
+    mockMcpKeysService.findByHash.mockResolvedValue(null);
+    await expect(guard.canActivate(makeContext({ 'x-api-key': 'mcp_validlooking12345678901234567890123456' }))).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should set req.user and req.mcpKeyId and return true for valid key', async () => {
+    const fakeKey = {
+      id: 'key-1',
+      userId: 'user-1',
+      user: { id: 'user-1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' },
+    };
+    mockMcpKeysService.findByHash.mockResolvedValue(fakeKey);
+
+    const ctx = makeContext({ 'x-api-key': 'mcp_validlooking12345678901234567890123456' });
+    const req = ctx.switchToHttp().getRequest();
+
+    const result = await guard.canActivate(ctx);
+
+    expect(result).toBe(true);
+    expect(req.user).toEqual({ id: 'user-1', email: 'x@x.com', role: 'CONTRIBUTOR', displayName: 'X' });
+    expect(req.mcpKeyId).toBe('key-1');
+    expect(mockMcpKeysService.updateLastUsed).toHaveBeenCalledWith('key-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd backend && npx jest api-key-auth.guard.spec.ts --no-coverage
+```
+
+Expected: FAIL — `Cannot find module './api-key-auth.guard'`
+
+- [ ] **Step 3: Implement ApiKeyAuthGuard**
+
+Create `backend/src/mcp-keys/api-key-auth.guard.ts`:
+
+```typescript
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { createHash } from 'crypto';
+import { McpKeysService } from './mcp-keys.service';
+
+const MCP_KEY_PREFIX = 'mcp_';
+const MIN_KEY_LENGTH = 20;
+
+@Injectable()
+export class ApiKeyAuthGuard implements CanActivate {
+  constructor(private readonly mcpKeys: McpKeysService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const raw: string | undefined = req.headers['x-api-key'];
+
+    if (!raw) {
+      throw new UnauthorizedException('Missing X-API-Key header');
+    }
+
+    if (!raw.startsWith(MCP_KEY_PREFIX) || raw.length < MIN_KEY_LENGTH) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    const hash = createHash('sha256').update(raw).digest('hex');
+    const key = await this.mcpKeys.findByHash(hash);
+
+    if (!key) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    req.user = key.user;
+    req.mcpKeyId = key.id;
+    this.mcpKeys.updateLastUsed(key.id);
+
+    return true;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — should pass**
+
+```bash
+cd backend && npx jest api-key-auth.guard.spec.ts --no-coverage
+```
+
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/mcp-keys/api-key-auth.guard.ts backend/src/mcp-keys/api-key-auth.guard.spec.ts
+git commit -m "feat: add ApiKeyAuthGuard for X-API-Key header validation"
+```
+
+---
+
+## Task 4: McpKeysController + McpKeysModule
+
+**Files:**
+- Create: `backend/src/mcp-keys/mcp-keys.controller.ts`
+- Create: `backend/src/mcp-keys/mcp-keys.module.ts`
+- Modify: `backend/src/app.module.ts`
+
+**Interfaces:**
+- Consumes: `McpKeysService.generateKey()`, `McpKeysService.listKeys()`, `McpKeysService.revokeKey()`
+- Produces:
+  - `GET /api/v1/mcp-keys` → `Array<{ id, name, prefix, createdAt, lastUsedAt }>`
+  - `POST /api/v1/mcp-keys` body `{ name: string }` → `{ id, prefix, name, createdAt, plaintext }`
+  - `DELETE /api/v1/mcp-keys/:id` → `204 No Content`
+
+- [ ] **Step 1: Create McpKeysController**
+
+Create `backend/src/mcp-keys/mcp-keys.controller.ts`:
+
+```typescript
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/interfaces/request.interface';
+import { McpKeysService } from './mcp-keys.service';
+
+class CreateMcpKeyDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(80)
+  name: string;
+}
+
+@ApiTags('MCP API Keys')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('mcp-keys')
+export class McpKeysController {
+  constructor(private readonly service: McpKeysService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List active MCP API keys for the current user' })
+  list(@Req() req: AuthenticatedRequest) {
+    return this.service.listKeys(req.user.id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Generate a new MCP API key (plaintext returned once)' })
+  generate(@Req() req: AuthenticatedRequest, @Body() dto: CreateMcpKeyDto) {
+    return this.service.generateKey(req.user.id, dto.name);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Revoke an MCP API key' })
+  revoke(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
+    return this.service.revokeKey(req.user.id, id);
+  }
+}
+```
+
+- [ ] **Step 2: Create McpKeysModule**
+
+Create `backend/src/mcp-keys/mcp-keys.module.ts`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { RedisModule } from '../redis/redis.module';
+import { McpKeysService } from './mcp-keys.service';
+import { McpKeysController } from './mcp-keys.controller';
+import { ApiKeyAuthGuard } from './api-key-auth.guard';
+
+@Module({
+  imports: [PrismaModule, RedisModule],
+  controllers: [McpKeysController],
+  providers: [McpKeysService, ApiKeyAuthGuard],
+  exports: [McpKeysService, ApiKeyAuthGuard],
+})
+export class McpKeysModule {}
+```
+
+- [ ] **Step 3: Register McpKeysModule in AppModule**
+
+Open `backend/src/app.module.ts`. Add the import at the top:
+
+```typescript
+import { McpKeysModule } from './mcp-keys/mcp-keys.module';
+```
+
+Add `McpKeysModule` to the `imports` array (after `CompetencyModule`):
+
+```typescript
+    CompetencyModule,
+    McpKeysModule,
+```
+
+- [ ] **Step 4: Run tests to confirm no regressions**
+
+```bash
+cd backend && npm run test -- --passWithNoTests 2>&1 | tail -20
+```
+
+Expected: All previously passing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/mcp-keys/ backend/src/app.module.ts
+git commit -m "feat: add McpKeysController and McpKeysModule"
+```
+
+---
+
+## Task 5: Harden mcpIntake Endpoint
+
+**Files:**
+- Modify: `backend/src/ai-question-bank/ai-question-bank.controller.ts`
+- Modify: `backend/src/ai-question-bank/ai-question-bank.service.ts`
+- Modify: `backend/src/ai-question-bank/ai-question-bank.module.ts`
+
+**Interfaces:**
+- Consumes: `ApiKeyAuthGuard` from McpKeysModule; `McpKeysService.checkRateLimit(keyId)`; `AuditService.log()`
+- The request now carries `req.mcpKeyId: string` (set by ApiKeyAuthGuard)
+
+- [ ] **Step 1: Update the controller — @Public + ApiKeyAuthGuard**
+
+Open `backend/src/ai-question-bank/ai-question-bank.controller.ts`.
+
+Add import at top (with existing imports):
+
+```typescript
+import { Public } from '../common/decorators/public.decorator';
+import { ApiKeyAuthGuard } from '../mcp-keys/api-key-auth.guard';
+```
+
+Add a `McpRequest` interface after the imports (extends the existing `AuthenticatedRequest`):
+
+```typescript
+interface McpRequest extends AuthenticatedRequest {
+  mcpKeyId: string;
+}
+```
+
+Replace the existing `mcpIntake` method:
+
+```typescript
+  @Post('mcp/intake')
+  @Public()
+  @UseGuards(ApiKeyAuthGuard)
+  @ApiOperation({
+    summary:
+      'MCP mode: receive questions pushed from external AI tools (Claude Desktop, etc.)',
+  })
+  mcpIntake(@Req() req: McpRequest, @Body() dto: McpIntakeDto) {
+    return this.service.mcpIntake(req.user.id, req.mcpKeyId, dto);
+  }
+```
+
+The existing `import type { AuthenticatedRequest } from '../common/interfaces/request.interface'` is already present in the file — no change needed to that import line.
+
+- [ ] **Step 2: Update AiQuestionBankModule to import McpKeysModule**
+
+Open `backend/src/ai-question-bank/ai-question-bank.module.ts`. Add imports:
+
+```typescript
+import { McpKeysModule } from '../mcp-keys/mcp-keys.module';
+import { RedisModule } from '../redis/redis.module';
+```
+
+Add both to the `imports` array:
+
+```typescript
+  imports: [
+    PrismaModule,
+    QuestionsModule,
+    LlmUsageModule,
+    EmbeddingModule,
+    DdsModule,
+    McpKeysModule,
+    RedisModule,
+    MulterModule.register({ limits: { fileSize: 50 * 1024 * 1024 } }),
+    BullModule.registerQueue({ name: AI_GEN_QUEUE }),
+    BullModule.registerQueue({ name: MATERIAL_CONVERSION_QUEUE }),
+  ],
+```
+
+Also add `ApiKeyAuthGuard` to the `providers` array:
+
+```typescript
+  providers: [AiQuestionBankService, EncryptionService, IngestionService, S3UploadService, ApiKeyAuthGuard],
+```
+
+And add the import:
+
+```typescript
+import { ApiKeyAuthGuard } from '../mcp-keys/api-key-auth.guard';
+```
+
+- [ ] **Step 3: Update AiQuestionBankService.mcpIntake — add rate limit + audit**
+
+Open `backend/src/ai-question-bank/ai-question-bank.service.ts`.
+
+Add `AuditService` to the imports and constructor. Add `McpKeysService` import:
+
+```typescript
+import { AuditService } from '../audit/audit.service';
+import { McpKeysService } from '../mcp-keys/mcp-keys.service';
+```
+
+Add to constructor parameters:
+
+```typescript
+    private readonly audit: AuditService,
+    private readonly mcpKeys: McpKeysService,
+```
+
+Replace the existing `mcpIntake` method signature and body:
+
+```typescript
+  async mcpIntake(userId: string, keyId: string, dto: McpIntakeDto) {
+    await this.mcpKeys.checkRateLimit(keyId);
+
+    const saved: string[] = [];
+    const discarded: number[] = [];
+
+    for (const [index, q] of dto.questions.entries()) {
+      const score = q.quality_score ?? 0.7;
+      const tier = this.scoreTotier(score);
+
+      if (tier === null) {
+        discarded.push(index);
+        continue;
+      }
+
+      const status =
+        tier === QualityTier.HIGH
+          ? QuestionStatus.APPROVED
+          : QuestionStatus.PENDING;
+      const qType = dto.questionType || QuestionType.SINGLE;
+
+      const question = await this.questions.create(
+        userId,
+        {
+          title: q.question,
+          explanation: q.explanation,
+          questionType: qType,
+          difficulty: dto.difficulty || Difficulty.MEDIUM,
+          certificationId: dto.certificationId,
+          domainId: dto.domainId,
+          choices: q.choices,
+        },
+        status,
+        undefined,
+        tier,
+      );
+
+      saved.push(question.id);
+    }
+
+    this.audit
+      .log({
+        userId,
+        action: 'MCP_INTAKE',
+        targetType: 'certification',
+        targetId: dto.certificationId,
+        metadata: {
+          keyId,
+          source: dto.source ?? 'MCP',
+          saved: saved.length,
+          discarded: discarded.length,
+        },
+      })
+      .catch(() => {});
+
+    return {
+      saved: saved.length,
+      discarded: discarded.length,
+      questionIds: saved,
+    };
+  }
+```
+
+- [ ] **Step 4: Run all backend tests**
+
+```bash
+cd backend && npm run test -- --passWithNoTests 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/ai-question-bank/
+git commit -m "feat: harden mcpIntake with ApiKeyAuthGuard, rate limiting, and audit log"
+```
+
+---
+
+## Task 6: Update mcp-server.ts
+
+**Files:**
+- Modify: `backend/src/mcp-server.ts`
+
+**Interfaces:**
+- Consumes: env var `BRAIN_GYM_API_KEY` (renamed from `BRAIN_GYM_BEARER_TOKEN`)
+- Produces: requests to `/api/v1/ai-questions/mcp/intake` with `X-API-Key` header instead of `Authorization: Bearer`
+
+- [ ] **Step 1: Update env var name and header**
+
+Open `backend/src/mcp-server.ts`. Make the following changes:
+
+1. Replace the file-header comment env var doc:
+
+```
+ *   BRAIN_GYM_API_KEY       – MCP API key generated in CertGym Settings (required, starts with mcp_)
+```
+
+2. Replace in the claude_desktop_config.json example in the comment:
+
+```
+ *           "BRAIN_GYM_API_KEY": "<your-mcp-api-key-from-settings>"
+```
+
+3. Replace the variable declaration:
+
+```typescript
+const BEARER_TOKEN = process.env.BRAIN_GYM_BEARER_TOKEN || '';
+```
+→
+```typescript
+const API_KEY = process.env.BRAIN_GYM_API_KEY || '';
+```
+
+4. Replace the guard check:
+
+```typescript
+if (!BEARER_TOKEN) {
+  console.error(
+    '[brain-gym-mcp] ERROR: BRAIN_GYM_BEARER_TOKEN environment variable is required.\n' +
+      'Set it to a valid JWT token from your Brain Gym account.',
+  );
+  process.exit(1);
+}
+```
+→
+```typescript
+if (!API_KEY || !API_KEY.startsWith('mcp_')) {
+  console.error(
+    '[brain-gym-mcp] ERROR: BRAIN_GYM_API_KEY environment variable is required.\n' +
+      'Generate one in CertGym Settings → MCP API Keys. It starts with "mcp_".',
+  );
+  process.exit(1);
+}
+```
+
+5. Replace the header in `callIntakeApi`:
+
+```typescript
+      Authorization: `Bearer ${BEARER_TOKEN}`,
+```
+→
+```typescript
+      'X-API-Key': API_KEY,
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cd backend && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: No errors related to mcp-server.ts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/mcp-server.ts
+git commit -m "feat: update mcp-server.ts to use BRAIN_GYM_API_KEY and X-API-Key header"
+```
+
+---
+
+## Task 7: Frontend — Types + Service
+
+**Files:**
+- Modify: `src/types/api-types.ts`
+- Create: `src/services/mcp-keys.ts`
+
+**Interfaces:**
+- Produces:
+  - `McpApiKey` type
+  - `McpApiKeyCreated` type (includes `plaintext`)
+  - `listMcpKeys(): Promise<McpApiKey[]>`
+  - `generateMcpKey(name: string): Promise<McpApiKeyCreated>`
+  - `revokeMcpKey(id: string): Promise<void>`
+
+- [ ] **Step 1: Add types to api-types.ts**
+
+Open `src/types/api-types.ts`. Add at the end:
+
+```typescript
+export interface McpApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface McpApiKeyCreated extends McpApiKey {
+  plaintext: string;
+}
+```
+
+- [ ] **Step 2: Create the frontend service**
+
+Create `src/services/mcp-keys.ts`:
+
+```typescript
+import api from "./api";
+import { McpApiKey, McpApiKeyCreated } from "../types/api-types";
+
+export const listMcpKeys = async (): Promise<McpApiKey[]> => {
+  const res = await api.get<McpApiKey[]>("/mcp-keys");
+  return res.data;
+};
+
+export const generateMcpKey = async (name: string): Promise<McpApiKeyCreated> => {
+  const res = await api.post<McpApiKeyCreated>("/mcp-keys", { name });
+  return res.data;
+};
+
+export const revokeMcpKey = async (id: string): Promise<void> => {
+  await api.delete(`/mcp-keys/${id}`);
+};
+```
+
+- [ ] **Step 3: Lint check**
+
+```bash
+npm run lint -- src/services/mcp-keys.ts src/types/api-types.ts
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/mcp-keys.ts src/types/api-types.ts
+git commit -m "feat: add MCP API key frontend types and service"
+```
+
+---
+
+## Task 8: Frontend — McpApiKeysTab Component
+
+**Files:**
+- Create: `src/components/profile/McpApiKeysTab.tsx`
+
+**Interfaces:**
+- Consumes: `listMcpKeys`, `generateMcpKey`, `revokeMcpKey` from `src/services/mcp-keys.ts`; `McpApiKey`, `McpApiKeyCreated` from `src/types/api-types.ts`
+- Produces: `<McpApiKeysTab />` — a React component with no props
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/profile/McpApiKeysTab.tsx`:
+
+```tsx
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Key, Plus, Trash2, Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { listMcpKeys, generateMcpKey, revokeMcpKey } from "@/services/mcp-keys";
+import { McpApiKeyCreated } from "@/types/api-types";
+
+export default function McpApiKeysTab() {
+  const { toast } = useToast();
+  const qc = useQueryClient();
+  const [showGenerate, setShowGenerate] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [createdKey, setCreatedKey] = useState<McpApiKeyCreated | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const { data: keys = [], isLoading } = useQuery({
+    queryKey: ["mcp-keys"],
+    queryFn: listMcpKeys,
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: () => generateMcpKey(newKeyName.trim()),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["mcp-keys"] });
+      setCreatedKey(data);
+      setNewKeyName("");
+    },
+    onError: () => {
+      toast({ title: "Failed to generate key", variant: "destructive" });
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: revokeMcpKey,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["mcp-keys"] });
+      toast({ title: "API key revoked" });
+    },
+    onError: () => {
+      toast({ title: "Failed to revoke key", variant: "destructive" });
+    },
+  });
+
+  const handleCopy = async () => {
+    if (!createdKey) return;
+    await navigator.clipboard.writeText(createdKey.plaintext);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleCloseCreated = () => {
+    setCreatedKey(null);
+    setShowGenerate(false);
+  };
+
+  const formatDate = (d: string | null) =>
+    d ? new Date(d).toLocaleDateString() : "Never";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">MCP API Keys</h3>
+          <p className="text-sm text-muted-foreground">
+            Use these keys to let Claude Desktop or any MCP-compatible tool push questions into your account.
+          </p>
+        </div>
+        <Button size="sm" onClick={() => setShowGenerate(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Generate key
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : keys.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-center text-muted-foreground">
+            <Key className="mx-auto mb-2 h-8 w-8 opacity-40" />
+            <p className="text-sm">No API keys yet. Generate one to get started.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {keys.map((key) => (
+            <Card key={key.id}>
+              <CardContent className="flex items-center justify-between py-4">
+                <div className="space-y-1">
+                  <p className="font-medium text-sm">{key.name}</p>
+                  <p className="font-mono text-xs text-muted-foreground">{key.prefix}…</p>
+                  <p className="text-xs text-muted-foreground">
+                    Created {formatDate(key.createdAt)} · Last used {formatDate(key.lastUsedAt)}
+                  </p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  disabled={revokeMutation.isPending}
+                  onClick={() => revokeMutation.mutate(key.id)}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Generate key dialog */}
+      <Dialog open={showGenerate && !createdKey} onOpenChange={(o) => { if (!o) setShowGenerate(false); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Generate MCP API Key</DialogTitle>
+            <DialogDescription>
+              Give this key a name so you can identify it later (e.g. "My Claude Desktop").
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="key-name">Key name</Label>
+            <Input
+              id="key-name"
+              placeholder="My Claude Desktop"
+              value={newKeyName}
+              onChange={(e) => setNewKeyName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter" && newKeyName.trim()) generateMutation.mutate(); }}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowGenerate(false)}>Cancel</Button>
+            <Button
+              disabled={!newKeyName.trim() || generateMutation.isPending}
+              onClick={() => generateMutation.mutate()}
+            >
+              Generate
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Show created key dialog */}
+      <Dialog open={!!createdKey} onOpenChange={(o) => { if (!o) handleCloseCreated(); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>API Key Created</DialogTitle>
+            <DialogDescription className="text-destructive font-medium">
+              This key will not be shown again. Copy it now.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label>Your new API key</Label>
+            <div className="flex gap-2">
+              <Input
+                readOnly
+                value={createdKey?.plaintext ?? ""}
+                className="font-mono text-xs"
+              />
+              <Button variant="outline" size="icon" onClick={handleCopy}>
+                {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Paste this into your Claude Desktop config as <code>BRAIN_GYM_API_KEY</code>.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button onClick={handleCloseCreated}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Lint check**
+
+```bash
+npm run lint -- src/components/profile/McpApiKeysTab.tsx
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/profile/McpApiKeysTab.tsx
+git commit -m "feat: add McpApiKeysTab component for key management UI"
+```
+
+---
+
+## Task 9: Wire McpApiKeysTab into Profile Page
+
+**Files:**
+- Modify: `src/pages/Profile.tsx`
+
+**Interfaces:**
+- Consumes: `McpApiKeysTab` from `src/components/profile/McpApiKeysTab.tsx`
+- Produces: A new "MCP Keys" tab in the existing `<Tabs>` on the Profile page
+
+- [ ] **Step 1: Import the component**
+
+Open `src/pages/Profile.tsx`. Add the import after the existing imports:
+
+```tsx
+import McpApiKeysTab from "@/components/profile/McpApiKeysTab";
+```
+
+- [ ] **Step 2: Add the tab trigger**
+
+Find the `<TabsList>` in the Profile page JSX. It contains triggers like `<TabsTrigger value="profile">`, `<TabsTrigger value="security">`, etc. Add a new trigger:
+
+```tsx
+<TabsTrigger value="mcp-keys">MCP Keys</TabsTrigger>
+```
+
+- [ ] **Step 3: Add the tab content**
+
+Find the last `</TabsContent>` before `</Tabs>`. Add after it:
+
+```tsx
+<TabsContent value="mcp-keys">
+  <McpApiKeysTab />
+</TabsContent>
+```
+
+- [ ] **Step 4: Lint check**
+
+```bash
+npm run lint -- src/pages/Profile.tsx
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Run all frontend tests**
+
+```bash
+npm run test -- --passWithNoTests 2>&1 | tail -10
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/Profile.tsx
+git commit -m "feat: add MCP Keys tab to Profile settings page"
+```
+
+---
+
+## Self-Review Checklist
+
+After completing all tasks, verify:
+
+- [ ] `POST /api/v1/mcp-keys` returns `plaintext` — verify with: `curl -X POST http://localhost:3000/api/v1/mcp-keys -H "Authorization: Bearer <jwt>" -H "Content-Type: application/json" -d '{"name":"Test"}'`
+- [ ] `POST /api/v1/ai-questions/mcp/intake` with a valid `X-API-Key` returns 200 and saves questions
+- [ ] Same endpoint with no header or invalid key returns 401
+- [ ] 101st request within an hour returns 429
+- [ ] Revoked key returns 401 on the intake endpoint
+- [ ] Audit log entry exists in DB after a successful intake call
+- [ ] Profile page shows "MCP Keys" tab with generate/revoke flow

--- a/docs/superpowers/specs/2026-06-19-mcp-api-keys-design.md
+++ b/docs/superpowers/specs/2026-06-19-mcp-api-keys-design.md
@@ -1,0 +1,174 @@
+# MCP API Keys — Secure LLM Question Intake
+
+**Date:** 2026-06-19  
+**Status:** Approved  
+**Contributor:** Pham Tien Thanh
+
+## Problem
+
+As a Contributor, I want Claude (or any MCP-compatible LLM tool) to generate certification exam questions in CertGym's format and push them into the review queue — so I don't have to author questions manually.
+
+An MCP server (`backend/src/mcp-server.ts`) and intake endpoint (`POST /api/v1/ai-questions/mcp/intake`) already exist but have three security gaps:
+
+1. The MCP server authenticates using the contributor's full-access JWT — a leaked config file gives an attacker complete account access.
+2. The intake endpoint has no rate limiting (unlike `/generate` which caps at 10/hr).
+3. No audit log is written when questions arrive via MCP.
+
+## Scope
+
+- Dedicated, revocable MCP API keys (scoped to the intake endpoint only)
+- Per-key rate limiting: 100 questions per hour per API key (counted per intake request, not per question in the payload) via the existing Redis throttler
+- Audit logging for every MCP intake call
+- Settings UI for key management (generate, list, revoke)
+- Update `mcp-server.ts` to use the new `X-API-Key` header
+
+Out of scope: review UI changes, notifications, per-user daily quota, multi-scope keys.
+
+---
+
+## Architecture
+
+```
+[Claude Desktop / any MCP client]
+        │  stdio
+        ▼
+[mcp-server.ts]  ──X-API-Key──►  POST /api/v1/ai-questions/mcp/intake
+                                          │
+                              ┌───────────┴───────────┐
+                        ApiKeyAuthGuard          ThrottleGuard
+                        (SHA-256 hash lookup,    (100 q/hr per key,
+                         hydrate req.user)        Redis-backed)
+                                          │
+                                   mcpIntake()
+                                          │
+                              ┌───────────┴───────────┐
+                         quality gate              audit log
+                         (≥0.85 → APPROVED,        (MCP_INTAKE action,
+                          0.60–0.84 → PENDING,      keyId, saved/discarded)
+                          <0.60 → discard)
+                                          │
+                                   questions table
+```
+
+Questions in `PENDING` status surface in the existing reviewer queue — no new review UI needed.
+
+---
+
+## Data Model
+
+### New Prisma model: `McpApiKey`
+
+```prisma
+model McpApiKey {
+  id         String    @id @default(cuid())
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name       String                     // contributor label, e.g. "My Claude Desktop"
+  keyHash    String    @unique          // SHA-256(raw key) — plaintext never stored
+  prefix     String                     // first 8 chars of raw key for display
+  lastUsedAt DateTime?
+  createdAt  DateTime  @default(now())
+  revokedAt  DateTime?                  // null = active; set on revoke, never deleted
+
+  @@index([userId])
+}
+```
+
+**Key format:** `mcp_` + 32 cryptographically random bytes encoded as base64url (total ~47 chars).  
+**Plaintext** is returned once at creation and never stored. Only `SHA-256(key)` is persisted.  
+**Revocation** sets `revokedAt`; the row is kept for audit trail purposes.
+
+---
+
+## Backend
+
+### New: `ApiKeyAuthGuard` (`backend/src/auth/guards/api-key-auth.guard.ts`)
+
+1. Read `X-API-Key` header — `401` if missing.
+2. Validate format (`mcp_` prefix, expected length) — `401` immediately on bad format (no DB hit, avoids leaking which check failed).
+3. Compute `SHA-256(rawKey)`, query `McpApiKey` where `keyHash = hash AND revokedAt IS NULL`.
+4. `401` if not found — same generic message as step 2.
+5. Set `req.user` from `key.user`, set `req.mcpKeyId = key.id` for downstream use.
+6. Update `lastUsedAt` asynchronously (fire-and-forget — does not block the request).
+
+### Updated: `AiQuestionBankController.mcpIntake`
+
+```typescript
+@Post('mcp/intake')
+@Throttle({ mcp: { ttl: 3_600_000, limit: 100 } })  // 100 requests/hr per key
+@UseGuards(ApiKeyAuthGuard)
+mcpIntake(@Req() req: McpRequest, @Body() dto: McpIntakeDto) {
+  return this.service.mcpIntake(req.user.id, req.mcpKeyId, dto);
+}
+```
+
+The throttler uses `req.mcpKeyId` as the tracker key via a `McpThrottlerGuard` subclass that overrides `getTracker()`. Revoking a key therefore also kills its rate-limit bucket on next Redis TTL expiry (≤1 hr).
+
+### Updated: `AiQuestionBankService.mcpIntake`
+
+Adds audit log call after saving questions:
+
+```typescript
+await this.audit.log({
+  action: 'MCP_INTAKE',
+  userId,
+  metadata: { keyId, saved: saved.length, discarded: discarded.length, certificationId: dto.certificationId },
+});
+```
+
+### New: `McpKeysController` (`backend/src/mcp-keys/`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/mcp-keys` | List active keys (prefix + metadata, no hash) |
+| `POST` | `/api/v1/mcp-keys` | Generate new key — returns plaintext once |
+| `DELETE` | `/api/v1/mcp-keys/:id` | Revoke key (sets `revokedAt`) |
+
+All endpoints use `JwtAuthGuard`. Ownership is enforced: `DELETE` verifies `key.userId === req.user.id`.
+
+---
+
+## Frontend
+
+A new **"MCP API Keys"** tab card added to the existing Settings page (`src/pages/Settings/`).
+
+**List view:** displays `name`, `prefix`, `createdAt`, `lastUsedAt` per key with a "Revoke" button.
+
+**Generate flow:**
+1. "Generate new key" button → modal with a `name` text input.
+2. On submit → `POST /api/v1/mcp-keys` → success shows a one-time code block with copy button and warning: *"This key will not be shown again. Copy it now and paste it into your Claude Desktop config."*
+3. On modal close → key appears in list by prefix only.
+
+---
+
+## MCP Server Changes (`backend/src/mcp-server.ts`)
+
+- Rename env var `BRAIN_GYM_BEARER_TOKEN` → `BRAIN_GYM_API_KEY`.
+- Replace `Authorization: Bearer ${token}` header with `X-API-Key: ${apiKey}`.
+- Update error message, README example, and `claude_desktop_config.json` snippet in the file header.
+- No logic changes — the tool schema and quality gate behavior are unchanged.
+
+---
+
+## Security Properties
+
+| Threat | Mitigation |
+|--------|-----------|
+| Stolen API key floods review queue | Per-key rate limit: 100 questions/hr via Redis throttler |
+| Stolen API key grants full account access | Key is scoped to intake only; `ApiKeyAuthGuard` only hydrates `req.user` — no session, no cookie, no JWT |
+| Key leaks from config file | Key shown once, never retrievable; contributor can revoke instantly from Settings |
+| Timing-based key enumeration | SHA-256 constant-time hash comparison; same 401 message for all failure modes |
+| Malformed / oversized payloads | Existing `class-validator` on `McpIntakeDto`; NestJS body size limit already in place |
+| Undetectable abuse | Audit log entry on every intake call; `lastUsedAt` visible in Settings UI |
+
+---
+
+## Migration
+
+One new migration: create `McpApiKey` table. No changes to existing tables.
+
+---
+
+## Open Questions
+
+None — all design decisions resolved in review.

--- a/src/components/profile/McpApiKeysTab.tsx
+++ b/src/components/profile/McpApiKeysTab.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Key, Plus, Trash2, Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { listMcpKeys, generateMcpKey, revokeMcpKey } from "@/services/mcp-keys";
+import { McpApiKeyCreated } from "@/types/api-types";
+
+export default function McpApiKeysTab() {
+  const { toast } = useToast();
+  const qc = useQueryClient();
+  const [showGenerate, setShowGenerate] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [createdKey, setCreatedKey] = useState<McpApiKeyCreated | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const { data: keys = [], isLoading } = useQuery({
+    queryKey: ["mcp-keys"],
+    queryFn: listMcpKeys,
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: () => generateMcpKey(newKeyName.trim()),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["mcp-keys"] });
+      setCreatedKey(data);
+      setNewKeyName("");
+    },
+    onError: () => {
+      toast({ title: "Failed to generate key", variant: "destructive" });
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: revokeMcpKey,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["mcp-keys"] });
+      toast({ title: "API key revoked" });
+    },
+    onError: () => {
+      toast({ title: "Failed to revoke key", variant: "destructive" });
+    },
+  });
+
+  const handleCopy = async () => {
+    if (!createdKey) return;
+    await navigator.clipboard.writeText(createdKey.plaintext);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleCloseCreated = () => {
+    setCreatedKey(null);
+    setShowGenerate(false);
+  };
+
+  const formatDate = (d: string | null) =>
+    d ? new Date(d).toLocaleDateString() : "Never";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">MCP API Keys</h3>
+          <p className="text-sm text-muted-foreground">
+            Use these keys to let Claude Desktop or any MCP-compatible tool push questions into your account.
+          </p>
+        </div>
+        <Button size="sm" onClick={() => setShowGenerate(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Generate key
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : keys.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-center text-muted-foreground">
+            <Key className="mx-auto mb-2 h-8 w-8 opacity-40" />
+            <p className="text-sm">No API keys yet. Generate one to get started.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {keys.map((key) => (
+            <Card key={key.id}>
+              <CardContent className="flex items-center justify-between py-4">
+                <div className="space-y-1">
+                  <p className="font-medium text-sm">{key.name}</p>
+                  <p className="font-mono text-xs text-muted-foreground">{key.prefix}…</p>
+                  <p className="text-xs text-muted-foreground">
+                    Created {formatDate(key.createdAt)} · Last used {formatDate(key.lastUsedAt)}
+                  </p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  disabled={revokeMutation.isPending}
+                  onClick={() => revokeMutation.mutate(key.id)}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Generate key dialog */}
+      <Dialog
+        open={showGenerate && !createdKey}
+        onOpenChange={(o) => { if (!o) setShowGenerate(false); }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Generate MCP API Key</DialogTitle>
+            <DialogDescription>
+              Give this key a name so you can identify it later (e.g. "My Claude Desktop").
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="key-name">Key name</Label>
+            <Input
+              id="key-name"
+              placeholder="My Claude Desktop"
+              value={newKeyName}
+              onChange={(e) => setNewKeyName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && newKeyName.trim()) generateMutation.mutate();
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowGenerate(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!newKeyName.trim() || generateMutation.isPending}
+              onClick={() => generateMutation.mutate()}
+            >
+              Generate
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Show created key — displayed once, never again */}
+      <Dialog open={!!createdKey} onOpenChange={(o) => { if (!o) handleCloseCreated(); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>API Key Created</DialogTitle>
+            <DialogDescription className="text-destructive font-medium">
+              This key will not be shown again. Copy it now.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label>Your new API key</Label>
+            <div className="flex gap-2">
+              <Input
+                readOnly
+                value={createdKey?.plaintext ?? ""}
+                className="font-mono text-xs"
+              />
+              <Button variant="outline" size="icon" onClick={handleCopy}>
+                {copied
+                  ? <Check className="h-4 w-4 text-green-500" />
+                  : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Paste this into your Claude Desktop config as{" "}
+              <code className="rounded bg-muted px-1">BRAIN_GYM_API_KEY</code>.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button onClick={handleCloseCreated}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -26,6 +26,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import McpApiKeysTab from "@/components/profile/McpApiKeysTab";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -349,6 +350,9 @@ export default function Profile() {
             <TabsTrigger value="activity" className="flex-1 gap-2 data-[state=active]:bg-primary/10 data-[state=active]:text-primary">
               <Clock className="h-4 w-4" /> Activity
             </TabsTrigger>
+            <TabsTrigger value="mcp-keys" className="flex-1 gap-2 data-[state=active]:bg-primary/10 data-[state=active]:text-primary">
+              <KeyRound className="h-4 w-4" /> MCP Keys
+            </TabsTrigger>
           </TabsList>
 
           {/* Personal Info */}
@@ -514,6 +518,11 @@ export default function Profile() {
                 </ul>
               </div>
             </Card>
+          </TabsContent>
+
+          {/* MCP API Keys */}
+          <TabsContent value="mcp-keys">
+            <McpApiKeysTab />
           </TabsContent>
         </Tabs>
           </div>

--- a/src/services/mcp-keys.ts
+++ b/src/services/mcp-keys.ts
@@ -1,0 +1,16 @@
+import api from "./api";
+import { McpApiKey, McpApiKeyCreated } from "../types/api-types";
+
+export const listMcpKeys = async (): Promise<McpApiKey[]> => {
+  const res = await api.get<McpApiKey[]>("/mcp-keys");
+  return res.data;
+};
+
+export const generateMcpKey = async (name: string): Promise<McpApiKeyCreated> => {
+  const res = await api.post<McpApiKeyCreated>("/mcp-keys", { name });
+  return res.data;
+};
+
+export const revokeMcpKey = async (id: string): Promise<void> => {
+  await api.delete(`/mcp-keys/${id}`);
+};

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -391,3 +391,15 @@ export interface GenerationJob {
   domain?: { name: string };
   _count: { questions: number };
 }
+
+export interface McpApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface McpApiKeyCreated extends McpApiKey {
+  plaintext: string;
+}


### PR DESCRIPTION
## Summary

- **Scoped API keys** replace long-lived JWTs for MCP authentication. Contributors generate revocable `mcp_` keys in Settings → MCP Keys; the full key is shown once and never stored (only the SHA-256 hash is persisted).
- **`ApiKeyAuthGuard`** validates the `X-API-Key` header, rejects missing/malformed keys with a uniform 401, and sets `req.user` + `req.mcpKeyId` for downstream use.
- **Per-key rate limiting** (100 req/hr via Redis INCR) added to `POST /ai-questions/mcp/intake`, keyed on the API key ID rather than IP.
- **Audit log** written on every MCP intake call (`MCP_INTAKE` action with `keyId`, `source`, `saved`, `discarded` counts).
- **`mcp-server.ts`** updated: `BRAIN_GYM_BEARER_TOKEN` → `BRAIN_GYM_API_KEY`, `Authorization: Bearer` → `X-API-Key` header.
- **Settings UI** — new "MCP Keys" tab on the Profile page with generate/copy/revoke flow.

## Changed files

| Area | Files |
|------|-------|
| DB | `prisma/schema.prisma`, `migrations/20260719000001_add_mcp_api_keys/` |
| Backend | `mcp-keys/` (service, guard, controller, module), `ai-question-bank/` (controller, service, module), `mcp-server.ts`, `app.module.ts` |
| Frontend | `src/services/mcp-keys.ts`, `src/types/api-types.ts`, `src/components/profile/McpApiKeysTab.tsx`, `src/pages/Profile.tsx` |
| Docs | `docs/superpowers/specs/2026-06-19-mcp-api-keys-design.md`, `docs/superpowers/plans/2026-06-19-mcp-api-keys.md` |

## Test plan

- [ ] Run `cd backend && npm test` — 609 tests pass
- [ ] Apply migration: `npx prisma migrate deploy` (requires DB)
- [ ] Generate an API key via `POST /api/v1/mcp-keys` with a JWT; confirm `plaintext` starts with `mcp_` and is not stored in DB
- [ ] Call `POST /api/v1/ai-questions/mcp/intake` with `X-API-Key: <key>` — confirm 200, questions saved, audit log entry created
- [ ] Call the same endpoint without the header — confirm 401
- [ ] Call with a revoked key (`DELETE /api/v1/mcp-keys/:id` first) — confirm 401
- [ ] Make 101 requests within an hour with the same key — confirm 429 on the 101st
- [ ] Profile page → MCP Keys tab: generate key, copy plaintext, close modal, verify key appears by prefix only, revoke it

🤖 Generated with [Claude Code](https://claude.com/claude-code)