### PR TITLE
feat: Sprint 3 — Compliance & Integrity (US-B3, B4, D1, D2, G1) + review fixes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,7 @@
         "bullmq": "^5.38.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.4",
+        "date-fns": "^3.6.0",
         "google-auth-library": "^10.6.2",
         "nodemailer": "^8.0.4",
         "passport": "^0.7.0",
@@ -6463,6 +6464,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -48,6 +48,7 @@
     "bullmq": "^5.38.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.4",
+    "date-fns": "^3.6.0",
     "google-auth-library": "^10.6.2",
     "nodemailer": "^8.0.4",
     "passport": "^0.7.0",

--- a/backend/prisma/migrations/20260721000001_sprint3_certs_idp_proctoring/migration.sql
+++ b/backend/prisma/migrations/20260721000001_sprint3_certs_idp_proctoring/migration.sql
@@ -1,0 +1,122 @@
+-- Sprint 3: Competency Certifications (US-B3), Manager Review & IDP (US-B4),
+--           Risk Proctoring fields (US-D2)
+
+-- ─── US-B3: New fields on competencies ───────────────────────────────────────
+
+ALTER TABLE "competencies"
+    ADD COLUMN "validity_months" INTEGER NOT NULL DEFAULT 12;
+
+-- ─── US-D2: Risk fields on assessments ───────────────────────────────────────
+
+ALTER TABLE "assessments"
+    ADD COLUMN "risk_threshold" INTEGER NOT NULL DEFAULT 70,
+    ADD COLUMN "auto_flag_risk" BOOLEAN NOT NULL DEFAULT true;
+
+-- ─── US-D2: Flag fields on candidate_invites ─────────────────────────────────
+
+ALTER TABLE "candidate_invites"
+    ADD COLUMN "is_flagged"      BOOLEAN   NOT NULL DEFAULT false,
+    ADD COLUMN "flagged_at"      TIMESTAMP(3),
+    ADD COLUMN "flagged_reason"  TEXT,
+    ADD COLUMN "flagged_by"      TEXT;
+
+-- ─── US-B3: Competency Certifications ────────────────────────────────────────
+
+CREATE TABLE "competency_certifications" (
+    "id"            TEXT NOT NULL,
+    "org_id"        TEXT NOT NULL,
+    "member_id"     TEXT NOT NULL,
+    "competency_id" TEXT NOT NULL,
+    "campaign_id"   TEXT,
+    "achieved_level" INTEGER NOT NULL,
+    "issued_at"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at"    TIMESTAMP(3) NOT NULL,
+    "revoked_at"    TIMESTAMP(3),
+
+    CONSTRAINT "competency_certifications_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "competency_certifications_member_id_competency_id_issued_at_key"
+    ON "competency_certifications"("member_id", "competency_id", "issued_at");
+CREATE INDEX "competency_certifications_org_id_competency_id_idx"
+    ON "competency_certifications"("org_id", "competency_id");
+CREATE INDEX "competency_certifications_member_id_idx"
+    ON "competency_certifications"("member_id");
+CREATE INDEX "competency_certifications_expires_at_idx"
+    ON "competency_certifications"("expires_at");
+
+ALTER TABLE "competency_certifications"
+    ADD CONSTRAINT "competency_certifications_org_id_fkey"
+        FOREIGN KEY ("org_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT "competency_certifications_member_id_fkey"
+        FOREIGN KEY ("member_id") REFERENCES "org_members"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT "competency_certifications_competency_id_fkey"
+        FOREIGN KEY ("competency_id") REFERENCES "competencies"("id") ON UPDATE CASCADE,
+    ADD CONSTRAINT "competency_certifications_campaign_id_fkey"
+        FOREIGN KEY ("campaign_id") REFERENCES "assessment_campaigns"("id") ON UPDATE CASCADE;
+
+-- ─── US-B4: Campaign Member Reviews ──────────────────────────────────────────
+
+CREATE TABLE "campaign_member_reviews" (
+    "id"          TEXT NOT NULL,
+    "org_id"      TEXT NOT NULL,
+    "campaign_id" TEXT NOT NULL,
+    "member_id"   TEXT NOT NULL,
+    "reviewed_by" TEXT NOT NULL,
+    "note"        TEXT NOT NULL,
+    "direction"   TEXT,
+    "created_at"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"  TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "campaign_member_reviews_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "campaign_member_reviews_campaign_id_member_id_key"
+    ON "campaign_member_reviews"("campaign_id", "member_id");
+CREATE INDEX "campaign_member_reviews_org_id_member_id_idx"
+    ON "campaign_member_reviews"("org_id", "member_id");
+
+ALTER TABLE "campaign_member_reviews"
+    ADD CONSTRAINT "campaign_member_reviews_org_id_fkey"
+        FOREIGN KEY ("org_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT "campaign_member_reviews_campaign_id_fkey"
+        FOREIGN KEY ("campaign_id") REFERENCES "assessment_campaigns"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT "campaign_member_reviews_member_id_fkey"
+        FOREIGN KEY ("member_id") REFERENCES "org_members"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT "campaign_member_reviews_reviewed_by_fkey"
+        FOREIGN KEY ("reviewed_by") REFERENCES "users"("id") ON UPDATE CASCADE;
+
+-- ─── US-B4: Member IDPs ───────────────────────────────────────────────────────
+
+CREATE TABLE "member_idps" (
+    "id"            TEXT NOT NULL,
+    "org_id"        TEXT NOT NULL,
+    "member_id"     TEXT NOT NULL,
+    "competency_id" TEXT NOT NULL,
+    "track_id"      TEXT NOT NULL,
+    "target_level"  INTEGER NOT NULL,
+    "due_date"      TIMESTAMP(3),
+    "completed_at"  TIMESTAMP(3),
+    "created_by"    TEXT NOT NULL,
+    "created_at"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"    TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "member_idps_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "member_idps_member_id_competency_id_track_id_key"
+    ON "member_idps"("member_id", "competency_id", "track_id");
+CREATE INDEX "member_idps_org_id_member_id_idx"
+    ON "member_idps"("org_id", "member_id");
+
+ALTER TABLE "member_idps"
+    ADD CONSTRAINT "member_idps_org_id_fkey"
+        FOREIGN KEY ("org_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT "member_idps_member_id_fkey"
+        FOREIGN KEY ("member_id") REFERENCES "org_members"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT "member_idps_competency_id_fkey"
+        FOREIGN KEY ("competency_id") REFERENCES "competencies"("id") ON UPDATE CASCADE,
+    ADD CONSTRAINT "member_idps_track_id_fkey"
+        FOREIGN KEY ("track_id") REFERENCES "learning_tracks"("id") ON UPDATE CASCADE,
+    ADD CONSTRAINT "member_idps_created_by_fkey"
+        FOREIGN KEY ("created_by") REFERENCES "users"("id") ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -872,10 +872,13 @@ model Organization {
   peerExplanations PeerExplanation[]
   userReputations  UserReputation[]
   reputationFlags  ReputationFlag[]
-  competencies       Competency[]
-  campaigns          AssessmentCampaign[]
-  publicApplyLinks   PublicApplyLink[]
-  screeningRules     ScreeningRule[]
+  competencies             Competency[]
+  campaigns                AssessmentCampaign[]
+  publicApplyLinks         PublicApplyLink[]
+  screeningRules           ScreeningRule[]
+  competencyCertifications CompetencyCertification[]
+  campaignReviews          CampaignMemberReview[]
+  memberIdps               MemberIdp[]
 
   @@map("organizations")
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -285,6 +285,8 @@ model User {
   oauthAccounts              OAuthAccount[]
   campaignsCreated           AssessmentCampaign[]
   publicApplyLinksCreated    PublicApplyLink[]
+  campaignReviewsGiven       CampaignMemberReview[]
+  memberIdpsCreated          MemberIdp[]
 
   @@index([status])
   @@map("users")
@@ -887,10 +889,13 @@ model OrgMember {
   joinedAt  DateTime @default(now()) @map("joined_at")
   isActive  Boolean  @default(true) @map("is_active")
 
-  organization Organization     @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  user         User             @relation(fields: [userId], references: [id])
-  group        OrgGroup?        @relation(fields: [groupId], references: [id])
-  assignments  OrgExamAssignment[]
+  organization             Organization              @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  user                     User                      @relation(fields: [userId], references: [id])
+  group                    OrgGroup?                 @relation(fields: [groupId], references: [id])
+  assignments              OrgExamAssignment[]
+  competencyCertifications CompetencyCertification[]
+  campaignReviews          CampaignMemberReview[]
+  memberIdps               MemberIdp[]
 
   @@unique([orgId, userId])
   @@map("org_members")
@@ -1046,6 +1051,7 @@ model LearningTrack {
 
   organization Organization      @relation(fields: [orgId], references: [id], onDelete: Cascade)
   catalogItems ExamCatalogItem[]
+  memberIdps   MemberIdp[]
 
   @@map("learning_tracks")
 }
@@ -1081,10 +1087,12 @@ model AssessmentCampaign {
   createdAt          DateTime            @default(now()) @map("created_at")
   updatedAt          DateTime            @updatedAt @map("updated_at")
 
-  organization Organization       @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  catalogItem  ExamCatalogItem    @relation(fields: [catalogItemId], references: [id])
-  creator      User               @relation(fields: [createdBy], references: [id])
-  assignments  OrgExamAssignment[]
+  organization             Organization              @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  catalogItem              ExamCatalogItem           @relation(fields: [catalogItemId], references: [id])
+  creator                  User                      @relation(fields: [createdBy], references: [id])
+  assignments              OrgExamAssignment[]
+  competencyCertifications CompetencyCertification[]
+  campaignReviews          CampaignMemberReview[]
 
   @@unique([orgId, name])
   @@index([orgId])
@@ -1155,6 +1163,8 @@ model Assessment {
   maxAttempts        Int                      @default(1)     @map("max_attempts")
   linkExpiryHours    Int                      @default(72) @map("link_expiry_hours")
   jobRoleId          String?                  @map("job_role_id")
+  riskThreshold      Int                      @default(70) @map("risk_threshold")
+  autoFlagRisk       Boolean                  @default(true) @map("auto_flag_risk")
   createdBy          String                   @map("created_by")
   createdAt          DateTime                 @default(now()) @map("created_at")
   updatedAt          DateTime                 @updatedAt @map("updated_at")
@@ -1218,6 +1228,11 @@ model CandidateInvite {
   consentedAt      DateTime?              @map("consented_at")
   /// US-C2: source apply link
   applyLinkId      String?                @map("apply_link_id")
+  /// US-D2: risk flag
+  isFlagged        Boolean                @default(false) @map("is_flagged")
+  flaggedAt        DateTime?              @map("flagged_at")
+  flaggedReason    String?                @map("flagged_reason")
+  flaggedBy        String?                @map("flagged_by")
   createdAt        DateTime               @default(now()) @map("created_at")
 
   assessment    Assessment        @relation(fields: [assessmentId], references: [id], onDelete: Cascade)
@@ -1662,17 +1677,20 @@ model Competency {
   orgId       String   @map("org_id")
   name        String
   description String?
-  scaleMin    Int      @default(1) @map("scale_min")
-  scaleMax    Int      @default(5) @map("scale_max")
-  isActive    Boolean  @default(true) @map("is_active")
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  scaleMin       Int      @default(1) @map("scale_min")
+  scaleMax       Int      @default(5) @map("scale_max")
+  validityMonths Int      @default(12) @map("validity_months")
+  isActive       Boolean  @default(true) @map("is_active")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
 
-  organization Organization           @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  domains      CompetencyDomain[]
-  questions    QuestionCompetency[]
-  jobRoles     JobRoleCompetency[]
-  examMappings ExamDomainCompetency[]
+  organization              Organization              @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  domains                   CompetencyDomain[]
+  questions                 QuestionCompetency[]
+  jobRoles                  JobRoleCompetency[]
+  examMappings              ExamDomainCompetency[]
+  competencyCertifications  CompetencyCertification[]
+  memberIdps                MemberIdp[]
 
   @@unique([orgId, name])
   @@index([orgId])
@@ -1812,4 +1830,76 @@ model ExamDomainCompetency {
   @@index([assessmentId])
   @@index([competencyId])
   @@map("exam_domain_competencies")
+}
+
+// ─── US-B3: COMPETENCY CERTIFICATIONS ───
+
+model CompetencyCertification {
+  id            String    @id @default(uuid())
+  orgId         String    @map("org_id")
+  memberId      String    @map("member_id")
+  competencyId  String    @map("competency_id")
+  campaignId    String?   @map("campaign_id")
+  achievedLevel Int       @map("achieved_level")
+  issuedAt      DateTime  @default(now()) @map("issued_at")
+  expiresAt     DateTime  @map("expires_at")
+  revokedAt     DateTime? @map("revoked_at")
+
+  organization Organization        @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  member       OrgMember           @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  competency   Competency          @relation(fields: [competencyId], references: [id], onDelete: Restrict)
+  campaign     AssessmentCampaign? @relation(fields: [campaignId], references: [id])
+
+  @@unique([memberId, competencyId, issuedAt])
+  @@index([orgId, competencyId])
+  @@index([memberId])
+  @@index([expiresAt])
+  @@map("competency_certifications")
+}
+
+// ─── US-B4: MANAGER REVIEW & IDP ───
+
+model CampaignMemberReview {
+  id         String   @id @default(uuid())
+  orgId      String   @map("org_id")
+  campaignId String   @map("campaign_id")
+  memberId   String   @map("member_id")
+  reviewedBy String   @map("reviewed_by")
+  note       String   @db.Text
+  direction  String?  @db.Text
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  organization Organization       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  campaign     AssessmentCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  member       OrgMember          @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  reviewer     User               @relation(fields: [reviewedBy], references: [id])
+
+  @@unique([campaignId, memberId])
+  @@index([orgId, memberId])
+  @@map("campaign_member_reviews")
+}
+
+model MemberIdp {
+  id           String    @id @default(uuid())
+  orgId        String    @map("org_id")
+  memberId     String    @map("member_id")
+  competencyId String    @map("competency_id")
+  trackId      String    @map("track_id")
+  targetLevel  Int       @map("target_level")
+  dueDate      DateTime? @map("due_date")
+  completedAt  DateTime? @map("completed_at")
+  createdBy    String    @map("created_by")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  organization Organization  @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  member       OrgMember     @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  competency   Competency    @relation(fields: [competencyId], references: [id], onDelete: Restrict)
+  track        LearningTrack @relation(fields: [trackId], references: [id], onDelete: Restrict)
+  creator      User          @relation(fields: [createdBy], references: [id])
+
+  @@unique([memberId, competencyId, trackId])
+  @@index([orgId, memberId])
+  @@map("member_idps")
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -46,6 +46,9 @@ import { CampaignsModule } from './campaigns/campaigns.module';
 import { ApplyModule } from './apply/apply.module';
 import { ScreeningModule } from './screening/screening.module';
 import { ScorecardModule } from './scorecard/scorecard.module';
+import { CompetencyCertModule } from './competency-cert/competency-cert.module';
+import { IdpModule } from './idp/idp.module';
+import { ExecutiveDashboardModule } from './executive-dashboard/executive-dashboard.module';
 
 @Module({
   imports: [
@@ -96,6 +99,9 @@ import { ScorecardModule } from './scorecard/scorecard.module';
     ApplyModule,
     ScreeningModule,
     ScorecardModule,
+    CompetencyCertModule,
+    IdpModule,
+    ExecutiveDashboardModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/assessments/assessments.controller.ts
+++ b/backend/src/assessments/assessments.controller.ts
@@ -176,6 +176,54 @@ export class AssessmentsController {
     return this.candidateService.getEvents(inviteId, aid);
   }
 
+  // ─── US-D1: Pool stats ─────────────────────────────────────────────────────
+
+  @Get(':aid/pool-stats')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  getPoolStats(@Param('orgId') orgId: string, @Param('aid') aid: string) {
+    return this.service.getPoolStats(orgId, aid);
+  }
+
+  @Get(':aid/pool-info')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  getPoolInfo(@Param('orgId') orgId: string, @Param('aid') aid: string) {
+    return this.service.getPoolInfo(orgId, aid);
+  }
+
+  // ─── US-D2: Risk config + flag management ─────────────────────────────────
+
+  @Patch(':aid/risk-config')
+  @OrgRoles('OWNER', 'ADMIN')
+  updateRiskConfig(
+    @Param('orgId') orgId: string,
+    @Param('aid') aid: string,
+    @Body() dto: { riskThreshold?: number; autoFlagRisk?: boolean },
+  ) {
+    return this.service.updateRiskConfig(orgId, aid, dto);
+  }
+
+  @Get(':aid/candidates/:inviteId/risk-timeline')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  getRiskTimeline(
+    @Param('orgId') orgId: string,
+    @Param('aid') aid: string,
+    @Param('inviteId') inviteId: string,
+  ) {
+    return this.candidateService.getRiskTimeline(orgId, aid, inviteId);
+  }
+
+  @Patch(':aid/candidates/:inviteId/flag')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  patchFlag(
+    @Param('orgId') orgId: string,
+    @Param('aid') aid: string,
+    @Param('inviteId') inviteId: string,
+    @CurrentUser('id') userId: string,
+    @Body() dto: { isFlagged: boolean; reason?: string },
+  ) {
+    return this.candidateService.patchFlag(orgId, aid, inviteId, userId, dto);
+  }
+
   @Delete(':aid')
   @OrgRoles('OWNER', 'ADMIN')
   delete(@Param('orgId') orgId: string, @Param('aid') aid: string) {

--- a/backend/src/assessments/assessments.controller.ts
+++ b/backend/src/assessments/assessments.controller.ts
@@ -18,6 +18,8 @@ import { CreateAssessmentDto } from './dto/create-assessment.dto';
 import { UpdateAssessmentDto } from './dto/update-assessment.dto';
 import { InviteCandidateDto } from './dto/invite-candidate.dto';
 import { UpdateCandidateDecisionDto } from './dto/update-candidate-decision.dto';
+import { UpdateRiskConfigDto } from './dto/update-risk-config.dto';
+import { PatchFlagDto } from './dto/patch-flag.dto';
 import { BulkCsvInviteDto } from './dto/bulk-csv-invite.dto';
 import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
 import { OrgRoles } from '../common/decorators/org-roles.decorator';
@@ -197,7 +199,7 @@ export class AssessmentsController {
   updateRiskConfig(
     @Param('orgId') orgId: string,
     @Param('aid') aid: string,
-    @Body() dto: { riskThreshold?: number; autoFlagRisk?: boolean },
+    @Body() dto: UpdateRiskConfigDto,
   ) {
     return this.service.updateRiskConfig(orgId, aid, dto);
   }
@@ -219,7 +221,7 @@ export class AssessmentsController {
     @Param('aid') aid: string,
     @Param('inviteId') inviteId: string,
     @CurrentUser('id') userId: string,
-    @Body() dto: { isFlagged: boolean; reason?: string },
+    @Body() dto: PatchFlagDto,
   ) {
     return this.candidateService.patchFlag(orgId, aid, inviteId, userId, dto);
   }

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -908,4 +908,108 @@ export class AssessmentsService {
     const available = await this.countPoolQuestions(orgId, config);
     return { available };
   }
+
+  // ─── US-D1: Pool stats ─────────────────────────────────────────────────────
+
+  async getPoolStats(slugOrId: string, assessmentId: string) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+
+    const assessment = await this.prisma.assessment.findFirst({
+      where: { id: assessmentId, orgId },
+      select: {
+        id: true,
+        selectionMode: true,
+        selectionConfig: true,
+        questionCount: true,
+        _count: { select: { questions: true } },
+      },
+    });
+    if (!assessment) throw new NotFoundException('Assessment not found');
+
+    const poolConfig =
+      (assessment.selectionConfig as Partial<PoolConfig>) ?? {};
+    const poolSize = await this.countPoolQuestions(orgId, poolConfig);
+    const drawCount = assessment.questionCount ?? assessment._count.questions;
+
+    const usageStats = await this.prisma.candidateAnswer.groupBy({
+      by: ['questionId'],
+      where: {
+        invite: { assessmentId },
+      },
+      _count: { questionId: true },
+      orderBy: { _count: { questionId: 'asc' } },
+    });
+
+    const leastUsed = usageStats.slice(0, 10).map((s) => ({
+      questionId: s.questionId,
+      usedCount: s._count.questionId,
+    }));
+
+    const overlapPct =
+      poolSize > 0 ? Math.round((drawCount / poolSize) * 100) : 100;
+
+    return {
+      assessmentId,
+      selectionMode: assessment.selectionMode,
+      poolSize,
+      drawCount,
+      overlapPct,
+      uniqueQuestionRatio:
+        poolSize > 0 ? Math.round((1 - drawCount / poolSize) * 100) : 0,
+      leastUsedQuestions: leastUsed,
+    };
+  }
+
+  async getPoolInfo(slugOrId: string, assessmentId: string) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+
+    const assessment = await this.prisma.assessment.findFirst({
+      where: { id: assessmentId, orgId },
+      select: {
+        selectionMode: true,
+        selectionConfig: true,
+        questionCount: true,
+      },
+    });
+    if (!assessment) throw new NotFoundException('Assessment not found');
+
+    const poolConfig =
+      (assessment.selectionConfig as Partial<PoolConfig>) ?? {};
+    const available = await this.countPoolQuestions(orgId, poolConfig);
+
+    return {
+      assessmentId,
+      selectionMode: assessment.selectionMode,
+      selectionConfig: poolConfig,
+      questionCount: assessment.questionCount,
+      poolAvailable: available,
+    };
+  }
+
+  // ─── US-D2: Risk config ────────────────────────────────────────────────────
+
+  async updateRiskConfig(
+    slugOrId: string,
+    assessmentId: string,
+    dto: { riskThreshold?: number; autoFlagRisk?: boolean },
+  ) {
+    const orgId = await this.orgsService.resolveOrgId(slugOrId);
+    const assessment = await this.prisma.assessment.findFirst({
+      where: { id: assessmentId, orgId },
+    });
+    if (!assessment) throw new NotFoundException('Assessment not found');
+
+    return this.prisma.assessment.update({
+      where: { id: assessmentId },
+      data: {
+        ...(dto.riskThreshold !== undefined && {
+          riskThreshold: dto.riskThreshold,
+        }),
+        ...(dto.autoFlagRisk !== undefined && {
+          autoFlagRisk: dto.autoFlagRisk,
+        }),
+      },
+      select: { id: true, riskThreshold: true, autoFlagRisk: true },
+    });
+  }
 }

--- a/backend/src/assessments/assessments.service.ts
+++ b/backend/src/assessments/assessments.service.ts
@@ -36,7 +36,7 @@ interface BlueprintConfig {
   certificationId?: string;
 }
 
-interface PoolConfig {
+export interface PoolConfig {
   drawCount: number;
   certificationId?: string;
   difficulty?: string;

--- a/backend/src/assessments/candidate.service.ts
+++ b/backend/src/assessments/candidate.service.ts
@@ -343,8 +343,9 @@ export class CandidateService {
       return integrityScore;
     });
 
-    // Run auto-screening asynchronously so submission never blocks on rule eval
+    // Run auto-screening and risk flagging asynchronously
     this.screeningService.evaluate(invite.id).catch(() => {});
+    this.autoFlagIfRisky(invite.id).catch(() => {});
 
     return {
       score: Number(score.toFixed(2)),
@@ -621,5 +622,88 @@ export class CandidateService {
         content: c.content,
       })),
     };
+  }
+
+  // ─── US-D2: Risk flagging ──────────────────────────────────────────────────
+
+  async autoFlagIfRisky(inviteId: string) {
+    const invite = await this.prisma.candidateInvite.findUnique({
+      where: { id: inviteId },
+      include: {
+        assessment: { select: { riskThreshold: true, autoFlagRisk: true } },
+      },
+    });
+    if (!invite || !invite.assessment.autoFlagRisk) return;
+
+    const integrityScore = invite.integrityScore ?? 100;
+    if (integrityScore < (invite.assessment.riskThreshold ?? 70)) {
+      await this.prisma.candidateInvite.update({
+        where: { id: inviteId },
+        data: {
+          isFlagged: true,
+          flaggedAt: new Date(),
+          flaggedReason: `Integrity score ${integrityScore} below threshold ${invite.assessment.riskThreshold ?? 70}`,
+          flaggedBy: 'SYSTEM',
+        },
+      });
+    }
+  }
+
+  async getRiskTimeline(orgId: string, assessmentId: string, inviteId: string) {
+    const invite = await this.prisma.candidateInvite.findFirst({
+      where: { id: inviteId, assessmentId },
+      include: { assessment: { select: { orgId: true } } },
+    });
+    if (!invite || invite.assessment.orgId !== orgId)
+      throw new NotFoundException('Invite not found');
+
+    const events = await this.prisma.candidateEvent.findMany({
+      where: { inviteId },
+      orderBy: { occurredAt: 'asc' },
+      select: { eventType: true, occurredAt: true, meta: true },
+    });
+
+    return {
+      inviteId,
+      candidateName: invite.candidateName,
+      candidateEmail: invite.candidateEmail,
+      integrityScore: invite.integrityScore,
+      isFlagged: invite.isFlagged,
+      flaggedAt: invite.flaggedAt,
+      flaggedReason: invite.flaggedReason,
+      events,
+    };
+  }
+
+  async patchFlag(
+    orgId: string,
+    assessmentId: string,
+    inviteId: string,
+    flaggedBy: string,
+    dto: { isFlagged: boolean; reason?: string },
+  ) {
+    const invite = await this.prisma.candidateInvite.findFirst({
+      where: { id: inviteId, assessmentId },
+      include: { assessment: { select: { orgId: true } } },
+    });
+    if (!invite || invite.assessment.orgId !== orgId)
+      throw new NotFoundException('Invite not found');
+
+    return this.prisma.candidateInvite.update({
+      where: { id: inviteId },
+      data: {
+        isFlagged: dto.isFlagged,
+        flaggedAt: dto.isFlagged ? new Date() : null,
+        flaggedReason: dto.isFlagged ? (dto.reason ?? 'Manual flag') : null,
+        flaggedBy: dto.isFlagged ? flaggedBy : null,
+      },
+      select: {
+        id: true,
+        isFlagged: true,
+        flaggedAt: true,
+        flaggedReason: true,
+        flaggedBy: true,
+      },
+    });
   }
 }

--- a/backend/src/assessments/candidate.service.ts
+++ b/backend/src/assessments/candidate.service.ts
@@ -672,8 +672,8 @@ export class CandidateService {
 
     const events = await this.prisma.candidateEvent.findMany({
       where: { inviteId },
-      orderBy: { occurredAt: 'asc' },
-      select: { eventType: true, occurredAt: true, meta: true },
+      orderBy: { clientTs: 'asc' },
+      select: { eventType: true, clientTs: true, payload: true },
     });
 
     return {

--- a/backend/src/assessments/candidate.service.ts
+++ b/backend/src/assessments/candidate.service.ts
@@ -8,6 +8,7 @@ import {
   HttpException,
   HttpStatus,
   Inject,
+  Logger,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AssessmentsService } from './assessments.service';
@@ -26,6 +27,8 @@ const CLIENT_TS_SKEW_MS = 60 * 60 * 1000; // allow ±1 hour skew
 
 @Injectable()
 export class CandidateService {
+  private readonly logger = new Logger(CandidateService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly assessmentsService: AssessmentsService,
@@ -344,8 +347,18 @@ export class CandidateService {
     });
 
     // Run auto-screening and risk flagging asynchronously
-    this.screeningService.evaluate(invite.id).catch(() => {});
-    this.autoFlagIfRisky(invite.id).catch(() => {});
+    this.screeningService
+      .evaluate(invite.id)
+      .catch((err) =>
+        this.logger.warn(
+          `screeningService.evaluate failed for invite ${invite.id}: ${String(err)}`,
+        ),
+      );
+    this.autoFlagIfRisky(invite.id).catch((err) =>
+      this.logger.warn(
+        `autoFlagIfRisky failed for invite ${invite.id}: ${String(err)}`,
+      ),
+    );
 
     return {
       score: Number(score.toFixed(2)),

--- a/backend/src/assessments/dto/patch-flag.dto.ts
+++ b/backend/src/assessments/dto/patch-flag.dto.ts
@@ -1,0 +1,11 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class PatchFlagDto {
+  @IsBoolean()
+  isFlagged: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/backend/src/assessments/dto/update-risk-config.dto.ts
+++ b/backend/src/assessments/dto/update-risk-config.dto.ts
@@ -1,0 +1,13 @@
+import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class UpdateRiskConfigDto {
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  riskThreshold?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  autoFlagRisk?: boolean;
+}

--- a/backend/src/competency-cert/competency-cert.controller.ts
+++ b/backend/src/competency-cert/competency-cert.controller.ts
@@ -1,0 +1,69 @@
+import { Controller, Get, Post, Param, Query, UseGuards } from '@nestjs/common';
+import { CompetencyCertService } from './competency-cert.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
+import { OrgRoles } from '../common/decorators/org-roles.decorator';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+
+@Controller()
+@UseGuards(JwtAuthGuard, OrgRoleGuard)
+export class CompetencyCertController {
+  constructor(private readonly service: CompetencyCertService) {}
+
+  @Post('organizations/:orgId/campaigns/:campaignId/issue-certifications')
+  @OrgRoles('OWNER', 'ADMIN')
+  issueByCampaign(
+    @Param('orgId') orgId: string,
+    @Param('campaignId') campaignId: string,
+  ) {
+    return this.service.issueByCampaign(orgId, campaignId);
+  }
+
+  @Get('organizations/:orgId/members/:memberId/certifications')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'MEMBER')
+  findByMember(
+    @Param('orgId') orgId: string,
+    @Param('memberId') memberId: string,
+    @CurrentUser('id') userId: string,
+    @CurrentUser('orgRole') orgRole: string,
+    @Query('status') status?: string,
+  ) {
+    return this.service.findByMember(
+      orgId,
+      memberId,
+      userId,
+      orgRole ?? 'MEMBER',
+      status,
+    );
+  }
+
+  @Get('organizations/:orgId/certifications')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  findByOrg(
+    @Param('orgId') orgId: string,
+    @Query('competencyId') competencyId?: string,
+    @Query('groupId') groupId?: string,
+    @Query('status') status?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.service.findByOrg(orgId, {
+      competencyId,
+      groupId,
+      status,
+      page: page ? parseInt(page) : 1,
+      limit: limit ? parseInt(limit) : 20,
+    });
+  }
+
+  @Get('organizations/:orgId/certifications/compliance')
+  @OrgRoles('OWNER', 'ADMIN')
+  getCompliance(
+    @Param('orgId') orgId: string,
+    @Query('competencyId') competencyId?: string,
+    @Query('groupId') groupId?: string,
+    @Query('status') status?: string,
+  ) {
+    return this.service.getCompliance(orgId, { competencyId, groupId, status });
+  }
+}

--- a/backend/src/competency-cert/competency-cert.module.ts
+++ b/backend/src/competency-cert/competency-cert.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CompetencyCertController } from './competency-cert.controller';
+import { CompetencyCertService } from './competency-cert.service';
+import { OrganizationsModule } from '../organizations/organizations.module';
+import { ScorecardModule } from '../scorecard/scorecard.module';
+
+@Module({
+  imports: [OrganizationsModule, ScorecardModule],
+  controllers: [CompetencyCertController],
+  providers: [CompetencyCertService],
+  exports: [CompetencyCertService],
+})
+export class CompetencyCertModule {}

--- a/backend/src/competency-cert/competency-cert.service.ts
+++ b/backend/src/competency-cert/competency-cert.service.ts
@@ -3,14 +3,22 @@ import {
   BadRequestException,
   NotFoundException,
   ForbiddenException,
+  Logger,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ScorecardService } from '../scorecard/scorecard.service';
 import { addMonths, addDays, isBefore } from 'date-fns';
 
-export type CertStatus = 'ACTIVE' | 'EXPIRING_SOON' | 'EXPIRED';
+export type CertStatus =
+  | 'ACTIVE'
+  | 'EXPIRING_SOON'
+  | 'EXPIRED'
+  | 'NOT_CERTIFIED';
 
-function certStatus(expiresAt: Date, revokedAt: Date | null): CertStatus {
+function certStatus(
+  expiresAt: Date,
+  revokedAt: Date | null,
+): Exclude<CertStatus, 'NOT_CERTIFIED'> {
   if (revokedAt) return 'EXPIRED';
   const now = new Date();
   if (isBefore(expiresAt, now)) return 'EXPIRED';
@@ -20,6 +28,8 @@ function certStatus(expiresAt: Date, revokedAt: Date | null): CertStatus {
 
 @Injectable()
 export class CompetencyCertService {
+  private readonly logger = new Logger(CompetencyCertService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly scorecard: ScorecardService,
@@ -29,7 +39,11 @@ export class CompetencyCertService {
     const campaign = await this.prisma.assessmentCampaign.findFirst({
       where: { id: campaignId, orgId },
       include: {
-        assignments: { include: { member: true } },
+        assignments: {
+          include: {
+            member: { include: { user: { select: { email: true } } } },
+          },
+        },
         catalogItem: true,
       },
     });
@@ -39,11 +53,81 @@ export class CompetencyCertService {
         'Campaign must be CLOSED before issuing certifications',
       );
 
-    // Need jobRoleId — take from the assessment linked via catalogItem
-    const assessment = await this.prisma.assessment.findFirst({
-      where: { orgId, jobRoleId: { not: null } },
-      orderBy: { createdAt: 'desc' },
+    // Batch: all org assessment IDs (Assessment and ExamCatalogItem have no direct FK)
+    const orgAssessmentIds = (
+      await this.prisma.assessment.findMany({
+        where: { orgId },
+        select: { id: true },
+      })
+    ).map((a) => a.id);
+
+    // Batch: build member → email lookup
+    const memberEmailMap = new Map<string, string>();
+    for (const assignment of campaign.assignments) {
+      if (assignment.memberId && assignment.member?.user?.email) {
+        memberEmailMap.set(assignment.memberId, assignment.member.user.email);
+      }
+    }
+    const allEmails = [...new Set(memberEmailMap.values())];
+
+    // Batch: latest submitted invite per candidate email
+    const invites = await this.prisma.candidateInvite.findMany({
+      where: {
+        assessmentId: { in: orgAssessmentIds },
+        candidateEmail: { in: allEmails },
+        status: 'SUBMITTED',
+      },
+      select: {
+        id: true,
+        assessmentId: true,
+        candidateEmail: true,
+        submittedAt: true,
+      },
+      orderBy: { submittedAt: 'desc' },
     });
+
+    const emailToInvite = new Map<
+      string,
+      { id: string; assessmentId: string }
+    >();
+    for (const invite of invites) {
+      if (invite.candidateEmail && !emailToInvite.has(invite.candidateEmail)) {
+        emailToInvite.set(invite.candidateEmail, {
+          id: invite.id,
+          assessmentId: invite.assessmentId,
+        });
+      }
+    }
+
+    // Batch: existing active certs for all campaign members
+    const memberIds = campaign.assignments
+      .map((a) => a.memberId)
+      .filter(Boolean) as string[];
+
+    const existingCerts = await this.prisma.competencyCertification.findMany({
+      where: {
+        memberId: { in: memberIds },
+        revokedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+      select: {
+        id: true,
+        memberId: true,
+        competencyId: true,
+        achievedLevel: true,
+      },
+    });
+
+    const existingCertMap = new Map<
+      string,
+      { id: string; achievedLevel: number }
+    >();
+    for (const cert of existingCerts) {
+      existingCertMap.set(`${cert.memberId}:${cert.competencyId}`, {
+        id: cert.id,
+        achievedLevel: cert.achievedLevel,
+      });
+    }
 
     const results = {
       issued: 0,
@@ -55,30 +139,11 @@ export class CompetencyCertService {
     for (const assignment of campaign.assignments) {
       if (!assignment.memberId) continue;
 
-      // Find submitted invite for this member in this assessment
-      const assessmentIds = await this.getAssessmentIdsForCatalog(
-        campaign.catalogItemId,
-      );
-      const memberEmail = assignment.member?.userId
-        ? ((
-            await this.prisma.user.findUnique({
-              where: { id: assignment.member.userId },
-              select: { email: true },
-            })
-          )?.email ?? '')
-        : '';
+      const email = memberEmailMap.get(assignment.memberId);
+      if (!email) continue;
 
-      const invite = await this.prisma.candidateInvite.findFirst({
-        where: {
-          assessmentId: { in: assessmentIds },
-          candidateEmail: memberEmail,
-          status: 'SUBMITTED',
-        },
-        select: { id: true, assessmentId: true },
-        orderBy: { submittedAt: 'desc' },
-      });
-
-      if (!invite || !assessment?.jobRoleId) continue;
+      const invite = emailToInvite.get(email);
+      if (!invite) continue;
 
       let scorecard: any;
       try {
@@ -86,34 +151,33 @@ export class CompetencyCertService {
           orgId,
           invite.assessmentId,
           invite.id,
-          assessment.jobRoleId,
         );
-      } catch {
+      } catch (err) {
+        this.logger.warn(
+          `Scorecard build failed for invite ${invite.id}: ${String(err)}`,
+        );
         continue;
       }
 
-      for (const item of scorecard.items ?? []) {
-        if (!item.passed) continue;
+      // Batch-fetch all competencies referenced in this scorecard
+      const passedItems = (scorecard.items ?? []).filter((i: any) => i.passed);
+      const competencyIds = [
+        ...new Set(passedItems.map((i: any) => i.competencyId as string)),
+      ];
+      const competencies = await this.prisma.competency.findMany({
+        where: { id: { in: competencyIds } },
+        select: { id: true, validityMonths: true },
+      });
+      const competencyMap = new Map(competencies.map((c) => [c.id, c]));
 
-        const competency = await this.prisma.competency.findUnique({
-          where: { id: item.competencyId },
-          select: { validityMonths: true, scaleMin: true, scaleMax: true },
-        });
+      for (const item of passedItems) {
+        const competency = competencyMap.get(item.competencyId);
         if (!competency) continue;
 
         const achievedLevel = Math.round(item.normalizedLevel);
         const expiresAt = addMonths(new Date(), competency.validityMonths);
-
-        // Check existing active cert
-        const existing = await this.prisma.competencyCertification.findFirst({
-          where: {
-            memberId: assignment.memberId,
-            competencyId: item.competencyId,
-            revokedAt: null,
-            expiresAt: { gt: new Date() },
-          },
-          orderBy: { issuedAt: 'desc' },
-        });
+        const cacheKey = `${assignment.memberId}:${item.competencyId}`;
+        const existing = existingCertMap.get(cacheKey);
 
         if (existing) {
           if (existing.achievedLevel >= achievedLevel) {
@@ -123,12 +187,15 @@ export class CompetencyCertService {
               competencyId: item.competencyId,
               competencyName: item.competencyName,
               achievedLevel,
-              expiresAt,
               action: 'SKIPPED',
             });
             continue;
           }
-          // Upgrade
+          // Revoke superseded cert before issuing upgraded one
+          await this.prisma.competencyCertification.update({
+            where: { id: existing.id },
+            data: { revokedAt: new Date() },
+          });
           await this.prisma.competencyCertification.create({
             data: {
               orgId,
@@ -142,7 +209,6 @@ export class CompetencyCertService {
           results.upgraded++;
           results.certifications.push({
             memberId: assignment.memberId,
-            memberName: assignment.member?.userId ?? '',
             competencyId: item.competencyId,
             competencyName: item.competencyName,
             achievedLevel,
@@ -163,7 +229,6 @@ export class CompetencyCertService {
           results.issued++;
           results.certifications.push({
             memberId: assignment.memberId,
-            memberName: assignment.member?.userId ?? '',
             competencyId: item.competencyId,
             competencyName: item.competencyName,
             achievedLevel,
@@ -189,7 +254,6 @@ export class CompetencyCertService {
     });
     if (!member) throw new NotFoundException('Member not found');
 
-    // MEMBER can only see their own certs
     if (requesterRole === 'MEMBER') {
       const requesterMember = await this.prisma.orgMember.findFirst({
         where: { orgId, userId: requesterId },
@@ -250,6 +314,8 @@ export class CompetencyCertService {
     },
   ) {
     const { competencyId, groupId, status, page = 1, limit = 20 } = filters;
+    const now = new Date();
+    const soon = addDays(now, 30);
 
     const memberWhere: any = { orgId };
     if (groupId) memberWhere.groupId = groupId;
@@ -261,39 +327,62 @@ export class CompetencyCertService {
       })
     ).map((m) => m.id);
 
-    const certs = await this.prisma.competencyCertification.findMany({
-      where: {
-        orgId,
-        memberId: { in: memberIds },
-        ...(competencyId ? { competencyId } : {}),
-      },
-      include: {
-        competency: { select: { name: true, scaleMin: true, scaleMax: true } },
-        member: { include: { user: { select: { displayName: true } } } },
-        campaign: { select: { name: true } },
-      },
-      orderBy: { issuedAt: 'desc' },
-      skip: (page - 1) * limit,
-      take: limit,
-    });
+    // Push status filter into the DB query using date predicates
+    const statusWhere: any = {};
+    if (status && status !== 'ALL') {
+      if (status === 'ACTIVE') {
+        statusWhere.revokedAt = null;
+        statusWhere.expiresAt = { gte: soon };
+      } else if (status === 'EXPIRING_SOON') {
+        statusWhere.revokedAt = null;
+        statusWhere.expiresAt = { gte: now, lt: soon };
+      } else if (status === 'EXPIRED') {
+        statusWhere.OR = [
+          { revokedAt: { not: null } },
+          { expiresAt: { lt: now } },
+        ];
+      }
+    }
 
-    const rows = certs
-      .map((c) => ({
-        id: c.id,
-        memberId: c.memberId,
-        memberName: c.member.user.displayName,
-        competencyId: c.competencyId,
-        competencyName: c.competency.name,
-        achievedLevel: c.achievedLevel,
-        scaleMax: c.competency.scaleMax,
-        issuedAt: c.issuedAt,
-        expiresAt: c.expiresAt,
-        status: certStatus(c.expiresAt, c.revokedAt),
-        campaignName: c.campaign?.name ?? null,
-      }))
-      .filter((c) => !status || status === 'ALL' || c.status === status);
+    const where = {
+      orgId,
+      memberId: { in: memberIds },
+      ...(competencyId ? { competencyId } : {}),
+      ...statusWhere,
+    };
 
-    return { total: rows.length, page, limit, rows };
+    const [total, certs] = await Promise.all([
+      this.prisma.competencyCertification.count({ where }),
+      this.prisma.competencyCertification.findMany({
+        where,
+        include: {
+          competency: {
+            select: { name: true, scaleMin: true, scaleMax: true },
+          },
+          member: { include: { user: { select: { displayName: true } } } },
+          campaign: { select: { name: true } },
+        },
+        orderBy: { issuedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+    ]);
+
+    const rows = certs.map((c) => ({
+      id: c.id,
+      memberId: c.memberId,
+      memberName: c.member.user.displayName,
+      competencyId: c.competencyId,
+      competencyName: c.competency.name,
+      achievedLevel: c.achievedLevel,
+      scaleMax: c.competency.scaleMax,
+      issuedAt: c.issuedAt,
+      expiresAt: c.expiresAt,
+      status: certStatus(c.expiresAt, c.revokedAt),
+      campaignName: c.campaign?.name ?? null,
+    }));
+
+    return { total, page, limit, rows };
   }
 
   async getCompliance(
@@ -312,29 +401,49 @@ export class CompetencyCertService {
       },
     });
 
+    const memberIds = members.map((m) => m.id);
+
     const jobRoleCompetencies = await this.prisma.jobRoleCompetency.findMany({
-      where: competencyId ? { competencyId } : {},
+      where: {
+        jobRole: { orgId },
+        ...(competencyId ? { competencyId } : {}),
+      },
       include: {
         competency: { select: { name: true } },
         jobRole: { select: { id: true } },
       },
     });
 
-    const now = new Date();
-    const rows: any[] = [];
+    // Bulk-fetch all certs for all members — eliminates N×M DB queries
+    const allCerts = await this.prisma.competencyCertification.findMany({
+      where: {
+        memberId: { in: memberIds },
+        ...(competencyId ? { competencyId } : {}),
+      },
+      select: {
+        memberId: true,
+        competencyId: true,
+        achievedLevel: true,
+        expiresAt: true,
+        revokedAt: true,
+        issuedAt: true,
+      },
+      orderBy: { issuedAt: 'desc' },
+    });
 
+    // Map: `${memberId}:${competencyId}` → most recent cert
+    const certMap = new Map<string, (typeof allCerts)[number]>();
+    for (const cert of allCerts) {
+      const key = `${cert.memberId}:${cert.competencyId}`;
+      if (!certMap.has(key)) certMap.set(key, cert);
+    }
+
+    const rows: any[] = [];
     for (const member of members) {
       for (const jrc of jobRoleCompetencies) {
-        const cert = await this.prisma.competencyCertification.findFirst({
-          where: {
-            memberId: member.id,
-            competencyId: jrc.competencyId,
-            revokedAt: null,
-          },
-          orderBy: { issuedAt: 'desc' },
-        });
-
-        const cs = cert
+        const key = `${member.id}:${jrc.competencyId}`;
+        const cert = certMap.get(key);
+        const cs: CertStatus = cert
           ? certStatus(cert.expiresAt, cert.revokedAt)
           : 'NOT_CERTIFIED';
         if (status && status !== 'ALL' && cs !== status) continue;
@@ -372,15 +481,5 @@ export class CompetencyCertService {
       },
       rows,
     };
-  }
-
-  private async getAssessmentIdsForCatalog(
-    catalogItemId: string,
-  ): Promise<string[]> {
-    const assessments = await this.prisma.assessment.findMany({
-      where: { id: catalogItemId },
-      select: { id: true },
-    });
-    return assessments.map((a) => a.id);
   }
 }

--- a/backend/src/competency-cert/competency-cert.service.ts
+++ b/backend/src/competency-cert/competency-cert.service.ts
@@ -161,7 +161,7 @@ export class CompetencyCertService {
 
       // Batch-fetch all competencies referenced in this scorecard
       const passedItems = (scorecard.items ?? []).filter((i: any) => i.passed);
-      const competencyIds = [
+      const competencyIds: string[] = [
         ...new Set(passedItems.map((i: any) => i.competencyId as string)),
       ];
       const competencies = await this.prisma.competency.findMany({

--- a/backend/src/competency-cert/competency-cert.service.ts
+++ b/backend/src/competency-cert/competency-cert.service.ts
@@ -161,8 +161,10 @@ export class CompetencyCertService {
 
       // Batch-fetch all competencies referenced in this scorecard
       const passedItems = (scorecard.items ?? []).filter((i: any) => i.passed);
-      const competencyIds: string[] = [
-        ...new Set(passedItems.map((i: any) => i.competencyId as string)),
+      const competencyIds = [
+        ...new Set<string>(
+          passedItems.map((i: any) => i.competencyId as string),
+        ),
       ];
       const competencies = await this.prisma.competency.findMany({
         where: { id: { in: competencyIds } },

--- a/backend/src/competency-cert/competency-cert.service.ts
+++ b/backend/src/competency-cert/competency-cert.service.ts
@@ -1,0 +1,386 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ScorecardService } from '../scorecard/scorecard.service';
+import { addMonths, addDays, isBefore } from 'date-fns';
+
+export type CertStatus = 'ACTIVE' | 'EXPIRING_SOON' | 'EXPIRED';
+
+function certStatus(expiresAt: Date, revokedAt: Date | null): CertStatus {
+  if (revokedAt) return 'EXPIRED';
+  const now = new Date();
+  if (isBefore(expiresAt, now)) return 'EXPIRED';
+  if (isBefore(expiresAt, addDays(now, 30))) return 'EXPIRING_SOON';
+  return 'ACTIVE';
+}
+
+@Injectable()
+export class CompetencyCertService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly scorecard: ScorecardService,
+  ) {}
+
+  async issueByCampaign(orgId: string, campaignId: string) {
+    const campaign = await this.prisma.assessmentCampaign.findFirst({
+      where: { id: campaignId, orgId },
+      include: {
+        assignments: { include: { member: true } },
+        catalogItem: true,
+      },
+    });
+    if (!campaign) throw new NotFoundException('Campaign not found');
+    if (campaign.status !== 'CLOSED')
+      throw new BadRequestException(
+        'Campaign must be CLOSED before issuing certifications',
+      );
+
+    // Need jobRoleId — take from the assessment linked via catalogItem
+    const assessment = await this.prisma.assessment.findFirst({
+      where: { orgId, jobRoleId: { not: null } },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const results = {
+      issued: 0,
+      upgraded: 0,
+      skipped: 0,
+      certifications: [] as any[],
+    };
+
+    for (const assignment of campaign.assignments) {
+      if (!assignment.memberId) continue;
+
+      // Find submitted invite for this member in this assessment
+      const assessmentIds = await this.getAssessmentIdsForCatalog(
+        campaign.catalogItemId,
+      );
+      const memberEmail = assignment.member?.userId
+        ? ((
+            await this.prisma.user.findUnique({
+              where: { id: assignment.member.userId },
+              select: { email: true },
+            })
+          )?.email ?? '')
+        : '';
+
+      const invite = await this.prisma.candidateInvite.findFirst({
+        where: {
+          assessmentId: { in: assessmentIds },
+          candidateEmail: memberEmail,
+          status: 'SUBMITTED',
+        },
+        select: { id: true, assessmentId: true },
+        orderBy: { submittedAt: 'desc' },
+      });
+
+      if (!invite || !assessment?.jobRoleId) continue;
+
+      let scorecard: any;
+      try {
+        scorecard = await this.scorecard.buildForCandidate(
+          orgId,
+          invite.assessmentId,
+          invite.id,
+          assessment.jobRoleId,
+        );
+      } catch {
+        continue;
+      }
+
+      for (const item of scorecard.items ?? []) {
+        if (!item.passed) continue;
+
+        const competency = await this.prisma.competency.findUnique({
+          where: { id: item.competencyId },
+          select: { validityMonths: true, scaleMin: true, scaleMax: true },
+        });
+        if (!competency) continue;
+
+        const achievedLevel = Math.round(item.normalizedLevel);
+        const expiresAt = addMonths(new Date(), competency.validityMonths);
+
+        // Check existing active cert
+        const existing = await this.prisma.competencyCertification.findFirst({
+          where: {
+            memberId: assignment.memberId,
+            competencyId: item.competencyId,
+            revokedAt: null,
+            expiresAt: { gt: new Date() },
+          },
+          orderBy: { issuedAt: 'desc' },
+        });
+
+        if (existing) {
+          if (existing.achievedLevel >= achievedLevel) {
+            results.skipped++;
+            results.certifications.push({
+              memberId: assignment.memberId,
+              competencyId: item.competencyId,
+              competencyName: item.competencyName,
+              achievedLevel,
+              expiresAt,
+              action: 'SKIPPED',
+            });
+            continue;
+          }
+          // Upgrade
+          await this.prisma.competencyCertification.create({
+            data: {
+              orgId,
+              memberId: assignment.memberId,
+              competencyId: item.competencyId,
+              campaignId,
+              achievedLevel,
+              expiresAt,
+            },
+          });
+          results.upgraded++;
+          results.certifications.push({
+            memberId: assignment.memberId,
+            memberName: assignment.member?.userId ?? '',
+            competencyId: item.competencyId,
+            competencyName: item.competencyName,
+            achievedLevel,
+            expiresAt,
+            action: 'UPGRADED',
+          });
+        } else {
+          await this.prisma.competencyCertification.create({
+            data: {
+              orgId,
+              memberId: assignment.memberId,
+              competencyId: item.competencyId,
+              campaignId,
+              achievedLevel,
+              expiresAt,
+            },
+          });
+          results.issued++;
+          results.certifications.push({
+            memberId: assignment.memberId,
+            memberName: assignment.member?.userId ?? '',
+            competencyId: item.competencyId,
+            competencyName: item.competencyName,
+            achievedLevel,
+            expiresAt,
+            action: 'ISSUED',
+          });
+        }
+      }
+    }
+
+    return { campaignId, ...results };
+  }
+
+  async findByMember(
+    orgId: string,
+    memberId: string,
+    requesterId: string,
+    requesterRole: string,
+    statusFilter?: string,
+  ) {
+    const member = await this.prisma.orgMember.findFirst({
+      where: { id: memberId, orgId },
+    });
+    if (!member) throw new NotFoundException('Member not found');
+
+    // MEMBER can only see their own certs
+    if (requesterRole === 'MEMBER') {
+      const requesterMember = await this.prisma.orgMember.findFirst({
+        where: { orgId, userId: requesterId },
+      });
+      if (!requesterMember || requesterMember.id !== memberId)
+        throw new ForbiddenException();
+    }
+
+    const certs = await this.prisma.competencyCertification.findMany({
+      where: { memberId, orgId },
+      include: {
+        competency: { select: { name: true, scaleMin: true, scaleMax: true } },
+        campaign: { select: { name: true } },
+      },
+      orderBy: { issuedAt: 'desc' },
+    });
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: member.userId },
+      select: { displayName: true },
+    });
+
+    const rows = certs
+      .map((c) => {
+        const status = certStatus(c.expiresAt, c.revokedAt);
+        return {
+          id: c.id,
+          competencyId: c.competencyId,
+          competencyName: c.competency.name,
+          achievedLevel: c.achievedLevel,
+          scaleMax: c.competency.scaleMax,
+          issuedAt: c.issuedAt,
+          expiresAt: c.expiresAt,
+          status,
+          campaignName: c.campaign?.name ?? null,
+        };
+      })
+      .filter(
+        (c) =>
+          !statusFilter || statusFilter === 'ALL' || c.status === statusFilter,
+      );
+
+    return {
+      memberId,
+      memberName: user?.displayName ?? '',
+      certifications: rows,
+    };
+  }
+
+  async findByOrg(
+    orgId: string,
+    filters: {
+      competencyId?: string;
+      groupId?: string;
+      status?: string;
+      page?: number;
+      limit?: number;
+    },
+  ) {
+    const { competencyId, groupId, status, page = 1, limit = 20 } = filters;
+
+    const memberWhere: any = { orgId };
+    if (groupId) memberWhere.groupId = groupId;
+
+    const memberIds = (
+      await this.prisma.orgMember.findMany({
+        where: memberWhere,
+        select: { id: true },
+      })
+    ).map((m) => m.id);
+
+    const certs = await this.prisma.competencyCertification.findMany({
+      where: {
+        orgId,
+        memberId: { in: memberIds },
+        ...(competencyId ? { competencyId } : {}),
+      },
+      include: {
+        competency: { select: { name: true, scaleMin: true, scaleMax: true } },
+        member: { include: { user: { select: { displayName: true } } } },
+        campaign: { select: { name: true } },
+      },
+      orderBy: { issuedAt: 'desc' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    const rows = certs
+      .map((c) => ({
+        id: c.id,
+        memberId: c.memberId,
+        memberName: c.member.user.displayName,
+        competencyId: c.competencyId,
+        competencyName: c.competency.name,
+        achievedLevel: c.achievedLevel,
+        scaleMax: c.competency.scaleMax,
+        issuedAt: c.issuedAt,
+        expiresAt: c.expiresAt,
+        status: certStatus(c.expiresAt, c.revokedAt),
+        campaignName: c.campaign?.name ?? null,
+      }))
+      .filter((c) => !status || status === 'ALL' || c.status === status);
+
+    return { total: rows.length, page, limit, rows };
+  }
+
+  async getCompliance(
+    orgId: string,
+    filters: { competencyId?: string; groupId?: string; status?: string },
+  ) {
+    const { competencyId, groupId, status } = filters;
+
+    const memberWhere: any = { orgId, isActive: true };
+    if (groupId) memberWhere.groupId = groupId;
+    const members = await this.prisma.orgMember.findMany({
+      where: memberWhere,
+      include: {
+        user: { select: { displayName: true } },
+        group: { select: { name: true } },
+      },
+    });
+
+    const jobRoleCompetencies = await this.prisma.jobRoleCompetency.findMany({
+      where: competencyId ? { competencyId } : {},
+      include: {
+        competency: { select: { name: true } },
+        jobRole: { select: { id: true } },
+      },
+    });
+
+    const now = new Date();
+    const rows: any[] = [];
+
+    for (const member of members) {
+      for (const jrc of jobRoleCompetencies) {
+        const cert = await this.prisma.competencyCertification.findFirst({
+          where: {
+            memberId: member.id,
+            competencyId: jrc.competencyId,
+            revokedAt: null,
+          },
+          orderBy: { issuedAt: 'desc' },
+        });
+
+        const cs = cert
+          ? certStatus(cert.expiresAt, cert.revokedAt)
+          : 'NOT_CERTIFIED';
+        if (status && status !== 'ALL' && cs !== status) continue;
+
+        rows.push({
+          memberId: member.id,
+          memberName: member.user.displayName,
+          groupName: member.group?.name ?? null,
+          competencyId: jrc.competencyId,
+          competencyName: jrc.competency.name,
+          certStatus: cs,
+          achievedLevel: cert?.achievedLevel ?? null,
+          requiredLevel: jrc.requiredLevel,
+          expiresAt: cert?.expiresAt ?? null,
+        });
+      }
+    }
+
+    const certified = rows.filter((r) => r.certStatus === 'ACTIVE').length;
+    const expiringSoon = rows.filter(
+      (r) => r.certStatus === 'EXPIRING_SOON',
+    ).length;
+    const expired = rows.filter((r) => r.certStatus === 'EXPIRED').length;
+    const notCertified = rows.filter(
+      (r) => r.certStatus === 'NOT_CERTIFIED',
+    ).length;
+
+    return {
+      summary: {
+        totalMembers: members.length,
+        certified,
+        expiringSoon,
+        expired,
+        notCertified,
+      },
+      rows,
+    };
+  }
+
+  private async getAssessmentIdsForCatalog(
+    catalogItemId: string,
+  ): Promise<string[]> {
+    const assessments = await this.prisma.assessment.findMany({
+      where: { id: catalogItemId },
+      select: { id: true },
+    });
+    return assessments.map((a) => a.id);
+  }
+}

--- a/backend/src/executive-dashboard/executive-dashboard.controller.ts
+++ b/backend/src/executive-dashboard/executive-dashboard.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Res, UseGuards } from '@nestjs/common';
-import { Response } from 'express';
+import type { Response } from 'express';
 import { ExecutiveDashboardService } from './executive-dashboard.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { OrgRoleGuard } from '../organizations/guards/org-role.guard';

--- a/backend/src/executive-dashboard/executive-dashboard.controller.ts
+++ b/backend/src/executive-dashboard/executive-dashboard.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, Param, Res, UseGuards } from '@nestjs/common';
+import { Response } from 'express';
+import { ExecutiveDashboardService } from './executive-dashboard.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
+import { OrgRoles } from '../common/decorators/org-roles.decorator';
+
+@Controller('organizations/:orgId/executive-dashboard')
+@UseGuards(JwtAuthGuard, OrgRoleGuard)
+@OrgRoles('OWNER', 'ADMIN')
+export class ExecutiveDashboardController {
+  constructor(private readonly service: ExecutiveDashboardService) {}
+
+  @Get()
+  getDashboard(@Param('orgId') orgId: string) {
+    return this.service.getDashboard(orgId);
+  }
+
+  @Get('compliance')
+  getCompliance(@Param('orgId') orgId: string) {
+    return this.service.getComplianceMetrics(orgId);
+  }
+
+  @Get('hiring-funnel')
+  getHiringFunnel(@Param('orgId') orgId: string) {
+    return this.service.getHiringFunnel(orgId);
+  }
+
+  @Get('integrity')
+  getIntegrity(@Param('orgId') orgId: string) {
+    return this.service.getIntegrityMetrics(orgId);
+  }
+
+  @Get('export/csv')
+  async exportCsv(@Param('orgId') orgId: string, @Res() res: Response) {
+    const csv = await this.service.exportCsv(orgId);
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="executive-dashboard-${orgId}-${Date.now()}.csv"`,
+    );
+    res.send(csv);
+  }
+}

--- a/backend/src/executive-dashboard/executive-dashboard.module.ts
+++ b/backend/src/executive-dashboard/executive-dashboard.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ExecutiveDashboardController } from './executive-dashboard.controller';
+import { ExecutiveDashboardService } from './executive-dashboard.service';
+import { OrganizationsModule } from '../organizations/organizations.module';
+import { RedisModule } from '../redis/redis.module';
+
+@Module({
+  imports: [OrganizationsModule, RedisModule],
+  controllers: [ExecutiveDashboardController],
+  providers: [ExecutiveDashboardService],
+})
+export class ExecutiveDashboardModule {}

--- a/backend/src/executive-dashboard/executive-dashboard.service.ts
+++ b/backend/src/executive-dashboard/executive-dashboard.service.ts
@@ -127,7 +127,7 @@ export class ExecutiveDashboardService {
 
     return {
       campaigns: campaigns.length,
-      activeCampaigns: campaigns.filter((c) => c.status === 'OPEN').length,
+      activeCampaigns: campaigns.filter((c) => c.status === 'ACTIVE').length,
       totalCandidates: invited,
       started,
       submitted,

--- a/backend/src/executive-dashboard/executive-dashboard.service.ts
+++ b/backend/src/executive-dashboard/executive-dashboard.service.ts
@@ -1,0 +1,200 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { REDIS_CLIENT } from '../redis/redis.module';
+import type Redis from 'ioredis';
+import { addDays, isBefore } from 'date-fns';
+
+const CACHE_TTL = 300; // 5 min
+
+@Injectable()
+export class ExecutiveDashboardService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {}
+
+  async getDashboard(orgId: string) {
+    const cacheKey = `exec-dashboard:${orgId}`;
+    try {
+      const cached = await this.redis.get(cacheKey);
+      if (cached) return JSON.parse(cached);
+    } catch {}
+
+    const [compliance, funnel, integrity] = await Promise.all([
+      this.getComplianceMetrics(orgId),
+      this.getHiringFunnel(orgId),
+      this.getIntegrityMetrics(orgId),
+    ]);
+
+    const result = { compliance, funnel, integrity, generatedAt: new Date() };
+
+    try {
+      await this.redis.set(cacheKey, JSON.stringify(result), 'EX', CACHE_TTL);
+    } catch {}
+
+    return result;
+  }
+
+  async getComplianceMetrics(orgId: string) {
+    const members = await this.prisma.orgMember.findMany({
+      where: { orgId, isActive: true },
+      select: { id: true },
+    });
+    const memberIds = members.map((m) => m.id);
+
+    const allCerts = await this.prisma.competencyCertification.findMany({
+      where: { orgId, memberId: { in: memberIds } },
+      select: {
+        memberId: true,
+        competencyId: true,
+        expiresAt: true,
+        revokedAt: true,
+      },
+    });
+
+    const now = new Date();
+    const soon = addDays(now, 30);
+    let active = 0;
+    let expiringSoon = 0;
+    let expired = 0;
+
+    for (const c of allCerts) {
+      if (c.revokedAt || isBefore(c.expiresAt, now)) {
+        expired++;
+      } else if (isBefore(c.expiresAt, soon)) {
+        expiringSoon++;
+      } else {
+        active++;
+      }
+    }
+
+    const uniqueMembersWithCert = new Set(allCerts.map((c) => c.memberId)).size;
+    const certRate =
+      members.length > 0
+        ? Math.round((uniqueMembersWithCert / members.length) * 100)
+        : 0;
+
+    return {
+      totalMembers: members.length,
+      certifiedMembers: uniqueMembersWithCert,
+      certRate,
+      certsByStatus: { active, expiringSoon, expired },
+    };
+  }
+
+  async getHiringFunnel(orgId: string) {
+    const campaigns = await this.prisma.assessmentCampaign.findMany({
+      where: { orgId },
+      select: {
+        id: true,
+        status: true,
+        _count: { select: { assignments: true } },
+      },
+    });
+
+    const assessments = await this.prisma.assessment.findMany({
+      where: { orgId },
+      select: { id: true },
+    });
+    const assessmentIds = assessments.map((a) => a.id);
+
+    const [invited, started, submitted] = await Promise.all([
+      this.prisma.candidateInvite.count({
+        where: { assessmentId: { in: assessmentIds } },
+      }),
+      this.prisma.candidateInvite.count({
+        where: {
+          assessmentId: { in: assessmentIds },
+          status: { in: ['STARTED', 'SUBMITTED', 'EXPIRED'] },
+        },
+      }),
+      this.prisma.candidateInvite.count({
+        where: { assessmentId: { in: assessmentIds }, status: 'SUBMITTED' },
+      }),
+    ]);
+
+    const passedCount = await this.prisma.candidateInvite.count({
+      where: {
+        assessmentId: { in: assessmentIds },
+        status: 'SUBMITTED',
+        score: {
+          gte: 70, // default threshold
+        },
+      },
+    });
+
+    return {
+      campaigns: campaigns.length,
+      activeCampaigns: campaigns.filter((c) => c.status === 'OPEN').length,
+      totalCandidates: invited,
+      started,
+      submitted,
+      passed: passedCount,
+      conversionRate: invited > 0 ? Math.round((submitted / invited) * 100) : 0,
+      passRate: submitted > 0 ? Math.round((passedCount / submitted) * 100) : 0,
+    };
+  }
+
+  async getIntegrityMetrics(orgId: string) {
+    const assessments = await this.prisma.assessment.findMany({
+      where: { orgId },
+      select: { id: true },
+    });
+    const assessmentIds = assessments.map((a) => a.id);
+
+    const flagged = await this.prisma.candidateInvite.count({
+      where: { assessmentId: { in: assessmentIds }, isFlagged: true },
+    });
+
+    const total = await this.prisma.candidateInvite.count({
+      where: {
+        assessmentId: { in: assessmentIds },
+        status: 'SUBMITTED',
+      },
+    });
+
+    const avgIntegrity = await this.prisma.candidateInvite.aggregate({
+      where: {
+        assessmentId: { in: assessmentIds },
+        status: 'SUBMITTED',
+        integrityScore: { not: null },
+      },
+      _avg: { integrityScore: true },
+    });
+
+    return {
+      totalSubmitted: total,
+      flaggedCount: flagged,
+      flagRate: total > 0 ? Math.round((flagged / total) * 100) : 0,
+      avgIntegrityScore: avgIntegrity._avg.integrityScore
+        ? Math.round(Number(avgIntegrity._avg.integrityScore))
+        : null,
+    };
+  }
+
+  async exportCsv(orgId: string): Promise<string> {
+    const data = await this.getDashboard(orgId);
+    const { compliance, funnel, integrity } = data;
+
+    const rows = [
+      ['Metric', 'Value'],
+      ['Total Members', String(compliance.totalMembers)],
+      ['Certified Members', String(compliance.certifiedMembers)],
+      ['Certification Rate (%)', String(compliance.certRate)],
+      ['Active Certs', String(compliance.certsByStatus.active)],
+      ['Expiring Soon Certs', String(compliance.certsByStatus.expiringSoon)],
+      ['Expired Certs', String(compliance.certsByStatus.expired)],
+      ['Active Campaigns', String(funnel.activeCampaigns)],
+      ['Total Candidates', String(funnel.totalCandidates)],
+      ['Submitted', String(funnel.submitted)],
+      ['Passed', String(funnel.passed)],
+      ['Conversion Rate (%)', String(funnel.conversionRate)],
+      ['Pass Rate (%)', String(funnel.passRate)],
+      ['Flagged Candidates', String(integrity.flaggedCount)],
+      ['Flag Rate (%)', String(integrity.flagRate)],
+      ['Avg Integrity Score', String(integrity.avgIntegrityScore ?? 'N/A')],
+    ];
+
+    return rows.map((r) => r.map((v) => `"${v}"`).join(',')).join('\n');
+  }
+}

--- a/backend/src/executive-dashboard/executive-dashboard.service.ts
+++ b/backend/src/executive-dashboard/executive-dashboard.service.ts
@@ -92,11 +92,12 @@ export class ExecutiveDashboardService {
       },
     });
 
-    const assessments = await this.prisma.assessment.findMany({
+    // Single query — id used for counts, passingScore used for pass threshold
+    const assessmentsWithScore = await this.prisma.assessment.findMany({
       where: { orgId },
-      select: { id: true },
+      select: { id: true, passingScore: true },
     });
-    const assessmentIds = assessments.map((a) => a.id);
+    const assessmentIds = assessmentsWithScore.map((a) => a.id);
 
     const [invited, started, submitted] = await Promise.all([
       this.prisma.candidateInvite.count({
@@ -112,16 +113,17 @@ export class ExecutiveDashboardService {
         where: { assessmentId: { in: assessmentIds }, status: 'SUBMITTED' },
       }),
     ]);
-
-    const passedCount = await this.prisma.candidateInvite.count({
-      where: {
-        assessmentId: { in: assessmentIds },
-        status: 'SUBMITTED',
-        score: {
-          gte: 70, // default threshold
+    let passedCount = 0;
+    for (const a of assessmentsWithScore) {
+      const threshold = a.passingScore ?? 70;
+      passedCount += await this.prisma.candidateInvite.count({
+        where: {
+          assessmentId: a.id,
+          status: 'SUBMITTED',
+          score: { gte: threshold },
         },
-      },
-    });
+      });
+    }
 
     return {
       campaigns: campaigns.length,

--- a/backend/src/idp/idp.controller.ts
+++ b/backend/src/idp/idp.controller.ts
@@ -1,0 +1,98 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
+import { IdpService, UpsertReviewDto, CreateIdpDto } from './idp.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OrgRoleGuard } from '../organizations/guards/org-role.guard';
+import { OrgRoles } from '../common/decorators/org-roles.decorator';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+
+@Controller()
+@UseGuards(JwtAuthGuard, OrgRoleGuard)
+export class IdpController {
+  constructor(private readonly service: IdpService) {}
+
+  // ─── Campaign Member Reviews ──────────────────────────────────────
+
+  @Get('organizations/:orgId/campaigns/:campaignId/reviews')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  listCampaignReviews(
+    @Param('orgId') orgId: string,
+    @Param('campaignId') campaignId: string,
+  ) {
+    return this.service.listCampaignReviews(orgId, campaignId);
+  }
+
+  @Get('organizations/:orgId/campaigns/:campaignId/reviews/:memberId')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  getReview(
+    @Param('orgId') orgId: string,
+    @Param('campaignId') campaignId: string,
+    @Param('memberId') memberId: string,
+  ) {
+    return this.service.getReview(orgId, campaignId, memberId);
+  }
+
+  @Post('organizations/:orgId/campaigns/:campaignId/reviews/:memberId')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  upsertReview(
+    @Param('orgId') orgId: string,
+    @Param('campaignId') campaignId: string,
+    @Param('memberId') memberId: string,
+    @CurrentUser('id') userId: string,
+    @Body() dto: UpsertReviewDto,
+  ) {
+    return this.service.upsertReview(orgId, campaignId, memberId, userId, dto);
+  }
+
+  // ─── Member IDPs ──────────────────────────────────────────────────
+
+  @Get('organizations/:orgId/members/:memberId/idp')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'MEMBER')
+  listIdps(
+    @Param('orgId') orgId: string,
+    @Param('memberId') memberId: string,
+    @CurrentUser('id') userId: string,
+    @CurrentUser('orgRole') orgRole: string,
+  ) {
+    return this.service.listIdps(orgId, memberId, userId, orgRole ?? 'MEMBER');
+  }
+
+  @Post('organizations/:orgId/members/:memberId/idp')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  createIdp(
+    @Param('orgId') orgId: string,
+    @Param('memberId') memberId: string,
+    @CurrentUser('id') userId: string,
+    @Body() dto: CreateIdpDto,
+  ) {
+    return this.service.createIdp(orgId, memberId, userId, dto);
+  }
+
+  @Patch('organizations/:orgId/members/:memberId/idp/:idpId/complete')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER', 'MEMBER')
+  completeIdp(
+    @Param('orgId') orgId: string,
+    @Param('memberId') memberId: string,
+    @Param('idpId') idpId: string,
+  ) {
+    return this.service.completeIdp(orgId, memberId, idpId);
+  }
+
+  @Delete('organizations/:orgId/members/:memberId/idp/:idpId')
+  @OrgRoles('OWNER', 'ADMIN', 'MANAGER')
+  deleteIdp(
+    @Param('orgId') orgId: string,
+    @Param('memberId') memberId: string,
+    @Param('idpId') idpId: string,
+  ) {
+    return this.service.deleteIdp(orgId, memberId, idpId);
+  }
+}

--- a/backend/src/idp/idp.module.ts
+++ b/backend/src/idp/idp.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { IdpController } from './idp.controller';
+import { IdpService } from './idp.service';
+import { OrganizationsModule } from '../organizations/organizations.module';
+
+@Module({
+  imports: [OrganizationsModule],
+  controllers: [IdpController],
+  providers: [IdpService],
+  exports: [IdpService],
+})
+export class IdpModule {}

--- a/backend/src/idp/idp.service.ts
+++ b/backend/src/idp/idp.service.ts
@@ -1,0 +1,210 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface UpsertReviewDto {
+  note: string;
+  direction?: string;
+}
+
+export interface CreateIdpDto {
+  competencyId: string;
+  trackId: string;
+  targetLevel: number;
+  dueDate?: string;
+}
+
+@Injectable()
+export class IdpService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ─── Campaign Member Reviews (US-B4) ─────────────────────────────
+
+  async upsertReview(
+    orgId: string,
+    campaignId: string,
+    memberId: string,
+    reviewedBy: string,
+    dto: UpsertReviewDto,
+  ) {
+    const campaign = await this.prisma.assessmentCampaign.findFirst({
+      where: { id: campaignId, orgId },
+    });
+    if (!campaign) throw new NotFoundException('Campaign not found');
+
+    const member = await this.prisma.orgMember.findFirst({
+      where: { id: memberId, orgId },
+    });
+    if (!member) throw new NotFoundException('Member not found');
+
+    return this.prisma.campaignMemberReview.upsert({
+      where: { campaignId_memberId: { campaignId, memberId } },
+      create: {
+        orgId,
+        campaignId,
+        memberId,
+        reviewedBy,
+        note: dto.note,
+        direction: dto.direction,
+      },
+      update: {
+        note: dto.note,
+        direction: dto.direction,
+        reviewedBy,
+      },
+    });
+  }
+
+  async getReview(orgId: string, campaignId: string, memberId: string) {
+    const review = await this.prisma.campaignMemberReview.findUnique({
+      where: { campaignId_memberId: { campaignId, memberId } },
+      include: {
+        member: { include: { user: { select: { displayName: true } } } },
+      },
+    });
+    if (!review) throw new NotFoundException('Review not found');
+    if (review.orgId !== orgId) throw new NotFoundException('Review not found');
+    return review;
+  }
+
+  async listCampaignReviews(orgId: string, campaignId: string) {
+    const campaign = await this.prisma.assessmentCampaign.findFirst({
+      where: { id: campaignId, orgId },
+    });
+    if (!campaign) throw new NotFoundException('Campaign not found');
+
+    const reviews = await this.prisma.campaignMemberReview.findMany({
+      where: { campaignId, orgId },
+      include: {
+        member: {
+          include: { user: { select: { displayName: true, email: true } } },
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    return reviews.map((r) => ({
+      memberId: r.memberId,
+      memberName: r.member.user.displayName,
+      memberEmail: r.member.user.email,
+      note: r.note,
+      direction: r.direction,
+      reviewedBy: r.reviewedBy,
+      updatedAt: r.updatedAt,
+    }));
+  }
+
+  // ─── Member IDPs (US-B4) ─────────────────────────────────────────
+
+  async createIdp(
+    orgId: string,
+    memberId: string,
+    createdBy: string,
+    dto: CreateIdpDto,
+  ) {
+    const member = await this.prisma.orgMember.findFirst({
+      where: { id: memberId, orgId },
+    });
+    if (!member) throw new NotFoundException('Member not found');
+
+    const track = await this.prisma.learningTrack.findFirst({
+      where: { id: dto.trackId, orgId },
+    });
+    if (!track) throw new NotFoundException('Learning track not found');
+
+    const existing = await this.prisma.memberIdp.findFirst({
+      where: { memberId, competencyId: dto.competencyId, trackId: dto.trackId },
+    });
+    if (existing)
+      throw new ConflictException(
+        'IDP already exists for this competency + track',
+      );
+
+    return this.prisma.memberIdp.create({
+      data: {
+        orgId,
+        memberId,
+        competencyId: dto.competencyId,
+        trackId: dto.trackId,
+        targetLevel: dto.targetLevel,
+        dueDate: dto.dueDate ? new Date(dto.dueDate) : undefined,
+        createdBy,
+      },
+      include: {
+        competency: { select: { name: true } },
+        track: { select: { name: true } },
+      },
+    });
+  }
+
+  async listIdps(
+    orgId: string,
+    memberId: string,
+    requesterId: string,
+    requesterRole: string,
+  ) {
+    const member = await this.prisma.orgMember.findFirst({
+      where: { id: memberId, orgId },
+    });
+    if (!member) throw new NotFoundException('Member not found');
+
+    if (requesterRole === 'MEMBER') {
+      const requesterMember = await this.prisma.orgMember.findFirst({
+        where: { orgId, userId: requesterId },
+      });
+      if (!requesterMember || requesterMember.id !== memberId)
+        throw new ForbiddenException();
+    }
+
+    const idps = await this.prisma.memberIdp.findMany({
+      where: { memberId, orgId },
+      include: {
+        competency: { select: { name: true, scaleMin: true, scaleMax: true } },
+        track: { select: { name: true } },
+      },
+      orderBy: { dueDate: 'asc' },
+    });
+
+    return idps.map((idp) => ({
+      id: idp.id,
+      competencyId: idp.competencyId,
+      competencyName: idp.competency.name,
+      trackId: idp.trackId,
+      trackName: idp.track.name,
+      targetLevel: idp.targetLevel,
+      scaleMax: idp.competency.scaleMax,
+      dueDate: idp.dueDate,
+      completedAt: idp.completedAt,
+      status: idp.completedAt
+        ? 'COMPLETED'
+        : idp.dueDate && idp.dueDate < new Date()
+          ? 'OVERDUE'
+          : 'PENDING',
+    }));
+  }
+
+  async completeIdp(orgId: string, memberId: string, idpId: string) {
+    const idp = await this.prisma.memberIdp.findFirst({
+      where: { id: idpId, memberId, orgId },
+    });
+    if (!idp) throw new NotFoundException('IDP not found');
+
+    return this.prisma.memberIdp.update({
+      where: { id: idpId },
+      data: { completedAt: new Date() },
+    });
+  }
+
+  async deleteIdp(orgId: string, memberId: string, idpId: string) {
+    const idp = await this.prisma.memberIdp.findFirst({
+      where: { id: idpId, memberId, orgId },
+    });
+    if (!idp) throw new NotFoundException('IDP not found');
+
+    await this.prisma.memberIdp.delete({ where: { id: idpId } });
+  }
+}

--- a/backend/src/idp/idp.service.ts
+++ b/backend/src/idp/idp.service.ts
@@ -5,16 +5,40 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import {
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Min,
+} from 'class-validator';
 
-export interface UpsertReviewDto {
+export class UpsertReviewDto {
+  @IsString()
+  @MaxLength(2000)
   note: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
   direction?: string;
 }
 
-export interface CreateIdpDto {
+export class CreateIdpDto {
+  @IsUUID()
   competencyId: string;
+
+  @IsUUID()
   trackId: string;
+
+  @IsInt()
+  @Min(1)
   targetLevel: number;
+
+  @IsOptional()
+  @IsISO8601()
   dueDate?: string;
 }
 

--- a/docs/specs/sprint-3-us-b3-competency-certification-srs.md
+++ b/docs/specs/sprint-3-us-b3-competency-certification-srs.md
@@ -1,0 +1,325 @@
+# SRS — US-B3: Chứng nhận năng lực nội bộ & hạn hiệu lực
+
+|                      |                                                                                                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tài liệu**         | Software Requirements Specification (SRS)                                                                                                                                   |
+| **Tính năng**        | US-B3 — Internal Competency Certification with Expiry                                                                                                                       |
+| **Issue**            | [#100](https://github.com/thanhpt-25/brain-gym/issues/100)                                                                                                                  |
+| **Epic**             | B — Chu kỳ đánh giá năng lực định kỳ                                                                                                                                        |
+| **Phiên bản**        | Draft 1.0                                                                                                                                                                   |
+| **Ngày**             | 2026-06-21                                                                                                                                                                  |
+| **Trạng thái**       | Draft — chờ implement                                                                                                                                                       |
+| **Phụ thuộc**        | **US-A1 (#95), US-A2 (#96) closed Sprint 1** ✓ — `Competency`, `JobRoleCompetency` đã có; **US-B1 (#98) closed Sprint 2** ✓ — `AssessmentCampaign`, campaign progress đã có |
+| **Module liên quan** | `competency` (backend mới) · `campaigns` (backend mở rộng) · `src/pages/org/` (frontend)                                                                                    |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-B3**, cho phép hệ thống tự động cấp _chứng nhận năng lực nội bộ_ (`CompetencyCertification`) khi nhân viên đạt ngưỡng `requiredLevel` trong một đợt đánh giá, lưu `achievedLevel` và `expiresAt`, đồng thời cảnh báo khi chứng nhận sắp hết hạn hoặc đã hết hạn.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+
+- Model `CompetencyCertification` — lưu chứng nhận của member cho từng competency, bao gồm `achievedLevel`, `expiresAt`, và `campaignId` gốc.
+- Service `CompetencyCertService.issueByCampaign(campaignId)` — duyệt kết quả campaign, so với `JobRoleCompetency.requiredLevel`, tự cấp cert.
+- Endpoint kích hoạt cấp cert sau khi campaign kết thúc.
+- Endpoint xem danh sách cert của member / của org (với filter sắp hết hạn / đã hết hạn).
+- Báo cáo compliance: danh sách member chưa có cert hoặc cert đã hết hạn theo competency.
+- RBAC: OWNER/ADMIN/MANAGER xem báo cáo; MEMBER tự xem cert của mình.
+
+**Ngoài phạm vi:**
+
+- Gửi email thông báo sắp hết hạn (thuộc US-B2/email module, để Sprint 4).
+- Cert cho recruiting candidate (chỉ cho internal member).
+- Gia hạn cert thủ công bởi Manager (deferred).
+- Public cert link để chia sẻ bên ngoài org (deferred).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ                   | Ý nghĩa                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------- |
+| **CompetencyCertification** | Bản ghi chứng nhận: member đạt level X cho competency Y, có hiệu lực đến `expiresAt`              |
+| **achievedLevel**           | Level đạt được (integer, trong thang `scaleMin`–`scaleMax` của Competency)                        |
+| **requiredLevel**           | `JobRoleCompetency.requiredLevel` — ngưỡng tối thiểu để pass và được cấp cert                     |
+| **expiresAt**               | Thời điểm cert hết hạn (mặc định: `issuedAt + validityMonths`, cấu hình theo org hoặc competency) |
+| **CertStatus**              | ACTIVE (còn hạn) · EXPIRING_SOON (≤ 30 ngày) · EXPIRED (quá hạn)                                  |
+| **ComplianceGap**           | Member có cert EXPIRED hoặc chưa có cert cho một competency bắt buộc theo JobRole                 |
+
+### 1.4. Hiện trạng trước US-B3
+
+- `Competency` (schema L1660): `id`, `orgId`, `name`, `scaleMin`, `scaleMax` — đã có.
+- `JobRoleCompetency` (schema L1712): `jobRoleId`, `competencyId`, `requiredLevel` — đã có.
+- `AssessmentCampaign` (schema L1067): campaign INTERNAL với status DRAFT/ACTIVE/CLOSED — đã có.
+- `OrgMember` — liên kết user với org — đã có.
+- Chưa có model `CompetencyCertification`.
+- Chưa có service/controller cấp cert.
+- Chưa có FE trang cert hoặc báo cáo compliance.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Schema mới: `CompetencyCertification`
+
+Thêm vào `prisma/schema.prisma`:
+
+```prisma
+model CompetencyCertification {
+  id            String    @id @default(uuid())
+  orgId         String    @map("org_id")
+  memberId      String    @map("member_id")
+  competencyId  String    @map("competency_id")
+  campaignId    String?   @map("campaign_id")      // nguồn cấp cert
+  achievedLevel Int       @map("achieved_level")
+  issuedAt      DateTime  @default(now()) @map("issued_at")
+  expiresAt     DateTime  @map("expires_at")
+  revokedAt     DateTime? @map("revoked_at")       // soft-revoke nếu cần
+
+  organization Organization       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  member       OrgMember          @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  competency   Competency         @relation(fields: [competencyId], references: [id], onDelete: Restrict)
+  campaign     AssessmentCampaign? @relation(fields: [campaignId], references: [id])
+
+  @@unique([memberId, competencyId, issuedAt])    // tránh cấp trùng cùng thời điểm
+  @@index([orgId, competencyId])
+  @@index([memberId])
+  @@index([expiresAt])
+  @@map("competency_certifications")
+}
+```
+
+**Mở rộng `Competency`:**
+
+```prisma
+validityMonths  Int  @default(12) @map("validity_months")  // TTL cert tính theo tháng
+```
+
+---
+
+### FR-2 — Cấp cert theo campaign
+
+#### `POST /organizations/:orgId/campaigns/:campaignId/issue-certifications`
+
+**RBAC:** OWNER, ADMIN.
+
+**Điều kiện:** Campaign phải ở trạng thái `CLOSED`.
+
+**Thuật toán:**
+
+```
+1. Load campaign → lấy tất cả OrgExamAssignment của campaign.
+2. Với mỗi assignment → load CandidateInvite (qua catalogItemId → assessment → invite của member).
+3. Load scorecard (reuse ScorecardService.buildForCandidate từ US-E3) với jobRoleId của campaign.
+4. Với mỗi CompetencyScoreItem:
+   a. Nếu passed = true:
+      - Kiểm tra đã có cert ACTIVE cho (memberId, competencyId) chưa?
+        → Nếu có và achievedLevel >= item.normalizedLevel → skip (không downgrade).
+        → Nếu có nhưng achievedLevel < item.normalizedLevel → issue cert mới (upgrade).
+        → Nếu chưa có → issue cert mới.
+      - expiresAt = now() + competency.validityMonths tháng.
+5. Return summary: { issued, skipped, upgraded }.
+```
+
+**Response `200`:**
+
+```json
+{
+  "campaignId": "uuid",
+  "issued": 12,
+  "upgraded": 2,
+  "skipped": 5,
+  "certifications": [
+    {
+      "memberId": "uuid",
+      "memberName": "Nguyen Van A",
+      "competencyId": "uuid",
+      "competencyName": "Cloud Networking",
+      "achievedLevel": 4,
+      "expiresAt": "2027-06-21T00:00:00Z",
+      "action": "ISSUED"
+    }
+  ]
+}
+```
+
+**Lỗi:**
+
+- `400` nếu campaign chưa CLOSED.
+- `404` nếu campaign không thuộc orgId.
+- `409` nếu đã chạy issue cho campaign này (idempotent: re-run safe, skip existing).
+
+---
+
+### FR-3 — Xem cert của member
+
+#### `GET /organizations/:orgId/members/:memberId/certifications`
+
+**RBAC:** OWNER, ADMIN, MANAGER; MEMBER chỉ xem cert của chính mình.
+
+Query params: `status?: ACTIVE | EXPIRING_SOON | EXPIRED | ALL` (default: ALL)
+
+**Tính `status` on-the-fly:**
+
+```
+EXPIRING_SOON: expiresAt <= now() + 30 ngày AND expiresAt > now() AND revokedAt IS NULL
+EXPIRED:       expiresAt <= now() OR revokedAt IS NOT NULL
+ACTIVE:        expiresAt > now() + 30 ngày AND revokedAt IS NULL
+```
+
+**Response `200`:**
+
+```json
+{
+  "memberId": "uuid",
+  "memberName": "Nguyen Van A",
+  "certifications": [
+    {
+      "id": "uuid",
+      "competencyId": "uuid",
+      "competencyName": "Cloud Networking",
+      "achievedLevel": 4,
+      "scaleMax": 5,
+      "issuedAt": "2026-06-21T00:00:00Z",
+      "expiresAt": "2027-06-21T00:00:00Z",
+      "status": "ACTIVE",
+      "campaignName": "Đánh giá Q2/2026"
+    }
+  ]
+}
+```
+
+---
+
+### FR-4 — Báo cáo compliance
+
+#### `GET /organizations/:orgId/certifications/compliance`
+
+**RBAC:** OWNER, ADMIN.
+
+Query params: `competencyId?`, `groupId?`, `status?: ACTIVE | EXPIRING_SOON | EXPIRED`
+
+**Mục đích:** Danh sách member theo trạng thái cert cho từng competency bắt buộc. Phục vụ dashboard điều hành (US-G1).
+
+**Response `200`:**
+
+```json
+{
+  "summary": {
+    "totalMembers": 45,
+    "certified": 30,
+    "expiringSoon": 5,
+    "expired": 4,
+    "notCertified": 6
+  },
+  "rows": [
+    {
+      "memberId": "uuid",
+      "memberName": "Tran Thi B",
+      "competencyId": "uuid",
+      "competencyName": "Security",
+      "certStatus": "EXPIRED",
+      "expiresAt": "2026-01-15T00:00:00Z",
+      "achievedLevel": 3,
+      "requiredLevel": 4
+    }
+  ]
+}
+```
+
+---
+
+### FR-5 — Xem cert theo org
+
+#### `GET /organizations/:orgId/certifications`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+Query params: `competencyId?`, `groupId?`, `status?`, `page`, `limit` (default 20).
+
+Response `200`: paginated list của `CompetencyCertification` kèm member name, competency name, status.
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR                   | Mô tả                                                                          |
+| --------------------- | ------------------------------------------------------------------------------ |
+| **Idempotent issue**  | Gọi lại `issue-certifications` nhiều lần → skip cert đã có (không tạo trùng)   |
+| **No downgrade**      | Không ghi cert mới nếu `achievedLevel` mới thấp hơn cert ACTIVE hiện tại       |
+| **RBAC member scope** | MEMBER chỉ đọc cert của chính mình; 403 nếu truy cập cert của người khác       |
+| **Org isolation**     | Mọi query filter theo `orgId`; competency của org khác không visible           |
+| **Index expiry**      | `@@index([expiresAt])` — cho cron job quét hết hạn và báo cáo compliance       |
+| **Soft-revoke**       | `revokedAt IS NOT NULL` = cert bị thu hồi; không xóa vật lý để giữ audit trail |
+
+---
+
+## 4. API Contract tổng hợp
+
+| Method | Path                                                       | RBAC                             | Mô tả                                  |
+| ------ | ---------------------------------------------------------- | -------------------------------- | -------------------------------------- |
+| POST   | `/organizations/:orgId/campaigns/:id/issue-certifications` | OWNER, ADMIN                     | Cấp cert hàng loạt sau campaign CLOSED |
+| GET    | `/organizations/:orgId/members/:memberId/certifications`   | OWNER,ADMIN,MANAGER,MEMBER(self) | Cert của member                        |
+| GET    | `/organizations/:orgId/certifications`                     | OWNER,ADMIN,MANAGER              | Danh sách cert toàn org                |
+| GET    | `/organizations/:orgId/certifications/compliance`          | OWNER, ADMIN                     | Báo cáo compliance gap                 |
+
+---
+
+## 5. Giao diện người dùng
+
+### 5.1. Campaign Detail — nút "Cấp chứng nhận"
+
+- Hiển thị khi `campaign.status = CLOSED`.
+- Nút "Cấp chứng nhận năng lực" → gọi POST issue-certifications → hiện modal kết quả (X cấp mới, Y nâng cấp, Z bỏ qua).
+
+### 5.2. Member Profile — tab "Chứng nhận"
+
+- Bảng: Năng lực | Level đạt được | Ngày cấp | Hết hạn | Trạng thái (badge ACTIVE / EXPIRING / EXPIRED).
+- Filter theo trạng thái.
+
+### 5.3. Trang Compliance (`/org/:slug/competency/compliance`)
+
+- Summary cards: Đã chứng nhận / Sắp hết hạn / Đã hết hạn / Chưa có cert.
+- Table chi tiết với filter group, competency, status.
+- Nút "Xuất CSV".
+
+---
+
+## 6. Test Cases
+
+| #   | Tình huống                                                 | Kết quả mong đợi                             |
+| --- | ---------------------------------------------------------- | -------------------------------------------- |
+| T1  | Issue cert cho campaign CLOSED, member passed 2 competency | 2 CompetencyCertification mới, action=ISSUED |
+| T2  | Issue cert cho campaign ACTIVE (chưa CLOSED)               | 400 Bad Request                              |
+| T3  | Member đã có cert ACTIVE level 4; tái đánh giá đạt level 3 | skip (không downgrade), action=SKIPPED       |
+| T4  | Member đã có cert ACTIVE level 3; tái đánh giá đạt level 4 | cert mới level 4 được cấp, action=UPGRADED   |
+| T5  | Gọi issue-certifications lần 2 cùng campaign               | Tất cả SKIPPED, không trùng lặp              |
+| T6  | GET certifications với status=EXPIRING_SOON                | Chỉ cert có expiresAt trong 30 ngày tới      |
+| T7  | MEMBER xem cert của member khác                            | 403 Forbidden                                |
+| T8  | GET compliance: 5 member thiếu cert Security               | summary.notCertified=5, rows đúng            |
+| T9  | Competency validityMonths=6; issue cert                    | expiresAt = issuedAt + 6 tháng               |
+| T10 | ADMIN revoke cert (set revokedAt)                          | status=EXPIRED trong response tiếp theo      |
+
+---
+
+## 7. Thứ tự implement
+
+1. **Migration** — thêm `CompetencyCertification`, field `validityMonths` vào `Competency`.
+2. **CompetencyCertService** — `issueByCampaign`, `findByMember`, `findByOrg`, `getCompliance`.
+3. **CompetencyCertController** — 4 endpoints; RBAC guards.
+4. **Module** — tạo `competency-cert.module.ts`, import vào `OrgsModule`.
+5. **FE Campaign Detail** — nút "Cấp chứng nhận" + modal kết quả.
+6. **FE Member Profile** — tab Chứng nhận.
+7. **FE Compliance page** — `/org/:slug/competency/compliance`.
+8. **Tests** — unit CompetencyCertService (T1–T5), integration (full flow campaign CLOSED → issue → GET).
+
+---
+
+## 8. Open Questions
+
+- `issue-certifications` nên chạy tự động khi campaign chuyển CLOSED không? (Đề xuất: thủ công MVP — Admin nhấn nút; auto-trigger để Sprint 4.)
+- Cần email thông báo sắp hết hạn không? (Đề xuất: defer — đã có US-C3 email template cho Sprint 4.)
+- `validityMonths` cấu hình per-competency hay per-org? (Đề xuất: per-competency, default 12 tháng — linh hoạt hơn.)

--- a/docs/specs/sprint-3-us-b4-manager-review-idp-srs.md
+++ b/docs/specs/sprint-3-us-b4-manager-review-idp-srs.md
@@ -1,0 +1,376 @@
+# SRS — US-B4: Review của quản lý + Kế hoạch phát triển (IDP)
+
+|                      |                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Tài liệu**         | Software Requirements Specification (SRS)                                                                                        |
+| **Tính năng**        | US-B4 — Manager Review & Individual Development Plan (IDP)                                                                       |
+| **Issue**            | [#101](https://github.com/thanhpt-25/brain-gym/issues/101)                                                                       |
+| **Epic**             | B — Chu kỳ đánh giá năng lực định kỳ                                                                                             |
+| **Phiên bản**        | Draft 1.0                                                                                                                        |
+| **Ngày**             | 2026-06-21                                                                                                                       |
+| **Trạng thái**       | Draft — chờ implement                                                                                                            |
+| **Phụ thuộc**        | **US-A3 (#97) closed Sprint 1** ✓ — competency gap profile đã có; **US-B1 (#98) closed Sprint 2** ✓ — `AssessmentCampaign` đã có |
+| **Module liên quan** | `campaigns` (backend mở rộng) · `competency` (backend mở rộng) · `src/pages/org/` (frontend)                                     |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-B4**, cho phép Manager thêm nhận xét/định hướng sau mỗi đợt đánh giá theo từng member, gợi ý `LearningTrack` để đóng competency gap, và tạo liên kết IDP hiển thị cho nhân viên — biến điểm số thành kế hoạch hành động cụ thể.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+
+- Model `CampaignMemberReview` — ghi chú của manager cho từng member trong một campaign cụ thể.
+- Model `MemberIdp` — kế hoạch phát triển cá nhân: liên kết member với LearningTrack theo từng competency gap.
+- Service + endpoints: tạo/cập nhật review, gợi ý LearningTrack theo gap, xem IDP của member.
+- RBAC: OWNER/ADMIN/MANAGER tạo review và IDP; MEMBER đọc IDP của chính mình.
+
+**Ngoài phạm vi:**
+
+- Approval workflow cho IDP (deferred).
+- Tích hợp LMS bên ngoài để enroll LearningTrack (deferred).
+- Gửi notification khi IDP được cập nhật (thuộc email module Sprint 4).
+- Auto-generate gợi ý bằng AI (deferred).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ                | Ý nghĩa                                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| **CampaignMemberReview** | Ghi chú của manager cho một member trong một campaign — riêng biệt theo (campaignId, memberId)      |
+| **MemberIdp**            | Kế hoạch phát triển cá nhân: gắn LearningTrack vào một competency gap, với target level và deadline |
+| **CompetencyGap**        | Hiệu số giữa `JobRoleCompetency.requiredLevel` và score thực tế của member — từ US-A3 gap profile   |
+| **LearningTrack**        | Model đã có (schema L1039): nhóm catalog exam theo chủ đề, thuộc org                                |
+
+### 1.4. Hiện trạng trước US-B4
+
+- `AssessmentCampaign` (schema L1067) — đã có.
+- `LearningTrack` (schema L1039): `id`, `orgId`, `name`, `description`, `isActive` — đã có, chưa liên kết với member gap.
+- `OrgMember` — đã có.
+- Competency gap data có sẵn qua `CandidateInvite.domainScores` + `ScorecardService` (US-E3).
+- Chưa có model `CampaignMemberReview`.
+- Chưa có model `MemberIdp`.
+- Chưa có endpoint hoặc UI cho manager review và IDP.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Schema mới: `CampaignMemberReview`
+
+```prisma
+model CampaignMemberReview {
+  id          String   @id @default(uuid())
+  orgId       String   @map("org_id")
+  campaignId  String   @map("campaign_id")
+  memberId    String   @map("member_id")
+  reviewedBy  String   @map("reviewed_by")        // userId của manager
+  note        String   @db.Text                   // nhận xét tự do
+  direction   String?  @db.Text                   // định hướng phát triển
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  organization Organization       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  campaign     AssessmentCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  member       OrgMember          @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  reviewer     User               @relation(fields: [reviewedBy], references: [id])
+
+  @@unique([campaignId, memberId])               // 1 review per (campaign, member)
+  @@index([orgId, memberId])
+  @@map("campaign_member_reviews")
+}
+```
+
+---
+
+### FR-2 — Schema mới: `MemberIdp`
+
+```prisma
+model MemberIdp {
+  id             String    @id @default(uuid())
+  orgId          String    @map("org_id")
+  memberId       String    @map("member_id")
+  competencyId   String    @map("competency_id")
+  trackId        String    @map("track_id")
+  targetLevel    Int       @map("target_level")   // level mục tiêu cần đạt
+  dueDate        DateTime? @map("due_date")
+  completedAt    DateTime? @map("completed_at")
+  createdBy      String    @map("created_by")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
+
+  organization Organization  @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  member       OrgMember     @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  competency   Competency    @relation(fields: [competencyId], references: [id], onDelete: Restrict)
+  track        LearningTrack @relation(fields: [trackId], references: [id], onDelete: Restrict)
+  creator      User          @relation(fields: [createdBy], references: [id])
+
+  @@unique([memberId, competencyId, trackId])    // tránh gán trùng track cho cùng 1 gap
+  @@index([orgId, memberId])
+  @@map("member_idps")
+}
+```
+
+---
+
+### FR-3 — Tạo / cập nhật Manager Review
+
+#### `PUT /organizations/:orgId/campaigns/:campaignId/members/:memberId/review`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+**Ngữ nghĩa:** Upsert — tạo mới nếu chưa có, cập nhật nếu đã có (unique: campaignId + memberId).
+
+Request body:
+
+```json
+{
+  "note": "Bạn thể hiện tốt ở domain Networking nhưng cần cải thiện Security.",
+  "direction": "Tham gia LearningTrack Security Fundamentals trước Q4/2026."
+}
+```
+
+**Validation:**
+
+- `note`: required, tối đa 2000 ký tự.
+- `direction`: optional, tối đa 2000 ký tự.
+- `memberId` phải thuộc `orgId`.
+- `campaignId` phải thuộc `orgId`.
+
+Response `200`:
+
+```json
+{
+  "id": "uuid",
+  "campaignId": "uuid",
+  "memberId": "uuid",
+  "memberName": "Nguyen Van A",
+  "note": "...",
+  "direction": "...",
+  "reviewedBy": "uuid",
+  "reviewerName": "Tran Manager",
+  "updatedAt": "ISO8601"
+}
+```
+
+---
+
+#### `GET /organizations/:orgId/campaigns/:campaignId/members/:memberId/review`
+
+**RBAC:** OWNER, ADMIN, MANAGER; MEMBER chỉ xem review của chính mình.
+
+Response `200`: object review hoặc `null` nếu chưa có review.
+
+---
+
+#### `GET /organizations/:orgId/campaigns/:campaignId/reviews`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+Response `200`: danh sách tất cả review trong campaign, kèm member name và reviewer name.
+
+---
+
+### FR-4 — Gợi ý LearningTrack theo gap
+
+#### `GET /organizations/:orgId/members/:memberId/idp/suggestions`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+**Logic gợi ý:**
+
+```
+1. Load competency gap của member (từ CompetencyCertification + JobRoleCompetency):
+   gap = requiredLevel - achievedLevel (chỉ lấy gap > 0 hoặc EXPIRED cert).
+2. Load tất cả LearningTrack của org đang isActive.
+3. Match: track.name ILIKE competency.name hoặc track.description ILIKE competency.name.
+   → Nếu không có match → trả về tất cả track (manager tự chọn).
+4. Trả về danh sách gợi ý kèm gap info.
+```
+
+Response `200`:
+
+```json
+{
+  "memberId": "uuid",
+  "memberName": "Nguyen Van A",
+  "gaps": [
+    {
+      "competencyId": "uuid",
+      "competencyName": "Security",
+      "currentLevel": 2,
+      "requiredLevel": 4,
+      "gap": 2,
+      "suggestedTracks": [
+        {
+          "trackId": "uuid",
+          "trackName": "Security Fundamentals",
+          "description": "Khóa nền tảng về bảo mật mạng"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### FR-5 — Tạo / cập nhật IDP
+
+#### `POST /organizations/:orgId/members/:memberId/idp`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+Request body:
+
+```json
+{
+  "competencyId": "uuid",
+  "trackId": "uuid",
+  "targetLevel": 4,
+  "dueDate": "2026-12-31T00:00:00Z"
+}
+```
+
+**Validation:**
+
+- `competencyId` và `trackId` phải thuộc `orgId`.
+- `targetLevel` trong khoảng `[competency.scaleMin, competency.scaleMax]`.
+- Unique: (memberId, competencyId, trackId) — 409 nếu đã tồn tại.
+
+Response `201`: IDP item đã tạo.
+
+---
+
+#### `GET /organizations/:orgId/members/:memberId/idp`
+
+**RBAC:** OWNER, ADMIN, MANAGER; MEMBER chỉ xem IDP của chính mình.
+
+Response `200`:
+
+```json
+{
+  "memberId": "uuid",
+  "memberName": "Nguyen Van A",
+  "idp": [
+    {
+      "id": "uuid",
+      "competencyName": "Security",
+      "trackName": "Security Fundamentals",
+      "targetLevel": 4,
+      "dueDate": "2026-12-31T00:00:00Z",
+      "completedAt": null,
+      "status": "IN_PROGRESS"
+    }
+  ]
+}
+```
+
+`status`: `IN_PROGRESS` (chưa xong, chưa hết hạn) · `OVERDUE` (hết hạn chưa xong) · `COMPLETED`.
+
+---
+
+#### `PATCH /organizations/:orgId/members/:memberId/idp/:idpId`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+Body: `{ "completedAt"?: ISO8601, "dueDate"?: ISO8601, "targetLevel"?: number }`.
+
+Response `200`: IDP item đã cập nhật.
+
+---
+
+#### `DELETE /organizations/:orgId/members/:memberId/idp/:idpId`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+Response `204`.
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR                | Mô tả                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| **RBAC self-read** | MEMBER chỉ đọc review và IDP của chính mình; 403 nếu truy cập data người khác        |
+| **Upsert review**  | `PUT review` idempotent — gọi lại cùng body → update, không tạo trùng                |
+| **Soft data**      | IDP không hard-delete campaign data — chỉ xóa MemberIdp record, không ảnh hưởng cert |
+| **Org isolation**  | Tất cả lookup filter theo `orgId`                                                    |
+
+---
+
+## 4. API Contract tổng hợp
+
+| Method | Path                                                       | RBAC                             | Mô tả                        |
+| ------ | ---------------------------------------------------------- | -------------------------------- | ---------------------------- |
+| PUT    | `/organizations/:orgId/campaigns/:cid/members/:mid/review` | OWNER,ADMIN,MANAGER              | Upsert manager review        |
+| GET    | `/organizations/:orgId/campaigns/:cid/members/:mid/review` | OWNER,ADMIN,MANAGER,MEMBER(self) | Xem review của member        |
+| GET    | `/organizations/:orgId/campaigns/:cid/reviews`             | OWNER,ADMIN,MANAGER              | Tất cả review trong campaign |
+| GET    | `/organizations/:orgId/members/:mid/idp/suggestions`       | OWNER,ADMIN,MANAGER              | Gợi ý LearningTrack theo gap |
+| POST   | `/organizations/:orgId/members/:mid/idp`                   | OWNER,ADMIN,MANAGER              | Thêm IDP item                |
+| GET    | `/organizations/:orgId/members/:mid/idp`                   | OWNER,ADMIN,MANAGER,MEMBER(self) | Xem IDP của member           |
+| PATCH  | `/organizations/:orgId/members/:mid/idp/:idpId`            | OWNER,ADMIN,MANAGER              | Cập nhật IDP item            |
+| DELETE | `/organizations/:orgId/members/:mid/idp/:idpId`            | OWNER,ADMIN,MANAGER              | Xóa IDP item                 |
+
+---
+
+## 5. Giao diện người dùng
+
+### 5.1. Campaign Detail — tab "Đánh giá thành viên"
+
+- Table: Member name | Điểm trung bình | Số competency đạt | Trạng thái review (Đã review / Chưa review).
+- Click vào row → mở panel bên phải với form review (note + direction).
+- Nút "Xem gap & gợi ý track" → load suggestions, cho phép tạo IDP ngay.
+
+### 5.2. Member Profile — tab "Kế hoạch phát triển (IDP)"
+
+- Bảng IDP: Năng lực | LearningTrack | Target Level | Deadline | Trạng thái.
+- Badge IN_PROGRESS (xanh) / OVERDUE (đỏ) / COMPLETED (xám).
+- Nút "Đánh dấu hoàn thành" (Manager).
+- MEMBER xem readonly.
+
+### 5.3. Campaign Detail — xem tổng quan review
+
+- Thanh tiến độ "X / Y members đã được review".
+- Filter: Đã review / Chưa review.
+
+---
+
+## 6. Test Cases
+
+| #   | Tình huống                                       | Kết quả mong đợi                                       |
+| --- | ------------------------------------------------ | ------------------------------------------------------ |
+| T1  | Manager PUT review lần đầu                       | 200, review mới được tạo                               |
+| T2  | Manager PUT review lần 2 cùng (campaign, member) | 200, review cũ được cập nhật (upsert)                  |
+| T3  | MEMBER xem review của chính mình                 | 200, trả về review                                     |
+| T4  | MEMBER xem review của member khác                | 403 Forbidden                                          |
+| T5  | GET suggestions: member có gap Security level 2  | trả về tracks match "Security"                         |
+| T6  | POST IDP với trackId không thuộc org             | 400 Bad Request                                        |
+| T7  | POST IDP trùng (memberId, competencyId, trackId) | 409 Conflict                                           |
+| T8  | PATCH IDP set completedAt                        | status = COMPLETED trong GET tiếp theo                 |
+| T9  | GET IDP: dueDate đã qua, completedAt = null      | status = OVERDUE                                       |
+| T10 | GET /campaigns/:id/reviews                       | trả về tất cả review trong campaign, kèm reviewer name |
+
+---
+
+## 7. Thứ tự implement
+
+1. **Migration** — thêm `CampaignMemberReview`, `MemberIdp`.
+2. **CampaignReviewService** — upsert review, list reviews per campaign.
+3. **IdpService** — suggestions, CRUD IDP, status computation.
+4. **Controllers** — mount review dưới campaigns, IDP dưới members.
+5. **Module** — extend `campaigns.module.ts`; tạo `idp.module.ts` hoặc extend `competency.module.ts`.
+6. **FE Campaign Detail** — tab "Đánh giá thành viên" + panel review + IDP modal.
+7. **FE Member Profile** — tab IDP.
+8. **Tests** — unit IdpService (T5, T8, T9), integration (full review + IDP flow).
+
+---
+
+## 8. Open Questions
+
+- Gợi ý track hiện dùng text matching đơn giản. Có cần vector similarity không? (Đề xuất: text matching MVP; AI suggestion để Sprint 4+.)
+- IDP có cần approval từ member không? (Đề xuất: không — manager tạo, member đọc; approval deferred.)
+- Có cho MEMBER tự tạo IDP không? (Đề xuất: không trong MVP — chỉ Manager/Admin; self-serve để Sprint 4.)

--- a/docs/specs/sprint-3-us-d1-unique-question-sets-srs.md
+++ b/docs/specs/sprint-3-us-d1-unique-question-sets-srs.md
@@ -1,0 +1,272 @@
+# SRS — US-D1: Bộ đề duy nhất mỗi ứng viên + ngân hàng lớn
+
+|                      |                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Tài liệu**         | Software Requirements Specification (SRS)                                                                                        |
+| **Tính năng**        | US-D1 — Unique Question Sets per Candidate + Large Pool                                                                          |
+| **Issue**            | [#105](https://github.com/thanhpt-25/brain-gym/issues/105)                                                                       |
+| **Epic**             | D — Tăng cường chống gian lận                                                                                                    |
+| **Phiên bản**        | Draft 1.0                                                                                                                        |
+| **Ngày**             | 2026-06-21                                                                                                                       |
+| **Trạng thái**       | Draft — chờ implement                                                                                                            |
+| **Phụ thuộc**        | Nền tảng `drawFromPool` đã có (`assessments.service.ts` L176); `drawnQuestionIds` snapshot trên `CandidateInvite` (schema L1207) |
+| **Module liên quan** | `assessments` (backend mở rộng) · Assessment Settings page (frontend mở rộng)                                                    |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-D1**, tăng cường tính ngẫu nhiên và độ phủ khi rút đề từ pool lớn: đảm bảo mỗi ứng viên nhận tổ hợp câu hỏi khác nhau, cung cấp báo cáo độ trùng đề giữa các ứng viên, và cảnh báo Recruiter khi pool quá nhỏ so với số ứng viên mời.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+
+- Kiểm tra pool size so với số candidate đã invite — cảnh báo khi pool quá nhỏ.
+- Báo cáo overlap: tỷ lệ câu hỏi trùng giữa các invite trong cùng assessment (dựa trên `drawnQuestionIds`).
+- Endpoint xem thống kê pool và overlap.
+- Validation khi publish assessment ở chế độ POOL/BLUEPRINT: đủ câu hỏi cho dự kiến số ứng viên.
+- Cải thiện `drawFromPool`: đảm bảo tối đa hóa sự khác biệt giữa các lần draw (prioritize least-used questions).
+
+**Ngoài phạm vi:**
+
+- Thay đổi cơ bản thuật toán POOL/BLUEPRINT (vẫn dùng random draw, chỉ thêm đảm bảo).
+- Webcam proctoring (US-D3 Sprint 4).
+- Phát hiện hành vi chia sẻ đáp án (analytics nâng cao — deferred).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ            | Ý nghĩa                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------- | ----- | --- | ----- | ---------------------- |
+| **Pool**             | Tập hợp câu hỏi có thể rút — từ `AssessmentQuestion` (MANUAL) hoặc cert/category (POOL mode)        |
+| **drawnQuestionIds** | Snapshot array của câu hỏi đã rút cho invite này (`CandidateInvite.drawnQuestionIds`, schema L1207) |
+| **Overlap ratio**    | Tỷ lệ câu hỏi trùng giữa 2 invite: `                                                                | A ∩ B | /   | A ∪ B | ` (Jaccard similarity) |
+| **Pool coverage**    | Tỷ lệ câu hỏi trong pool đã được sử dụng bởi ít nhất 1 invite                                       |
+| **Min pool ratio**   | Ngưỡng tối thiểu: pool size / draw count — khuyến nghị ≥ 3x để đảm bảo đa dạng                      |
+
+### 1.4. Hiện trạng trước US-D1
+
+- `Assessment.selectionMode` — MANUAL / POOL / BLUEPRINT — đã có.
+- `Assessment.selectionConfig` JSON — cấu hình pool draw (`drawCount`, `certificationId`, `categories`) — đã có.
+- `CandidateInvite.drawnQuestionIds` String[] — snapshot đã được lưu khi draw — đã có.
+- `drawFromPool()` (`assessments.service.ts` L176) — rút ngẫu nhiên từ pool — đã có.
+- Chưa có: kiểm tra pool size vs candidate count, báo cáo overlap, least-used draw priority.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Kiểm tra pool size khi invite
+
+Mở rộng `CandidateService.inviteCandidate()`:
+
+**Trước khi tạo invite mới:**
+
+1. Đếm pool size: số câu hỏi khả dụng theo `selectionConfig` của assessment.
+2. Tính `drawCount` (số câu mỗi invite cần rút).
+3. Nếu `poolSize / drawCount < MIN_POOL_RATIO` (mặc định 2.0):
+   - **Không chặn** — vẫn tạo invite.
+   - Trả về warning trong response: `{ "warning": "POOL_TOO_SMALL", "poolSize": 20, "drawCount": 15, "ratio": 1.33 }`.
+4. Nếu `poolSize < drawCount`:
+   - **Chặn** — 400 Bad Request: `"Không đủ câu hỏi trong pool (cần ${drawCount}, có ${poolSize})"`.
+
+`MIN_POOL_RATIO` có thể cấu hình qua env var `POOL_MIN_RATIO` (default: `2.0`).
+
+---
+
+### FR-2 — Least-used draw priority
+
+Cải thiện `drawFromPool()` để ưu tiên câu hỏi chưa hoặc ít được rút nhất:
+
+**Thuật toán mới:**
+
+```
+1. Load pool candidates (như hiện tại).
+2. Load usage count cho từng câu trong pool:
+   usage[qId] = COUNT of invites in this assessment WHERE drawnQuestionIds CONTAINS qId
+3. Sắp xếp pool theo usage ASC (ít dùng nhất → ưu tiên cao hơn).
+4. Chia pool thành 2 nhóm:
+   - low_use: usage <= percentile_25 của pool
+   - rest: phần còn lại
+5. Draw: 70% từ low_use (nếu đủ), 30% từ rest → shuffle kết quả cuối.
+   Nếu low_use < 0.7 * drawCount → draw toàn random (fallback hiện tại).
+6. Snapshot drawnQuestionIds như hiện tại.
+```
+
+> **Lưu ý hiệu năng:** Usage count query chạy một lần per invite. Khi pool > 5000 câu, thêm `@@index([assessmentId])` trên drawn_question_ids (array index PostgreSQL GIN).
+
+---
+
+### FR-3 — Báo cáo overlap
+
+#### `GET /organizations/:orgId/assessments/:assessmentId/pool-stats`
+
+**RBAC:** OWNER, ADMIN, MANAGER, RECRUITER.
+
+**Tính toán:**
+
+1. Load tất cả invite đã SUBMITTED của assessment, lấy `drawnQuestionIds`.
+2. Tính pairwise Jaccard overlap cho tất cả cặp (O(n²) — giới hạn tính toán cho ≤ 500 invite; trả về `approximated: true` nếu vượt).
+3. Tính pool coverage: distinct question IDs đã được dùng / pool size.
+
+Response `200`:
+
+```json
+{
+  "assessmentId": "uuid",
+  "poolSize": 120,
+  "drawCount": 30,
+  "poolRatio": 4.0,
+  "poolWarning": false,
+  "totalInvites": 45,
+  "submittedInvites": 38,
+  "poolCoverage": 0.87,
+  "overlap": {
+    "approximated": false,
+    "avgJaccard": 0.12,
+    "maxJaccard": 0.31,
+    "highOverlapPairs": [
+      {
+        "invite1": "uuid",
+        "invite2": "uuid",
+        "candidate1": "nguyenvana@example.com",
+        "candidate2": "tranthib@example.com",
+        "jaccard": 0.31,
+        "sharedQuestions": 9
+      }
+    ]
+  },
+  "usageDistribution": {
+    "used0Times": 15,
+    "used1Time": 42,
+    "used2To5Times": 38,
+    "usedOver5Times": 25
+  }
+}
+```
+
+`highOverlapPairs`: tất cả cặp có `jaccard > 0.3` (configurable).
+
+---
+
+### FR-4 — Cảnh báo khi publish assessment
+
+Mở rộng `POST /organizations/:orgId/assessments/:assessmentId/publish`:
+
+**Thêm pool validation trước khi publish** (chỉ áp dụng với selectionMode = POOL hoặc BLUEPRINT):
+
+1. Tính pool size theo `selectionConfig`.
+2. Nếu `poolSize / drawCount < 2.0` → trả về warning trong response (không chặn publish).
+3. Nếu `poolSize < drawCount` → **chặn publish** với 400: `"Pool không đủ câu hỏi để phát đề"`.
+
+---
+
+### FR-5 — Hiển thị pool info trong Assessment Settings
+
+#### `GET /organizations/:orgId/assessments/:assessmentId/pool-info`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+Response `200`:
+
+```json
+{
+  "selectionMode": "POOL",
+  "poolSize": 120,
+  "drawCount": 30,
+  "poolRatio": 4.0,
+  "warning": null,
+  "recommendedPoolSize": 90
+}
+```
+
+`recommendedPoolSize = drawCount * MIN_POOL_RATIO * 1.5` (buffer 50%).
+
+`warning`: `null` | `"POOL_TOO_SMALL"` | `"POOL_CRITICAL"` (ratio < 1.5).
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR                 | Mô tả                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Backward compat** | `drawFromPool` fallback về random thuần nếu usage data không có hoặc pool quá nhỏ                         |
+| **Performance**     | Pool-stats tính toán pairwise chỉ với ≤ 500 invite; vượt ngưỡng → `approximated: true`, sample 200 invite |
+| **Non-blocking**    | Pool size warning không chặn invite — chỉ thêm field `warning` trong response                             |
+| **Pool isolation**  | Mỗi assessment có pool riêng; drawnQuestionIds không chia sẻ giữa assessment                              |
+| **GIN index**       | Thêm GIN index trên `candidate_invites.drawn_question_ids` nếu query scan > 1000 rows                     |
+
+---
+
+## 4. API Contract tổng hợp
+
+| Method | Path                                                | RBAC                          | Mô tả                        |
+| ------ | --------------------------------------------------- | ----------------------------- | ---------------------------- |
+| GET    | `/organizations/:orgId/assessments/:aid/pool-stats` | OWNER,ADMIN,MANAGER,RECRUITER | Overlap report + pool stats  |
+| GET    | `/organizations/:orgId/assessments/:aid/pool-info`  | OWNER,ADMIN,MANAGER           | Pool size check cho settings |
+
+_(Các endpoint invite và publish đã có — chỉ mở rộng logic.)_
+
+---
+
+## 5. Giao diện người dùng
+
+### 5.1. Assessment Settings — card "Pool & Đề thi"
+
+- Hiển thị: Pool size / Draw count / Pool ratio.
+- Badge cảnh báo: "⚠ Pool nhỏ (ratio 1.3x — khuyến nghị ≥ 2x)" màu vàng nếu ratio < 2.
+- Badge nguy hiểm: "✗ Pool không đủ (cần 30 câu, có 25)" màu đỏ nếu poolSize < drawCount.
+- Nút "Xem báo cáo đề" → mở trang pool-stats.
+
+### 5.2. Trang Pool Stats (`/org/:slug/assessments/:id/pool-stats`)
+
+- Cards: Pool coverage % | Avg overlap | Max overlap | Số cặp overlap cao.
+- Table "Cặp ứng viên overlap cao": Ứng viên 1 | Ứng viên 2 | % trùng | Số câu trùng.
+- Bar chart: phân phối usage (dùng 0 lần / 1 lần / 2-5 lần / >5 lần).
+
+### 5.3. Invite flow — warning
+
+Khi Recruiter invite và pool ratio thấp:
+
+- Toast warning màu vàng: "Lưu ý: pool câu hỏi nhỏ (ratio 1.3x). Xem xét thêm câu hỏi để giảm trùng đề."
+- Invite vẫn được tạo bình thường.
+
+---
+
+## 6. Test Cases
+
+| #   | Tình huống                                          | Kết quả mong đợi                                                |
+| --- | --------------------------------------------------- | --------------------------------------------------------------- |
+| T1  | Pool 30 câu, draw 30 → invite                       | Invite thành công nhưng warning POOL_CRITICAL (ratio=1.0)       |
+| T2  | Pool 25 câu, draw 30 → invite                       | 400 Bad Request "Pool không đủ"                                 |
+| T3  | Pool 120 câu, draw 30 → invite                      | Invite thành công, không warning                                |
+| T4  | 2 invite với pool 30 câu, draw 15 (ratio=2)         | avgJaccard < 0.5, drawnQuestionIds khác nhau đáng kể            |
+| T5  | drawFromPool: 10 câu dùng 0 lần, 20 câu dùng 5+ lần | Draw ưu tiên 10 câu chưa dùng (xuất hiện nhiều hơn trong drawn) |
+| T6  | GET pool-stats: 2 invite share 9/30 câu             | jaccard = 9/(30+30-9) = 0.176                                   |
+| T7  | Publish assessment với poolSize < drawCount         | 400 chặn publish                                                |
+| T8  | GET pool-stats assessment selectionMode=MANUAL      | poolSize = số câu MANUAL, overlap tính bình thường              |
+| T9  | GET pool-stats > 500 invite                         | approximated=true, tính sample 200 invite                       |
+| T10 | Tạo invite thứ 2 trong pool nhỏ: least-used draw    | Câu hỏi chưa dùng xuất hiện với tần suất cao hơn                |
+
+---
+
+## 7. Thứ tự implement
+
+1. **Pool validation** — mở rộng `inviteCandidate()`: đếm pool size, trả về warning/error.
+2. **Least-used draw** — cải thiện `drawFromPool()` với usage-aware selection.
+3. **pool-info endpoint** — truy vấn đơn giản, không cần migration.
+4. **pool-stats endpoint** — tính Jaccard overlap + coverage; thêm GIN index nếu cần.
+5. **Publish validation** — mở rộng publish endpoint với pool check.
+6. **FE Assessment Settings** — card Pool info + badge warning.
+7. **FE Pool Stats page** — overlap table + usage chart.
+8. **Tests** — unit drawFromPool (T4, T5), unit Jaccard (T6), integration (T1, T2, T3, T7).
+
+---
+
+## 8. Open Questions
+
+- Least-used draw có tốn quá nhiều query không khi pool lớn? (Đề xuất: Redis cache usage map per assessment, TTL 5 phút.)
+- `MIN_POOL_RATIO = 2.0` — có nên cấu hình per-org không? (Đề xuất: env var global MVP; per-org setting để Sprint 4.)
+- Threshold `highOverlapPairs > 0.3` — hardcode hay configurable per assessment? (Đề xuất: configurable field trên `Assessment` — default 0.3.)

--- a/docs/specs/sprint-3-us-d2-advanced-proctoring-srs.md
+++ b/docs/specs/sprint-3-us-d2-advanced-proctoring-srs.md
@@ -1,0 +1,324 @@
+# SRS — US-D2: Proctoring nâng cao & cờ rủi ro
+
+|                      |                                                                                                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Tài liệu**         | Software Requirements Specification (SRS)                                                                                                                                            |
+| **Tính năng**        | US-D2 — Advanced Proctoring & Risk Flags                                                                                                                                             |
+| **Issue**            | [#106](https://github.com/thanhpt-25/brain-gym/issues/106)                                                                                                                           |
+| **Epic**             | D — Tăng cường chống gian lận                                                                                                                                                        |
+| **Phiên bản**        | Draft 1.0                                                                                                                                                                            |
+| **Ngày**             | 2026-06-21                                                                                                                                                                           |
+| **Trạng thái**       | Draft — chờ implement                                                                                                                                                                |
+| **Phụ thuộc**        | `CandidateEvent` (schema L1245) đã có; `calcIntegrityScore()` (`candidate.service.ts` L413) đã có; `getEvents()` (L396) đã có; `CandidateInvite.integrityScore` (schema L1201) đã có |
+| **Module liên quan** | `assessments` (backend mở rộng) · `AssessmentResults` page (frontend mở rộng)                                                                                                        |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-D2**, cho phép Recruiter xem nhật ký sự kiện `CandidateEvent` dưới dạng timeline trực quan trong trang kết quả, với cờ rủi ro tự động theo ngưỡng cấu hình được, và filter ứng viên theo `integrityScore`.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+
+- API trả về `CandidateEvent` timeline cho một invite.
+- Cấu hình ngưỡng rủi ro per-assessment: `riskThreshold` (integrity score tối thiểu để được coi là "sạch").
+- Endpoint filter ứng viên theo `integrityScore < riskThreshold`.
+- Đánh dấu (flag) ứng viên nghi vấn: field `isFlagged` trên invite, set bởi Recruiter hoặc tự động.
+- Timeline UI trong Candidate Detail / Assessment Results.
+- Badge "Nghi vấn" trên candidate list khi integrityScore thấp.
+
+**Ngoài phạm vi:**
+
+- Webcam snapshot / xác thực danh tính (US-D3, Sprint 4).
+- AI phân tích hành vi nâng cao (deferred).
+- Gửi email cảnh báo khi phát hiện gian lận (deferred).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ          | Ý nghĩa                                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| **CandidateEvent** | Sự kiện hành vi trong khi thi: `tab_switch`, `fullscreen_exit`, `paste`, `focus_lost`, `copy` v.v.    |
+| **integrityScore** | Điểm toàn vẹn 0–100 (`CandidateInvite.integrityScore`), giảm dần khi có sự kiện vi phạm               |
+| **riskThreshold**  | Ngưỡng dưới ngưỡng này ứng viên được tự động flag — cấu hình per-assessment (default: 70)             |
+| **isFlagged**      | Boolean trên `CandidateInvite`: `true` nếu tự động hoặc thủ công đánh dấu nghi vấn                    |
+| **RiskLevel**      | LOW (score ≥ threshold) · MEDIUM (threshold - 20 ≤ score < threshold) · HIGH (score < threshold - 20) |
+
+### 1.4. Hiện trạng trước US-D2
+
+- `CandidateEvent` (schema L1245): `id`, `inviteId`, `eventType`, `payload`, `clientTs` — đã được ghi từ exam engine.
+- `CandidateInvite.integrityScore` (schema L1201) — đã tính và lưu khi submit.
+- `calcIntegrityScore()` (`candidate.service.ts` L413) — đã có.
+- `getEvents(inviteId, assessmentId)` (`candidate.service.ts` L396) — đã có, trả về raw events.
+- `CandidateInvite.tabSwitchCount` (schema L1199) — đã có.
+- Chưa có: `riskThreshold` trên Assessment, `isFlagged` trên CandidateInvite, timeline UI, filter theo integrity.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Schema: thêm risk fields
+
+**Mở rộng `Assessment`:**
+
+```prisma
+riskThreshold  Int  @default(70) @map("risk_threshold")  // integrityScore min để "sạch"
+autoFlagRisk   Boolean @default(true) @map("auto_flag_risk") // tự động flag khi submit
+```
+
+**Mở rộng `CandidateInvite`:**
+
+```prisma
+isFlagged      Boolean   @default(false) @map("is_flagged")
+flaggedAt      DateTime? @map("flagged_at")
+flaggedReason  String?   @map("flagged_reason")  // "AUTO_LOW_INTEGRITY" | "MANUAL" | null
+flaggedBy      String?   @map("flagged_by")       // userId nếu manual
+```
+
+---
+
+### FR-2 — Tự động flag khi submit
+
+Mở rộng `CandidateService.submitExam()`:
+
+```
+Sau khi tính integrityScore:
+IF assessment.autoFlagRisk = true AND integrityScore < assessment.riskThreshold:
+  invite.isFlagged = true
+  invite.flaggedAt = now()
+  invite.flaggedReason = "AUTO_LOW_INTEGRITY"
+```
+
+---
+
+### FR-3 — Event timeline endpoint
+
+#### `GET /organizations/:orgId/assessments/:assessmentId/candidates/:inviteId/events`
+
+**RBAC:** OWNER, ADMIN, MANAGER, RECRUITER.
+
+**Xử lý:** Gọi `getEvents(inviteId, assessmentId)`, nhóm theo `eventType`, sort `clientTs ASC`.
+
+Response `200`:
+
+```json
+{
+  "inviteId": "uuid",
+  "candidateName": "Nguyen Van A",
+  "candidateEmail": "nguyenvana@example.com",
+  "integrityScore": 58,
+  "riskThreshold": 70,
+  "riskLevel": "HIGH",
+  "isFlagged": true,
+  "totalEvents": 14,
+  "summary": {
+    "tab_switch": 6,
+    "fullscreen_exit": 4,
+    "paste": 2,
+    "focus_lost": 2
+  },
+  "timeline": [
+    {
+      "id": "uuid",
+      "eventType": "tab_switch",
+      "clientTs": "2026-06-15T10:03:22Z",
+      "relativeMinute": 3,
+      "payload": { "url": "" },
+      "severity": "HIGH"
+    },
+    {
+      "id": "uuid",
+      "eventType": "paste",
+      "clientTs": "2026-06-15T10:07:45Z",
+      "relativeMinute": 7,
+      "payload": { "length": 142 },
+      "severity": "MEDIUM"
+    }
+  ]
+}
+```
+
+**Severity per eventType:**
+
+| eventType         | severity |
+| ----------------- | -------- |
+| `tab_switch`      | HIGH     |
+| `fullscreen_exit` | MEDIUM   |
+| `paste`           | HIGH     |
+| `copy`            | MEDIUM   |
+| `focus_lost`      | LOW      |
+| others            | LOW      |
+
+**`relativeMinute`**: số phút kể từ `invite.startedAt`.
+
+---
+
+### FR-4 — Thủ công flag / unflag
+
+#### `PATCH /organizations/:orgId/assessments/:assessmentId/candidates/:inviteId/flag`
+
+**RBAC:** OWNER, ADMIN, MANAGER, RECRUITER.
+
+Request body:
+
+```json
+{
+  "isFlagged": true,
+  "reason": "Phát hiện chia sẻ đáp án qua chat"
+}
+```
+
+**Xử lý:**
+
+- `isFlagged = true`: set `flaggedAt = now()`, `flaggedReason = "MANUAL"`, `flaggedBy = currentUserId`.
+- `isFlagged = false`: clear `flaggedAt`, `flaggedReason`, `flaggedBy` (unflag).
+
+Response `200`: invite đã cập nhật (`isFlagged`, `flaggedAt`, `flaggedReason`).
+
+---
+
+### FR-5 — Cấu hình riskThreshold
+
+#### `PATCH /organizations/:orgId/assessments/:assessmentId/risk-config`
+
+**RBAC:** OWNER, ADMIN, MANAGER.
+
+Request body:
+
+```json
+{
+  "riskThreshold": 65,
+  "autoFlagRisk": true
+}
+```
+
+**Validation:**
+
+- `riskThreshold`: integer 0–100.
+- `autoFlagRisk`: boolean.
+
+Response `200`: assessment đã cập nhật.
+
+**Side effect:** Thay đổi `riskThreshold` **không** hồi tố — không tự động re-flag các invite đã submit.
+
+---
+
+### FR-6 — Filter candidates theo risk
+
+Mở rộng `GET /organizations/:orgId/assessments/:assessmentId/candidates`:
+
+**Thêm query params:**
+
+- `maxIntegrity?: number` — chỉ trả về invite có `integrityScore <= maxIntegrity`.
+- `isFlagged?: boolean` — lọc theo flag.
+- `riskLevel?: LOW | MEDIUM | HIGH` — tính toán theo threshold của assessment.
+
+Response item bổ sung:
+
+```json
+{
+  "inviteId": "uuid",
+  "candidateName": "...",
+  "integrityScore": 58,
+  "riskLevel": "HIGH",
+  "isFlagged": true,
+  "flaggedReason": "AUTO_LOW_INTEGRITY",
+  "tabSwitchCount": 6
+}
+```
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR                    | Mô tả                                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| **RBAC**               | Candidate không tự xem events của mình; 403 nếu cố truy cập                            |
+| **Org isolation**      | inviteId phải thuộc assessmentId phải thuộc orgId; chain validation 3 cấp              |
+| **Non-retroactive**    | Thay đổi riskThreshold sau submit không tự re-flag invite cũ                           |
+| **Append-only events** | CandidateEvent chỉ ghi, không sửa/xóa; timeline luôn immutable                         |
+| **Performance**        | Tối đa 1000 events per invite; nếu > 1000 → trả về 1000 events đầu + `truncated: true` |
+
+---
+
+## 4. API Contract tổng hợp
+
+| Method | Path                                                            | RBAC                          | Mô tả                     |
+| ------ | --------------------------------------------------------------- | ----------------------------- | ------------------------- |
+| GET    | `/organizations/:orgId/assessments/:aid/candidates/:iid/events` | OWNER,ADMIN,MANAGER,RECRUITER | Event timeline của invite |
+| PATCH  | `/organizations/:orgId/assessments/:aid/candidates/:iid/flag`   | OWNER,ADMIN,MANAGER,RECRUITER | Thủ công flag / unflag    |
+| PATCH  | `/organizations/:orgId/assessments/:aid/risk-config`            | OWNER,ADMIN,MANAGER           | Cấu hình riskThreshold    |
+
+_(GET candidates đã có — chỉ mở rộng query params.)_
+
+---
+
+## 5. Giao diện người dùng
+
+### 5.1. Assessment Results — cột risk
+
+Trong bảng danh sách ứng viên:
+
+- Cột "Integrity" hiển thị score (0–100) + badge risk level: 🟢 LOW / 🟡 MEDIUM / 🔴 HIGH.
+- Icon 🚩 nếu `isFlagged = true`.
+- Filter bar: "Chỉ hiện nghi vấn" checkbox → `isFlagged=true`; slider "Integrity tối đa: 70".
+
+### 5.2. Candidate Detail — tab "Giám sát"
+
+- Header: Integrity score lớn + badge risk + flagged badge (nếu có).
+- Card tóm tắt: Tab switch: 6 | Fullscreen exit: 4 | Paste: 2.
+- Timeline dọc (CSS timeline component):
+  - Mỗi event là một node: icon + eventType label + thời gian tương đối ("3 phút sau khi bắt đầu") + severity badge.
+  - Màu node: đỏ (HIGH) / vàng (MEDIUM) / xám (LOW).
+- Nút "Đánh dấu nghi vấn" / "Bỏ đánh dấu" → gọi PATCH flag.
+
+### 5.3. Assessment Settings — tab "Proctoring"
+
+- Toggle "Tự động đánh dấu khi integrity thấp".
+- Slider/input "Ngưỡng integrity: [70]".
+- Label: "Ứng viên có integrity < 70 sẽ được tự động đánh dấu nghi vấn".
+
+---
+
+## 6. Test Cases
+
+| #   | Tình huống                                                        | Kết quả mong đợi                                                      |
+| --- | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
+| T1  | Submit với integrityScore=55, riskThreshold=70, autoFlagRisk=true | isFlagged=true, flaggedReason="AUTO_LOW_INTEGRITY"                    |
+| T2  | Submit với integrityScore=85, riskThreshold=70, autoFlagRisk=true | isFlagged=false                                                       |
+| T3  | Submit với integrityScore=55, autoFlagRisk=false                  | isFlagged=false (auto-flag tắt)                                       |
+| T4  | PATCH flag {isFlagged: true, reason: "manual"}                    | flaggedReason="MANUAL", flaggedBy=currentUserId                       |
+| T5  | PATCH flag {isFlagged: false}                                     | isFlagged=false, flaggedAt/reason/by cleared                          |
+| T6  | GET events: 6 tab_switch, 2 paste                                 | summary.tab_switch=6, severity HIGH cho tab_switch                    |
+| T7  | GET candidates?isFlagged=true                                     | Chỉ trả về invite có isFlagged=true                                   |
+| T8  | GET candidates?maxIntegrity=60                                    | Chỉ trả về invite có integrityScore <= 60                             |
+| T9  | GET candidates?riskLevel=HIGH với threshold=70                    | Chỉ trả về invite có score < 50 (threshold-20)                        |
+| T10 | Candidate thử GET events của chính mình                           | 403 Forbidden                                                         |
+| T11 | PATCH risk-config riskThreshold=60 sau khi có invite đã flagged   | Invite cũ không bị re-flag/unflag; chỉ invite mới submit bị ảnh hưởng |
+| T12 | GET events > 1000 events                                          | Trả về 1000 đầu, truncated=true                                       |
+
+---
+
+## 7. Thứ tự implement
+
+1. **Migration** — thêm `riskThreshold`, `autoFlagRisk` vào `Assessment`; `isFlagged`, `flaggedAt`, `flaggedReason`, `flaggedBy` vào `CandidateInvite`.
+2. **Auto-flag trong submitExam()** — mở rộng `CandidateService.submitExam()`.
+3. **risk-config endpoint** — PATCH assessment risk settings.
+4. **Events timeline endpoint** — wrap `getEvents()` + tính severity + relativeMinute.
+5. **Flag/unflag endpoint** — PATCH flag.
+6. **Candidates filter** — mở rộng query params trên GET candidates.
+7. **FE Assessment Results** — cột integrity + filter + badge.
+8. **FE Candidate Detail** — tab Giám sát + timeline component.
+9. **FE Assessment Settings** — tab Proctoring.
+10. **Tests** — unit (T1–T3), integration (T6, T7, T8), E2E candidate detail tab.
+
+---
+
+## 8. Open Questions
+
+- `relativeMinute` tính từ `invite.startedAt` — nếu `startedAt` null thì sao? (Đề xuất: dùng event đầu tiên làm baseline; log warning nếu startedAt missing.)
+- Có nên lưu `riskLevel` vào DB hay tính on-the-fly? (Đề xuất: tính on-the-fly từ integrityScore + threshold; tránh stale data khi threshold thay đổi.)
+- Có cần `AuditLog` khi flag/unflag thủ công không? (Đề xuất: có — ghi vào existing `AuditLog` model với action `CANDIDATE_FLAGGED` / `CANDIDATE_UNFLAGGED`.)

--- a/docs/specs/sprint-3-us-g1-executive-dashboard-srs.md
+++ b/docs/specs/sprint-3-us-g1-executive-dashboard-srs.md
@@ -1,0 +1,360 @@
+# SRS — US-G1: Dashboard điều hành cho lãnh đạo
+
+|                      |                                                                                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tài liệu**         | Software Requirements Specification (SRS)                                                                                                          |
+| **Tính năng**        | US-G1 — Executive Leadership Dashboard                                                                                                             |
+| **Issue**            | [#113](https://github.com/thanhpt-25/brain-gym/issues/113)                                                                                         |
+| **Epic**             | G — Báo cáo, tuân thủ & dữ liệu                                                                                                                    |
+| **Phiên bản**        | Draft 1.0                                                                                                                                          |
+| **Ngày**             | 2026-06-21                                                                                                                                         |
+| **Trạng thái**       | Draft — chờ implement                                                                                                                              |
+| **Phụ thuộc**        | `org-analytics.service.ts` đã có; US-B3 (CompetencyCertification) nên hoàn thành trước để có cert data; US-D1/D2 (integrity data) cần submit đã có |
+| **Module liên quan** | `analytics` (backend mở rộng) · `src/pages/org/` (frontend mới) · `src/components/org/` (frontend tái dùng)                                        |
+
+---
+
+## 1. Giới thiệu
+
+### 1.1. Mục đích
+
+Đặc tả yêu cầu cho **US-G1**, cung cấp cho OWNER/ADMIN một dashboard điều hành tổng hợp toàn org: compliance đào tạo theo competency, recruiting funnel, và integrity summary — với lát cắt theo group/jobRole/competency — và xuất báo cáo PDF/CSV.
+
+### 1.2. Phạm vi
+
+**Trong phạm vi:**
+
+- **Competency compliance track**: % member đạt cert theo competency và jobRole, gap chart theo phòng ban.
+- **Recruiting funnel track**: số ứng viên theo từng stage (APPLIED → SHORTLISTED → HIRED/REJECTED), conversion rate.
+- **Integrity summary**: phân phối integrityScore, tỷ lệ flagged, tổng số sự kiện vi phạm theo assessment.
+- Lát cắt (filter): theo `groupId`, `jobRoleId`, `competencyId`, khoảng thời gian.
+- Xuất CSV toàn bộ dữ liệu.
+- RBAC: chỉ OWNER và ADMIN.
+
+**Ngoài phạm vi:**
+
+- Real-time streaming (dashboard refresh mỗi giây) — batch query đủ.
+- Drill-down đến từng cá nhân từ dashboard (link đến trang member profile đã có).
+- PDF export phía server (dùng browser print CSS cho MVP).
+- Benchmark so sánh với org khác (deferred).
+
+### 1.3. Định nghĩa thuật ngữ
+
+| Thuật ngữ             | Ý nghĩa                                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| **Compliance rate**   | % member có cert ACTIVE cho một competency bắt buộc / tổng member có jobRole cần competency đó |
+| **Funnel stage**      | `CandidateStage`: APPLIED → SHORTLISTED → HIRED hoặc REJECTED                                  |
+| **Conversion rate**   | % chuyển đổi giữa hai stage kế tiếp trong funnel                                               |
+| **Integrity summary** | Phân phối `integrityScore` và tỷ lệ `isFlagged` theo assessment hoặc toàn org                  |
+| **Executive slice**   | Một lát cắt báo cáo: có thể là toàn org, một group, một jobRole, hoặc một competency           |
+
+### 1.4. Hiện trạng trước US-G1
+
+- `analytics.service.ts` — có các metric cơ bản (attempt stats, domain breakdown) — đã có.
+- `OrgMember`, `OrgGroup`, `JobRole`, `Competency`, `JobRoleCompetency` — đã có.
+- `CompetencyCertification` — sẽ có sau US-B3.
+- `CandidateInvite` với `stage`, `integrityScore`, `isFlagged` — đã có (isFlagged sau US-D2).
+- `AssessmentCampaign` — đã có.
+- Chưa có: executive dashboard endpoints, PDF/CSV export tổng hợp, compliance + funnel + integrity aggregation trong một service.
+
+---
+
+## 2. Yêu cầu chức năng
+
+### FR-1 — Executive Summary Endpoint
+
+#### `GET /organizations/:orgId/executive-dashboard`
+
+**RBAC:** OWNER, ADMIN.
+
+Query params:
+
+| Param          | Mô tả               | Default       |
+| -------------- | ------------------- | ------------- |
+| `groupId`      | Lọc theo group      | all groups    |
+| `jobRoleId`    | Lọc theo job role   | all roles     |
+| `competencyId` | Lọc theo competency | all           |
+| `from`         | ISO8601 — từ ngày   | 90 ngày trước |
+| `to`           | ISO8601 — đến ngày  | now()         |
+
+Response `200`:
+
+```json
+{
+  "generatedAt": "2026-06-21T08:00:00Z",
+  "period": { "from": "2026-03-23", "to": "2026-06-21" },
+  "filters": { "groupId": null, "jobRoleId": null, "competencyId": null },
+  "competencyCompliance": {
+    "overallRate": 0.72,
+    "totalMembers": 45,
+    "certifiedMembers": 32,
+    "expiringSoon": 4,
+    "expired": 5,
+    "notCertified": 4,
+    "byCompetency": [
+      {
+        "competencyId": "uuid",
+        "competencyName": "Cloud Networking",
+        "requiredForRoles": 3,
+        "certifiedCount": 18,
+        "totalEligible": 22,
+        "complianceRate": 0.82
+      }
+    ],
+    "byGroup": [
+      {
+        "groupId": "uuid",
+        "groupName": "Engineering",
+        "complianceRate": 0.91,
+        "memberCount": 12
+      }
+    ]
+  },
+  "recruitingFunnel": {
+    "period": { "from": "2026-03-23", "to": "2026-06-21" },
+    "totalCandidates": 124,
+    "byStage": {
+      "APPLIED": 124,
+      "SHORTLISTED": 48,
+      "HIRED": 11,
+      "REJECTED": 65
+    },
+    "conversionRates": {
+      "appliedToShortlisted": 0.387,
+      "shortlistedToHired": 0.229,
+      "overallYield": 0.089
+    },
+    "byAssessment": [
+      {
+        "assessmentId": "uuid",
+        "assessmentTitle": "Backend Engineer Test",
+        "totalInvites": 56,
+        "shortlisted": 22,
+        "hired": 5
+      }
+    ]
+  },
+  "integritySummary": {
+    "totalSubmitted": 113,
+    "flaggedCount": 8,
+    "flaggedRate": 0.071,
+    "avgIntegrityScore": 84,
+    "scoreDistribution": {
+      "90-100": 45,
+      "70-89": 42,
+      "50-69": 18,
+      "0-49": 8
+    },
+    "topViolationEvents": [
+      { "eventType": "tab_switch", "count": 142 },
+      { "eventType": "fullscreen_exit", "count": 87 },
+      { "eventType": "paste", "count": 31 }
+    ]
+  }
+}
+```
+
+---
+
+### FR-2 — Competency Compliance Detail
+
+#### `GET /organizations/:orgId/executive-dashboard/compliance`
+
+**RBAC:** OWNER, ADMIN.
+
+Query params: `competencyId?`, `groupId?`, `jobRoleId?`, `status?: ACTIVE | EXPIRING_SOON | EXPIRED | NOT_CERTIFIED`.
+
+Response `200`:
+
+```json
+{
+  "rows": [
+    {
+      "memberId": "uuid",
+      "memberName": "Nguyen Van A",
+      "groupName": "Engineering",
+      "jobRoleTitle": "Cloud Engineer",
+      "competencyName": "Security",
+      "certStatus": "EXPIRED",
+      "achievedLevel": 3,
+      "requiredLevel": 4,
+      "expiresAt": "2026-01-15T00:00:00Z"
+    }
+  ],
+  "total": 42,
+  "page": 1,
+  "limit": 50
+}
+```
+
+_(Tái dùng data từ FR-4 của US-B3 `/certifications/compliance` — chỉ thêm pagination.)_
+
+---
+
+### FR-3 — Recruiting Funnel Detail
+
+#### `GET /organizations/:orgId/executive-dashboard/funnel`
+
+**RBAC:** OWNER, ADMIN.
+
+Query params: `assessmentId?`, `jobRoleId?`, `from?`, `to?`.
+
+Response `200`:
+
+```json
+{
+  "rows": [
+    {
+      "inviteId": "uuid",
+      "candidateName": "Tran Thi B",
+      "candidateEmail": "tranthib@example.com",
+      "assessmentTitle": "Backend Engineer Test",
+      "jobRoleTitle": "Backend Engineer",
+      "stage": "SHORTLISTED",
+      "score": 87.5,
+      "integrityScore": 92,
+      "isFlagged": false,
+      "submittedAt": "2026-06-10T14:23:00Z"
+    }
+  ],
+  "total": 124,
+  "page": 1,
+  "limit": 50
+}
+```
+
+---
+
+### FR-4 — Xuất CSV
+
+#### `GET /organizations/:orgId/executive-dashboard/export?type=compliance|funnel|integrity`
+
+**RBAC:** OWNER, ADMIN.
+
+Response `200` với `Content-Type: text/csv; charset=utf-8`:
+
+**type=compliance:**
+
+```
+Member,Group,JobRole,Competency,Cert Status,Achieved Level,Required Level,Expires At
+Nguyen Van A,Engineering,Cloud Engineer,Security,EXPIRED,3,4,2026-01-15
+```
+
+**type=funnel:**
+
+```
+Candidate,Email,Assessment,Job Role,Stage,Score,Integrity Score,Flagged,Submitted At
+Tran Thi B,tranthib@example.com,Backend Engineer Test,Backend Engineer,SHORTLISTED,87.5,92,No,2026-06-10
+```
+
+**type=integrity:**
+
+```
+Candidate,Email,Assessment,Integrity Score,Flagged,Tab Switches,Paste Events,Submitted At
+...
+```
+
+---
+
+### FR-5 — In / xuất PDF
+
+Không có server-side PDF generation trong MVP. Frontend cung cấp:
+
+- Nút "In báo cáo" → `window.print()` với CSS `@media print` ẩn sidebar/nav, hiện đầy đủ dashboard.
+- Tiêu đề in tự động kèm org name + date range.
+
+---
+
+## 3. Yêu cầu phi chức năng
+
+| NFR                  | Mô tả                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| **RBAC strict**      | Chỉ OWNER và ADMIN; MANAGER/MEMBER → 403 ngay cả khi biết URL                                    |
+| **Response time**    | Executive summary ≤ 3s cho org ≤ 500 members và ≤ 1000 invites; vượt ngưỡng → cache Redis 5 phút |
+| **Cache key**        | `exec-dashboard:{orgId}:{filters_hash}` với TTL 5 phút                                           |
+| **Cache invalidate** | Invalidate khi có cert mới được issue, invite mới submit, hoặc flag thay đổi                     |
+| **Pagination**       | Detail endpoints (FR-2, FR-3) phân trang; summary (FR-1) không phân trang (aggregated)           |
+| **Time zone**        | Tất cả datetime trả về ISO8601 UTC; frontend tự convert theo browser timezone                    |
+
+---
+
+## 4. API Contract tổng hợp
+
+| Method | Path                                                   | RBAC         | Mô tả                                    |
+| ------ | ------------------------------------------------------ | ------------ | ---------------------------------------- |
+| GET    | `/organizations/:orgId/executive-dashboard`            | OWNER, ADMIN | Summary: compliance + funnel + integrity |
+| GET    | `/organizations/:orgId/executive-dashboard/compliance` | OWNER, ADMIN | Compliance detail + pagination           |
+| GET    | `/organizations/:orgId/executive-dashboard/funnel`     | OWNER, ADMIN | Recruiting funnel detail                 |
+| GET    | `/organizations/:orgId/executive-dashboard/export`     | OWNER, ADMIN | CSV export (type param)                  |
+
+---
+
+## 5. Giao diện người dùng
+
+### 5.1. Trang Executive Dashboard (`/org/:slug/executive`)
+
+**Header:** Org name · Filter bar (Group / JobRole / Competency / Date range) · Nút "Xuất CSV" · Nút "In PDF".
+
+**Section 1 — Compliance Overview:**
+
+- 4 KPI cards: % Đạt cert | Sắp hết hạn | Đã hết hạn | Chưa có cert.
+- Bar chart: Compliance rate theo competency (horizontal bars, sorted ASC).
+- Bar chart: Compliance rate theo group.
+- Link "Xem chi tiết" → `/org/:slug/competency/compliance`.
+
+**Section 2 — Recruiting Funnel:**
+
+- Funnel chart (SVG/D3 hoặc custom CSS): APPLIED → SHORTLISTED → HIRED với con số và %.
+- Table "Theo assessment": Assessment title | Tổng invite | Shortlisted | Hired | Conversion %.
+- Link "Xem chi tiết ứng viên" → trang Assessment Results đã có.
+
+**Section 3 — Integrity Summary:**
+
+- KPI: Tỷ lệ flagged % | Avg integrity score | Tổng sự kiện vi phạm.
+- Donut chart: phân phối score (90-100 / 70-89 / 50-69 / 0-49).
+- List: Top vi phạm (tab_switch: 142 lần, ...).
+
+### 5.2. Responsive và Print
+
+- Desktop: 3-column grid cho KPI cards; 2-column cho charts.
+- Print CSS: full-width single-column; ẩn sidebar, filter bar, nav; hiện org name + date range + timestamp.
+
+---
+
+## 6. Test Cases
+
+| #   | Tình huống                                                 | Kết quả mong đợi                                    |
+| --- | ---------------------------------------------------------- | --------------------------------------------------- |
+| T1  | MANAGER GET executive-dashboard                            | 403 Forbidden                                       |
+| T2  | OWNER GET summary: 32/45 members certified                 | overallRate = 0.711, certifiedMembers = 32          |
+| T3  | Filter ?groupId=X: chỉ tính members thuộc group X          | Kết quả scope xuống group X                         |
+| T4  | Filter ?from=2026-01-01&to=2026-03-31: funnel chỉ trong Q1 | byStage.APPLIED chỉ đếm invite submittedAt trong Q1 |
+| T5  | GET compliance?status=EXPIRED                              | Chỉ trả về rows có certStatus=EXPIRED               |
+| T6  | GET export?type=compliance                                 | 200, Content-Type: text/csv, rows đúng cột          |
+| T7  | GET summary: org chưa có cert nào (US-B3 chưa chạy)        | certifiedMembers=0, overallRate=0, không lỗi        |
+| T8  | GET summary: gọi lần 2 trong 5 phút                        | Response từ Redis cache (X-Cache: HIT header)       |
+| T9  | Issue cert mới → gọi GET summary                           | Cache invalidated, response fresh                   |
+| T10 | GET funnel?jobRoleId=X                                     | Chỉ tính invite thuộc assessment có jobRoleId=X     |
+
+---
+
+## 7. Thứ tự implement
+
+1. **ExecutiveDashboardService** — tổng hợp query compliance + funnel + integrity; dùng `prisma.$transaction` để parallel query.
+2. **Cache layer** — Redis cache với key + TTL 5 phút; invalidation hooks sau cert issue và submit.
+3. **ExecutiveDashboardController** — 4 endpoints; RBAC OWNER/ADMIN guard.
+4. **Module** — thêm vào `analytics.module.ts` hoặc tạo `executive.module.ts`.
+5. **CSV export** — stream response; 3 type.
+6. **FE Executive Dashboard page** — route `/org/:slug/executive`, 3 sections.
+7. **FE Charts** — reuse components từ `src/components/org/*`; thêm funnel chart.
+8. **FE Print CSS** — `@media print` stylesheet.
+9. **Tests** — unit ExecutiveDashboardService (T2–T4, T7), integration (T1, T5, T6), cache (T8, T9).
+
+---
+
+## 8. Open Questions
+
+- Compliance rate tính theo "tất cả member" hay chỉ "member có jobRole"? (Đề xuất: chỉ member có jobRole với `requiredLevel` cho competency đó — có meaningful hơn.)
+- Funnel period: filter theo `invite.submittedAt` hay `invite.createdAt`? (Đề xuất: `submittedAt` — muốn biết ai đã thi trong kỳ; `createdAt` để filter deferred.)
+- Có cần scheduled report (email PDF hàng tuần cho OWNER) không? (Đề xuất: deferred Sprint 4 — cần US-C3 email template trước.)
+- `X-Cache: HIT` header có cần không? (Đề xuất: có — dễ debug; set trong Redis cache middleware.)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,13 @@ const OrgScorecard = lazy(() => import("./pages/org/OrgScorecard"));
 const PublicApply = lazy(() => import("./pages/PublicApply"));
 const OrgAnalytics = lazy(() => import("./pages/org/OrgAnalytics"));
 const OrgAuditLog = lazy(() => import("./pages/org/OrgAuditLog"));
+const OrgComplianceDashboard = lazy(
+  () => import("./pages/org/OrgComplianceDashboard"),
+);
+const OrgExecutiveDashboard = lazy(
+  () => import("./pages/org/OrgExecutiveDashboard"),
+);
+const OrgPoolStats = lazy(() => import("./pages/org/OrgPoolStats"));
 const CandidateExam = lazy(() => import("./pages/CandidateExam"));
 const CandidateResult = lazy(() => import("./pages/CandidateResult"));
 const MasteryPage = lazy(() => import("./pages/Dashboard/MasteryPage"));
@@ -409,6 +416,18 @@ const AnimatedRoutes = () => {
           <Route path="analytics" element={<OrgAnalytics />} />
           <Route path="settings" element={<OrgSettings />} />
           <Route path="settings/audit" element={<OrgAuditLog />} />
+          <Route
+            path="competency/compliance"
+            element={<OrgComplianceDashboard />}
+          />
+          <Route
+            path="executive-dashboard"
+            element={<OrgExecutiveDashboard />}
+          />
+          <Route
+            path="assessments/:aid/pool-stats"
+            element={<OrgPoolStats />}
+          />
         </Route>
 
         {/* Public apply link (no auth) */}

--- a/src/components/org/OrgSidebar.tsx
+++ b/src/components/org/OrgSidebar.tsx
@@ -13,6 +13,8 @@ import {
   BarChart3,
   Briefcase,
   Award,
+  ShieldCheck,
+  TrendingUp,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { OrgRole } from "@/types/org-types";
@@ -93,10 +95,22 @@ const OrgSidebar = () => {
       roles: ["OWNER", "ADMIN", "MANAGER"] as OrgRole[],
     },
     {
+      label: "Cert Compliance",
+      href: `/org/${slug}/competency/compliance`,
+      icon: ShieldCheck,
+      roles: ["OWNER", "ADMIN"] as OrgRole[],
+    },
+    {
       label: "Analytics",
       href: `/org/${slug}/analytics`,
       icon: BarChart3,
       roles: ["OWNER", "ADMIN", "MANAGER"] as OrgRole[],
+    },
+    {
+      label: "Executive",
+      href: `/org/${slug}/executive-dashboard`,
+      icon: TrendingUp,
+      roles: ["OWNER", "ADMIN"] as OrgRole[],
     },
     {
       label: "Settings",

--- a/src/pages/org/AssessmentResults.tsx
+++ b/src/pages/org/AssessmentResults.tsx
@@ -1,29 +1,40 @@
-import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useOrgStore } from '@/stores/org.store';
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useOrgStore } from "@/stores/org.store";
 import {
-  getAssessmentResults, inviteCandidates, updateAssessmentStatus,
+  getAssessmentResults,
+  inviteCandidates,
+  updateAssessmentStatus,
   exportAssessmentCsv,
-} from '@/services/assessments';
-import { Card, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+} from "@/services/assessments";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
-  ArrowLeft, Loader2, ClipboardList, UserPlus, Download,
-  Play, Pause, Users, Upload, Briefcase,
-} from 'lucide-react';
-import { toast } from 'sonner';
-import InviteCandidatesModal from '@/components/org/InviteCandidatesModal';
-import CsvImportModal from '@/components/org/CsvImportModal';
-import CandidateRanking from '@/components/org/CandidateRanking';
-import AssessmentFunnel from '@/components/org/AssessmentFunnel';
+  ArrowLeft,
+  Loader2,
+  ClipboardList,
+  UserPlus,
+  Download,
+  Play,
+  Pause,
+  Users,
+  Upload,
+  Briefcase,
+  Database,
+} from "lucide-react";
+import { toast } from "sonner";
+import InviteCandidatesModal from "@/components/org/InviteCandidatesModal";
+import CsvImportModal from "@/components/org/CsvImportModal";
+import CandidateRanking from "@/components/org/CandidateRanking";
+import AssessmentFunnel from "@/components/org/AssessmentFunnel";
 
 const statusColors: Record<string, string> = {
-  DRAFT: 'bg-muted text-muted-foreground',
-  ACTIVE: 'bg-emerald-500/15 text-emerald-400',
-  CLOSED: 'bg-amber-500/15 text-amber-400',
-  ARCHIVED: 'bg-zinc-500/15 text-zinc-400',
+  DRAFT: "bg-muted text-muted-foreground",
+  ACTIVE: "bg-emerald-500/15 text-emerald-400",
+  CLOSED: "bg-amber-500/15 text-amber-400",
+  ARCHIVED: "bg-zinc-500/15 text-zinc-400",
 };
 
 const AssessmentResults = () => {
@@ -31,12 +42,12 @@ const AssessmentResults = () => {
   const queryClient = useQueryClient();
   const { aid } = useParams();
   const currentOrg = useOrgStore((s) => s.currentOrg);
-  const slug = currentOrg?.slug || '';
+  const slug = currentOrg?.slug || "";
   const [showInvite, setShowInvite] = useState(false);
   const [showCsvImport, setShowCsvImport] = useState(false);
 
   const { data, isLoading } = useQuery({
-    queryKey: ['assessment-results', slug, aid],
+    queryKey: ["assessment-results", slug, aid],
     queryFn: () => getAssessmentResults(slug, aid!),
     enabled: !!slug && !!aid,
   });
@@ -48,43 +59,52 @@ const AssessmentResults = () => {
       toast.success(`${result.invited} candidate(s) invited`);
       setShowInvite(false);
       setShowCsvImport(false);
-      queryClient.invalidateQueries({ queryKey: ['assessment-results', slug, aid] });
+      queryClient.invalidateQueries({
+        queryKey: ["assessment-results", slug, aid],
+      });
     },
-    onError: (e: any) => toast.error(e?.response?.data?.message || 'Invite failed'),
+    onError: (e: any) =>
+      toast.error(e?.response?.data?.message || "Invite failed"),
   });
 
   const reinviteMutation = useMutation({
     mutationFn: (email: string) =>
       inviteCandidates(slug, aid!, { candidates: [{ email }] }),
     onSuccess: () => {
-      toast.success('Invite re-sent');
-      queryClient.invalidateQueries({ queryKey: ['assessment-results', slug, aid] });
+      toast.success("Invite re-sent");
+      queryClient.invalidateQueries({
+        queryKey: ["assessment-results", slug, aid],
+      });
     },
-    onError: (e: any) => toast.error(e?.response?.data?.message || 'Re-invite failed'),
+    onError: (e: any) =>
+      toast.error(e?.response?.data?.message || "Re-invite failed"),
   });
 
   const statusMutation = useMutation({
-    mutationFn: (status: 'ACTIVE' | 'CLOSED') =>
+    mutationFn: (status: "ACTIVE" | "CLOSED") =>
       updateAssessmentStatus(slug, aid!, status),
     onSuccess: () => {
-      toast.success('Status updated');
-      queryClient.invalidateQueries({ queryKey: ['assessment-results', slug, aid] });
+      toast.success("Status updated");
+      queryClient.invalidateQueries({
+        queryKey: ["assessment-results", slug, aid],
+      });
     },
-    onError: (e: any) => toast.error(e?.response?.data?.message || 'Update failed'),
+    onError: (e: any) =>
+      toast.error(e?.response?.data?.message || "Update failed"),
   });
 
   const handleExport = async () => {
     try {
       const csv = await exportAssessmentCsv(slug, aid!);
-      const blob = new Blob([csv], { type: 'text/csv' });
+      const blob = new Blob([csv], { type: "text/csv" });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
       a.download = `assessment-${aid}-results.csv`;
       a.click();
       URL.revokeObjectURL(url);
     } catch {
-      toast.error('Export failed');
+      toast.error("Export failed");
     }
   };
 
@@ -99,7 +119,9 @@ const AssessmentResults = () => {
   if (!data) {
     return (
       <div className="text-center py-16">
-        <p className="text-muted-foreground font-mono text-sm">Assessment not found</p>
+        <p className="text-muted-foreground font-mono text-sm">
+          Assessment not found
+        </p>
       </div>
     );
   }
@@ -111,7 +133,11 @@ const AssessmentResults = () => {
       {/* Header */}
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" onClick={() => navigate(`/org/${slug}/assessments`)}>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => navigate(`/org/${slug}/assessments`)}
+          >
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
@@ -120,41 +146,62 @@ const AssessmentResults = () => {
               {assessment.title}
             </h1>
             <div className="flex items-center gap-2 mt-1 flex-wrap">
-              <Badge className={`text-[10px] ${statusColors[assessment.status]}`}>
+              <Badge
+                className={`text-[10px] ${statusColors[assessment.status]}`}
+              >
                 {assessment.status}
               </Badge>
               {assessment.jobRole && (
                 <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
                   <Briefcase className="h-3 w-3" />
                   {assessment.jobRole.title}
-                  {assessment.jobRole.department && ` · ${assessment.jobRole.department}`}
+                  {assessment.jobRole.department &&
+                    ` · ${assessment.jobRole.department}`}
                 </span>
               )}
               <span className="text-xs text-muted-foreground font-mono">
-                {assessment.questionCount} questions · {assessment.timeLimit} min
-                {assessment.passingScore != null && ` · ${assessment.passingScore}% to pass`}
+                {assessment.questionCount} questions · {assessment.timeLimit}{" "}
+                min
+                {assessment.passingScore != null &&
+                  ` · ${assessment.passingScore}% to pass`}
               </span>
             </div>
           </div>
         </div>
 
         <div className="flex items-center gap-2 shrink-0 flex-wrap">
-          {assessment.status === 'DRAFT' && (
-            <Button size="sm" variant="outline" onClick={() => statusMutation.mutate('ACTIVE')}
-              disabled={statusMutation.isPending}>
+          {assessment.status === "DRAFT" && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => statusMutation.mutate("ACTIVE")}
+              disabled={statusMutation.isPending}
+            >
               <Play className="h-4 w-4 mr-1.5" /> Activate
             </Button>
           )}
-          {assessment.status === 'ACTIVE' && (
+          {assessment.status === "ACTIVE" && (
             <>
-              <Button size="sm" className="glow-cyan" onClick={() => setShowInvite(true)}>
+              <Button
+                size="sm"
+                className="glow-cyan"
+                onClick={() => setShowInvite(true)}
+              >
                 <UserPlus className="h-4 w-4 mr-1.5" /> Invite
               </Button>
-              <Button size="sm" variant="outline" onClick={() => setShowCsvImport(true)}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowCsvImport(true)}
+              >
                 <Upload className="h-4 w-4 mr-1.5" /> Import CSV
               </Button>
-              <Button size="sm" variant="outline" onClick={() => statusMutation.mutate('CLOSED')}
-                disabled={statusMutation.isPending}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => statusMutation.mutate("CLOSED")}
+                disabled={statusMutation.isPending}
+              >
                 <Pause className="h-4 w-4 mr-1.5" /> Close
               </Button>
             </>
@@ -164,6 +211,15 @@ const AssessmentResults = () => {
               <Download className="h-4 w-4 mr-1.5" /> CSV
             </Button>
           )}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() =>
+              navigate(`/org/${slug}/assessments/${aid}/pool-stats`)
+            }
+          >
+            <Database className="h-4 w-4 mr-1.5" /> Pool Stats
+          </Button>
         </div>
       </div>
 
@@ -171,9 +227,7 @@ const AssessmentResults = () => {
       <AssessmentFunnel funnel={funnel} />
 
       {/* Stage pipeline summary */}
-      {candidates.length > 0 && (
-        <StageSummary candidates={candidates} />
-      )}
+      {candidates.length > 0 && <StageSummary candidates={candidates} />}
 
       {/* Candidate table */}
       {candidates.length > 0 ? (
@@ -182,14 +236,20 @@ const AssessmentResults = () => {
           passingScore={assessment.passingScore}
           slug={slug}
           aid={aid!}
-          onReinvite={assessment.status === 'ACTIVE' ? (email) => reinviteMutation.mutate(email) : undefined}
+          onReinvite={
+            assessment.status === "ACTIVE"
+              ? (email) => reinviteMutation.mutate(email)
+              : undefined
+          }
           isReinviting={reinviteMutation.isPending}
         />
       ) : (
         <div className="text-center py-12">
           <Users className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-          <p className="text-muted-foreground font-mono text-sm">No candidates yet</p>
-          {assessment.status === 'ACTIVE' && (
+          <p className="text-muted-foreground font-mono text-sm">
+            No candidates yet
+          </p>
+          {assessment.status === "ACTIVE" && (
             <div className="flex justify-center gap-2 mt-4">
               <Button className="glow-cyan" onClick={() => setShowInvite(true)}>
                 <UserPlus className="h-4 w-4 mr-1.5" /> Invite Candidates
@@ -223,19 +283,31 @@ const AssessmentResults = () => {
 
 // ─── Stage summary bar ────────────────────────────────────────────────────────
 
-import type { CandidateInvite, CandidateStage } from '@/types/assessment-types';
+import type { CandidateInvite, CandidateStage } from "@/types/assessment-types";
 
 const STAGES: { stage: CandidateStage; label: string; color: string }[] = [
-  { stage: 'APPLIED',     label: 'Applied',     color: 'bg-blue-500/20 text-blue-400' },
-  { stage: 'SCREENING',   label: 'Screening',   color: 'bg-amber-500/20 text-amber-400' },
-  { stage: 'SHORTLISTED', label: 'Shortlisted', color: 'bg-violet-500/20 text-violet-400' },
-  { stage: 'HIRED',       label: 'Hired',       color: 'bg-emerald-500/20 text-emerald-400' },
-  { stage: 'REJECTED',    label: 'Rejected',    color: 'bg-red-500/20 text-red-400' },
+  { stage: "APPLIED", label: "Applied", color: "bg-blue-500/20 text-blue-400" },
+  {
+    stage: "SCREENING",
+    label: "Screening",
+    color: "bg-amber-500/20 text-amber-400",
+  },
+  {
+    stage: "SHORTLISTED",
+    label: "Shortlisted",
+    color: "bg-violet-500/20 text-violet-400",
+  },
+  {
+    stage: "HIRED",
+    label: "Hired",
+    color: "bg-emerald-500/20 text-emerald-400",
+  },
+  { stage: "REJECTED", label: "Rejected", color: "bg-red-500/20 text-red-400" },
 ];
 
 const StageSummary = ({ candidates }: { candidates: CandidateInvite[] }) => {
   const counts = candidates.reduce<Record<string, number>>((acc, c) => {
-    const stage = c.stage ?? 'APPLIED';
+    const stage = c.stage ?? "APPLIED";
     acc[stage] = (acc[stage] ?? 0) + 1;
     return acc;
   }, {});

--- a/src/pages/org/OrgCampaigns.tsx
+++ b/src/pages/org/OrgCampaigns.tsx
@@ -9,6 +9,7 @@ import {
   type Campaign,
   type CreateCampaignPayload,
 } from "@/services/campaigns";
+import { issueCertificationsByCampaign } from "@/services/competency-cert";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -45,6 +46,7 @@ import {
   CalendarClock,
   Loader2,
   RefreshCw,
+  ShieldCheck,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -241,14 +243,18 @@ interface CampaignCardProps {
   campaign: Campaign;
   onActivate: (id: string) => void;
   onDelete: (id: string) => void;
+  onIssueCerts: (id: string) => void;
   activating: boolean;
+  issuingCerts: boolean;
 }
 
 const CampaignCard = ({
   campaign,
   onActivate,
   onDelete,
+  onIssueCerts,
   activating,
+  issuingCerts,
 }: CampaignCardProps) => (
   <Card className="bg-card border-border">
     <CardContent className="p-4 space-y-3">
@@ -281,6 +287,15 @@ const CampaignCard = ({
                 disabled={activating}
               >
                 <Play className="h-3.5 w-3.5 mr-2 text-emerald-400" /> Activate
+              </DropdownMenuItem>
+            )}
+            {campaign.status === "CLOSED" && (
+              <DropdownMenuItem
+                onClick={() => onIssueCerts(campaign.id)}
+                disabled={issuingCerts}
+              >
+                <ShieldCheck className="h-3.5 w-3.5 mr-2 text-violet-400" />
+                {issuingCerts ? "Đang cấp..." : "Cấp chứng nhận"}
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
@@ -386,6 +401,18 @@ const OrgCampaigns = () => {
       toast.error(e?.response?.data?.message || "Delete failed"),
   });
 
+  const issueCertsMutation = useMutation({
+    mutationFn: (campaignId: string) =>
+      issueCertificationsByCampaign(org!.id, campaignId),
+    onSuccess: (result) => {
+      toast.success(
+        `Đã cấp ${result.issued} chứng nhận mới, nâng cấp ${result.upgraded}`,
+      );
+    },
+    onError: (e: any) =>
+      toast.error(e?.response?.data?.message || "Issue certs failed"),
+  });
+
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
@@ -429,7 +456,9 @@ const OrgCampaigns = () => {
               campaign={c}
               onActivate={(id) => activateMutation.mutate(id)}
               onDelete={(id) => deleteMutation.mutate(id)}
+              onIssueCerts={(id) => issueCertsMutation.mutate(id)}
               activating={activateMutation.isPending}
+              issuingCerts={issueCertsMutation.isPending}
             />
           ))}
         </div>

--- a/src/pages/org/OrgCampaigns.tsx
+++ b/src/pages/org/OrgCampaigns.tsx
@@ -403,7 +403,7 @@ const OrgCampaigns = () => {
 
   const issueCertsMutation = useMutation({
     mutationFn: (campaignId: string) =>
-      issueCertificationsByCampaign(org!.id, campaignId),
+      issueCertificationsByCampaign(currentOrg!.id, campaignId),
     onSuccess: (result) => {
       toast.success(
         `Đã cấp ${result.issued} chứng nhận mới, nâng cấp ${result.upgraded}`,

--- a/src/pages/org/OrgComplianceDashboard.tsx
+++ b/src/pages/org/OrgComplianceDashboard.tsx
@@ -1,0 +1,235 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useOrgStore } from "@/stores/org.store";
+import {
+  getComplianceDashboard,
+  type ComplianceRow,
+  type CertStatus,
+} from "@/services/competency-cert";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ShieldCheck, AlertTriangle, XCircle, Loader2 } from "lucide-react";
+import { format } from "date-fns";
+
+const STATUS_COLOR: Record<string, string> = {
+  ACTIVE: "bg-emerald-500/15 text-emerald-400",
+  EXPIRING_SOON: "bg-amber-500/15 text-amber-400",
+  EXPIRED: "bg-rose-500/15 text-rose-400",
+  NOT_CERTIFIED: "bg-zinc-500/15 text-zinc-400",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  ACTIVE: "Hoạt động",
+  EXPIRING_SOON: "Sắp hết hạn",
+  EXPIRED: "Hết hạn",
+  NOT_CERTIFIED: "Chưa cấp",
+};
+
+export default function OrgComplianceDashboard() {
+  const { org } = useOrgStore();
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("ALL");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["compliance", org?.id, statusFilter],
+    queryFn: () =>
+      getComplianceDashboard(org!.id, {
+        status: statusFilter === "ALL" ? undefined : statusFilter,
+      }),
+    enabled: !!org,
+  });
+
+  const rows: ComplianceRow[] = (data?.rows ?? []).filter(
+    (r) =>
+      search === "" ||
+      r.memberName.toLowerCase().includes(search.toLowerCase()) ||
+      r.competencyName.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const s = data?.summary;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Tuân thủ chứng nhận</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Theo dõi trạng thái chứng nhận năng lực của tất cả thành viên
+        </p>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4 text-emerald-400" />
+              Đã chứng nhận
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-emerald-400">
+              {s?.certified ?? "—"}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              / {s?.totalMembers ?? "—"} thành viên
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-amber-400" />
+              Sắp hết hạn
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-amber-400">
+              {s?.expiringSoon ?? "—"}
+            </div>
+            <div className="text-xs text-muted-foreground">trong 30 ngày</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <XCircle className="h-4 w-4 text-rose-400" />
+              Hết hạn
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-rose-400">
+              {s?.expired ?? "—"}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Chưa cấp
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-zinc-400">
+              {s?.notCertified ?? "—"}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters */}
+      <div className="flex gap-3">
+        <Input
+          placeholder="Tìm kiếm thành viên / năng lực..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="max-w-xs"
+        />
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ALL">Tất cả</SelectItem>
+            <SelectItem value="ACTIVE">Hoạt động</SelectItem>
+            <SelectItem value="EXPIRING_SOON">Sắp hết hạn</SelectItem>
+            <SelectItem value="EXPIRED">Hết hạn</SelectItem>
+            <SelectItem value="NOT_CERTIFIED">Chưa cấp</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="flex justify-center p-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Thành viên</TableHead>
+                  <TableHead>Nhóm</TableHead>
+                  <TableHead>Năng lực</TableHead>
+                  <TableHead>Cấp độ</TableHead>
+                  <TableHead>Trạng thái</TableHead>
+                  <TableHead>Hết hạn</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={6}
+                      className="text-center text-muted-foreground py-8"
+                    >
+                      Không có dữ liệu
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  rows.map((row, i) => (
+                    <TableRow key={`${row.memberId}-${row.competencyId}-${i}`}>
+                      <TableCell className="font-medium">
+                        {row.memberName}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {row.groupName ?? "—"}
+                      </TableCell>
+                      <TableCell>{row.competencyName}</TableCell>
+                      <TableCell>
+                        {row.achievedLevel != null ? (
+                          <span>
+                            {row.achievedLevel} / {row.requiredLevel}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">
+                            — / {row.requiredLevel}
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          className={
+                            STATUS_COLOR[row.certStatus] ??
+                            STATUS_COLOR.NOT_CERTIFIED
+                          }
+                        >
+                          {STATUS_LABEL[row.certStatus] ?? row.certStatus}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm">
+                        {row.expiresAt
+                          ? format(new Date(row.expiresAt), "dd/MM/yyyy")
+                          : "—"}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/org/OrgExecutiveDashboard.tsx
+++ b/src/pages/org/OrgExecutiveDashboard.tsx
@@ -16,7 +16,6 @@ import {
   Loader2,
   RefreshCw,
 } from "lucide-react";
-import { useAuthStore } from "@/stores/auth.store";
 
 function StatCard({
   title,
@@ -48,19 +47,18 @@ function StatCard({
 }
 
 export default function OrgExecutiveDashboard() {
-  const { org } = useOrgStore();
-  const { token } = useAuthStore();
+  const currentOrg = useOrgStore((s) => s.currentOrg);
 
   const { data, isLoading, refetch, isFetching } = useQuery({
-    queryKey: ["executive-dashboard", org?.id],
-    queryFn: () => getExecutiveDashboard(org!.id),
-    enabled: !!org,
+    queryKey: ["executive-dashboard", currentOrg?.id],
+    queryFn: () => getExecutiveDashboard(currentOrg!.id),
+    enabled: !!currentOrg,
     staleTime: 5 * 60 * 1000,
   });
 
   const handleExport = () => {
-    if (!org) return;
-    const url = getExecutiveDashboardCsvUrl(org.id);
+    if (!currentOrg) return;
+    const url = getExecutiveDashboardCsvUrl(currentOrg.id);
     const a = document.createElement("a");
     a.href = url;
     a.click();

--- a/src/pages/org/OrgExecutiveDashboard.tsx
+++ b/src/pages/org/OrgExecutiveDashboard.tsx
@@ -1,0 +1,274 @@
+import { useQuery } from "@tanstack/react-query";
+import { useOrgStore } from "@/stores/org.store";
+import {
+  getExecutiveDashboard,
+  getExecutiveDashboardCsvUrl,
+} from "@/services/executive-dashboard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import {
+  ShieldCheck,
+  Users,
+  TrendingUp,
+  AlertTriangle,
+  Download,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+import { useAuthStore } from "@/stores/auth.store";
+
+function StatCard({
+  title,
+  value,
+  sub,
+  icon: Icon,
+  color = "text-foreground",
+}: {
+  title: string;
+  value: string | number;
+  sub?: string;
+  icon: React.ElementType;
+  color?: string;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+          <Icon className={`h-4 w-4 ${color}`} />
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className={`text-3xl font-bold ${color}`}>{value}</div>
+        {sub && <div className="text-xs text-muted-foreground mt-1">{sub}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function OrgExecutiveDashboard() {
+  const { org } = useOrgStore();
+  const { token } = useAuthStore();
+
+  const { data, isLoading, refetch, isFetching } = useQuery({
+    queryKey: ["executive-dashboard", org?.id],
+    queryFn: () => getExecutiveDashboard(org!.id),
+    enabled: !!org,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const handleExport = () => {
+    if (!org) return;
+    const url = getExecutiveDashboardCsvUrl(org.id);
+    const a = document.createElement("a");
+    a.href = url;
+    a.click();
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Executive Dashboard</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Tổng quan tuân thủ, tuyển dụng và toàn vẹn
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            <RefreshCw
+              className={`h-4 w-4 mr-2 ${isFetching ? "animate-spin" : ""}`}
+            />
+            Làm mới
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleExport}>
+            <Download className="h-4 w-4 mr-2" />
+            Xuất CSV
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : !data ? null : (
+        <>
+          {/* Compliance */}
+          <section className="space-y-4">
+            <h2 className="text-lg font-medium flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-emerald-400" />
+              Tuân thủ chứng nhận
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <StatCard
+                title="Tỷ lệ chứng nhận"
+                value={`${data.compliance.certRate}%`}
+                sub={`${data.compliance.certifiedMembers} / ${data.compliance.totalMembers} thành viên`}
+                icon={ShieldCheck}
+                color="text-emerald-400"
+              />
+              <StatCard
+                title="Chứng nhận hoạt động"
+                value={data.compliance.certsByStatus.active}
+                icon={ShieldCheck}
+                color="text-emerald-400"
+              />
+              <StatCard
+                title="Sắp hết hạn"
+                value={data.compliance.certsByStatus.expiringSoon}
+                sub="trong 30 ngày"
+                icon={AlertTriangle}
+                color="text-amber-400"
+              />
+              <StatCard
+                title="Đã hết hạn"
+                value={data.compliance.certsByStatus.expired}
+                icon={AlertTriangle}
+                color="text-rose-400"
+              />
+            </div>
+            <Card>
+              <CardContent className="pt-4">
+                <div className="flex justify-between text-sm mb-2">
+                  <span className="text-muted-foreground">
+                    Tỷ lệ tuân thủ tổng
+                  </span>
+                  <span className="font-medium">
+                    {data.compliance.certRate}%
+                  </span>
+                </div>
+                <Progress value={data.compliance.certRate} className="h-2" />
+              </CardContent>
+            </Card>
+          </section>
+
+          {/* Hiring Funnel */}
+          <section className="space-y-4">
+            <h2 className="text-lg font-medium flex items-center gap-2">
+              <Users className="h-5 w-5 text-blue-400" />
+              Phễu tuyển dụng
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <StatCard
+                title="Ứng viên mời"
+                value={data.funnel.totalCandidates}
+                icon={Users}
+                color="text-blue-400"
+              />
+              <StatCard
+                title="Đã nộp bài"
+                value={data.funnel.submitted}
+                sub={`Tỷ lệ hoàn thành: ${data.funnel.conversionRate}%`}
+                icon={TrendingUp}
+                color="text-blue-400"
+              />
+              <StatCard
+                title="Đạt yêu cầu"
+                value={data.funnel.passed}
+                sub={`Pass rate: ${data.funnel.passRate}%`}
+                icon={TrendingUp}
+                color="text-emerald-400"
+              />
+              <StatCard
+                title="Campaign đang mở"
+                value={data.funnel.activeCampaigns}
+                sub={`/ ${data.funnel.campaigns} tổng`}
+                icon={Users}
+              />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Card>
+                <CardContent className="pt-4">
+                  <div className="flex justify-between text-sm mb-2">
+                    <span className="text-muted-foreground">
+                      Tỷ lệ hoàn thành
+                    </span>
+                    <span>{data.funnel.conversionRate}%</span>
+                  </div>
+                  <Progress
+                    value={data.funnel.conversionRate}
+                    className="h-2"
+                  />
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-4">
+                  <div className="flex justify-between text-sm mb-2">
+                    <span className="text-muted-foreground">Tỷ lệ đậu</span>
+                    <span>{data.funnel.passRate}%</span>
+                  </div>
+                  <Progress value={data.funnel.passRate} className="h-2" />
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+
+          {/* Integrity */}
+          <section className="space-y-4">
+            <h2 className="text-lg font-medium flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-rose-400" />
+              Toàn vẹn thi cử
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <StatCard
+                title="Ứng viên bị gắn cờ"
+                value={data.integrity.flaggedCount}
+                sub={`${data.integrity.flagRate}% tổng nộp`}
+                icon={AlertTriangle}
+                color="text-rose-400"
+              />
+              <StatCard
+                title="Điểm toàn vẹn TB"
+                value={
+                  data.integrity.avgIntegrityScore != null
+                    ? data.integrity.avgIntegrityScore
+                    : "—"
+                }
+                sub="/ 100"
+                icon={ShieldCheck}
+                color={
+                  (data.integrity.avgIntegrityScore ?? 100) >= 80
+                    ? "text-emerald-400"
+                    : "text-amber-400"
+                }
+              />
+              <StatCard
+                title="Tổng nộp bài"
+                value={data.integrity.totalSubmitted}
+                icon={Users}
+              />
+            </div>
+            {data.integrity.avgIntegrityScore != null && (
+              <Card>
+                <CardContent className="pt-4">
+                  <div className="flex justify-between text-sm mb-2">
+                    <span className="text-muted-foreground">
+                      Điểm toàn vẹn trung bình
+                    </span>
+                    <span>{data.integrity.avgIntegrityScore} / 100</span>
+                  </div>
+                  <Progress
+                    value={data.integrity.avgIntegrityScore}
+                    className="h-2"
+                  />
+                </CardContent>
+              </Card>
+            )}
+          </section>
+
+          <p className="text-xs text-muted-foreground">
+            Cập nhật lúc: {new Date(data.generatedAt).toLocaleString("vi-VN")} ·
+            Cache 5 phút
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/org/OrgPoolStats.tsx
+++ b/src/pages/org/OrgPoolStats.tsx
@@ -1,0 +1,186 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useOrgStore } from "@/stores/org.store";
+import api from "@/services/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Shuffle, Database, TrendingDown, Loader2 } from "lucide-react";
+
+interface PoolStats {
+  assessmentId: string;
+  selectionMode: string;
+  poolSize: number;
+  drawCount: number;
+  overlapPct: number;
+  uniqueQuestionRatio: number;
+  leastUsedQuestions: { questionId: string; usedCount: number }[];
+}
+
+const getPoolStats = (orgId: string, aid: string): Promise<PoolStats> =>
+  api
+    .get(`/organizations/${orgId}/assessments/${aid}/pool-stats`)
+    .then((r) => r.data);
+
+export default function OrgPoolStats() {
+  const { aid } = useParams<{ aid: string }>();
+  const { org } = useOrgStore();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["pool-stats", org?.id, aid],
+    queryFn: () => getPoolStats(org!.id, aid!),
+    enabled: !!org && !!aid,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const overlapColor =
+    data.overlapPct >= 80
+      ? "text-rose-400"
+      : data.overlapPct >= 50
+        ? "text-amber-400"
+        : "text-emerald-400";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Thống kê Question Pool</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Phân tích mức độ đa dạng và trùng lặp câu hỏi
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Database className="h-4 w-4" />
+              Kích thước pool
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{data.poolSize}</div>
+            <div className="text-xs text-muted-foreground">
+              câu hỏi khả dụng
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Shuffle className="h-4 w-4" />
+              Số câu rút
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{data.drawCount}</div>
+            <div className="text-xs text-muted-foreground">mỗi lần thi</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Tỷ lệ trùng lặp
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className={`text-3xl font-bold ${overlapColor}`}>
+              {data.overlapPct}%
+            </div>
+            <div className="text-xs text-muted-foreground">
+              overlap giữa các lần thi
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <TrendingDown className="h-4 w-4 text-emerald-400" />
+              Đa dạng câu hỏi
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold text-emerald-400">
+              {data.uniqueQuestionRatio}%
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="flex justify-between text-sm mb-2">
+            <span className="text-muted-foreground">Mức độ trùng lặp</span>
+            <span className={overlapColor}>{data.overlapPct}%</span>
+          </div>
+          <Progress value={data.overlapPct} className="h-2" />
+          <p className="text-xs text-muted-foreground mt-2">
+            {data.overlapPct >= 80
+              ? "⚠ Pool nhỏ — mỗi bộ đề trùng nhiều câu. Hãy bổ sung thêm câu hỏi."
+              : data.overlapPct >= 50
+                ? "Pool trung bình — nên thêm câu hỏi để tăng tính bảo mật."
+                : "Pool tốt — đủ đa dạng để giảm thiểu trùng lặp."}
+          </p>
+        </CardContent>
+      </Card>
+
+      {data.leastUsedQuestions.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Câu hỏi ít được sử dụng nhất
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID câu hỏi</TableHead>
+                  <TableHead className="text-right">Số lần xuất hiện</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.leastUsedQuestions.map((q) => (
+                  <TableRow key={q.questionId}>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {q.questionId}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Badge variant="outline">{q.usedCount}</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="text-xs text-muted-foreground">
+        Chế độ chọn câu hỏi:{" "}
+        <Badge variant="outline" className="text-xs">
+          {data.selectionMode}
+        </Badge>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/org/OrgPoolStats.tsx
+++ b/src/pages/org/OrgPoolStats.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useOrgStore } from "@/stores/org.store";
-import api from "@/services/api";
+import { getPoolStats, type PoolStats } from "@/services/assessments";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
@@ -15,29 +15,14 @@ import {
 } from "@/components/ui/table";
 import { Shuffle, Database, TrendingDown, Loader2 } from "lucide-react";
 
-interface PoolStats {
-  assessmentId: string;
-  selectionMode: string;
-  poolSize: number;
-  drawCount: number;
-  overlapPct: number;
-  uniqueQuestionRatio: number;
-  leastUsedQuestions: { questionId: string; usedCount: number }[];
-}
-
-const getPoolStats = (orgId: string, aid: string): Promise<PoolStats> =>
-  api
-    .get(`/organizations/${orgId}/assessments/${aid}/pool-stats`)
-    .then((r) => r.data);
-
 export default function OrgPoolStats() {
   const { aid } = useParams<{ aid: string }>();
-  const { org } = useOrgStore();
+  const currentOrg = useOrgStore((s) => s.currentOrg);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["pool-stats", org?.id, aid],
-    queryFn: () => getPoolStats(org!.id, aid!),
-    enabled: !!org && !!aid,
+  const { data, isLoading } = useQuery<PoolStats>({
+    queryKey: ["pool-stats", currentOrg?.slug, aid],
+    queryFn: () => getPoolStats(currentOrg!.slug, aid!),
+    enabled: !!currentOrg && !!aid,
   });
 
   if (isLoading) {

--- a/src/services/assessments.ts
+++ b/src/services/assessments.ts
@@ -1,4 +1,4 @@
-import api from './api';
+import api from "./api";
 import type {
   Assessment,
   AssessmentResults,
@@ -15,7 +15,7 @@ import type {
   CandidateInvite,
   UpdateCandidateDecisionPayload,
   PoolConfig,
-} from '@/types/assessment-types';
+} from "@/types/assessment-types";
 
 const base = (slug: string) => `/organizations/${slug}/assessments`;
 
@@ -62,7 +62,9 @@ export const updateAssessmentStatus = async (
   aid: string,
   status: AssessmentStatus,
 ): Promise<Assessment> => {
-  const res = await api.patch<Assessment>(`${base(slug)}/${aid}/status`, { status });
+  const res = await api.patch<Assessment>(`${base(slug)}/${aid}/status`, {
+    status,
+  });
   return res.data;
 };
 
@@ -71,7 +73,10 @@ export const inviteCandidates = async (
   aid: string,
   data: InviteCandidatePayload,
 ): Promise<{ invited: number }> => {
-  const res = await api.post<{ invited: number }>(`${base(slug)}/${aid}/invite`, data);
+  const res = await api.post<{ invited: number }>(
+    `${base(slug)}/${aid}/invite`,
+    data,
+  );
   return res.data;
 };
 
@@ -83,9 +88,12 @@ export const getAssessmentResults = async (
   return res.data;
 };
 
-export const exportAssessmentCsv = async (slug: string, aid: string): Promise<string> => {
+export const exportAssessmentCsv = async (
+  slug: string,
+  aid: string,
+): Promise<string> => {
   const res = await api.get<string>(`${base(slug)}/${aid}/results/export`, {
-    responseType: 'text',
+    responseType: "text",
   });
   return res.data;
 };
@@ -93,13 +101,17 @@ export const exportAssessmentCsv = async (slug: string, aid: string): Promise<st
 /** Preview: count APPROVED questions matching a pool config filter. */
 export const getPoolCount = async (
   slug: string,
-  config: Partial<Pick<PoolConfig, 'difficulty' | 'certificationId' | 'categories' | 'tags'>>,
+  config: Partial<
+    Pick<PoolConfig, "difficulty" | "certificationId" | "categories" | "tags">
+  >,
 ): Promise<{ available: number }> => {
   const params = new URLSearchParams();
-  if (config.difficulty) params.set('difficulty', config.difficulty);
-  if (config.certificationId) params.set('certificationId', config.certificationId);
-  if (config.categories?.length) params.set('categories', config.categories.join(','));
-  if (config.tags?.length) params.set('tags', config.tags.join(','));
+  if (config.difficulty) params.set("difficulty", config.difficulty);
+  if (config.certificationId)
+    params.set("certificationId", config.certificationId);
+  if (config.categories?.length)
+    params.set("categories", config.categories.join(","));
+  if (config.tags?.length) params.set("tags", config.tags.join(","));
   const res = await api.get<{ available: number }>(
     `${base(slug)}/pool-count?${params.toString()}`,
   );
@@ -118,7 +130,9 @@ export const loadCandidateAssessment = async (
 export const startCandidateAttempt = async (
   token: string,
 ): Promise<CandidateExamPayload> => {
-  const res = await api.post<CandidateExamPayload>(`/assessments/take/${token}/start`);
+  const res = await api.post<CandidateExamPayload>(
+    `/assessments/take/${token}/start`,
+  );
   return res.data;
 };
 
@@ -145,8 +159,12 @@ export const reportCandidateEvent = async (
   });
 };
 
-export const requestCandidateOtp = async (token: string): Promise<{ message: string }> => {
-  const res = await api.post<{ message: string }>(`/assessments/take/${token}/otp/request`);
+export const requestCandidateOtp = async (
+  token: string,
+): Promise<{ message: string }> => {
+  const res = await api.post<{ message: string }>(
+    `/assessments/take/${token}/otp/request`,
+  );
   return res.data;
 };
 
@@ -194,5 +212,23 @@ export const bulkInviteCandidatesFromCsv = async (
     `${base(slug)}/${aid}/invite`,
     { candidates },
   );
+  return res.data;
+};
+
+export interface PoolStats {
+  assessmentId: string;
+  selectionMode: string;
+  poolSize: number;
+  drawCount: number;
+  overlapPct: number;
+  uniqueQuestionRatio: number;
+  leastUsedQuestions: { questionId: string; usedCount: number }[];
+}
+
+export const getPoolStats = async (
+  slug: string,
+  aid: string,
+): Promise<PoolStats> => {
+  const res = await api.get<PoolStats>(`${base(slug)}/${aid}/pool-stats`);
   return res.data;
 };

--- a/src/services/competency-cert.ts
+++ b/src/services/competency-cert.ts
@@ -1,0 +1,89 @@
+import api from "./api";
+
+export type CertStatus =
+  | "ACTIVE"
+  | "EXPIRING_SOON"
+  | "EXPIRED"
+  | "NOT_CERTIFIED";
+
+export interface Certification {
+  id: string;
+  competencyId: string;
+  competencyName: string;
+  achievedLevel: number;
+  scaleMax: number;
+  issuedAt: string;
+  expiresAt: string;
+  status: CertStatus;
+  campaignName?: string | null;
+}
+
+export interface ComplianceRow {
+  memberId: string;
+  memberName: string;
+  groupName?: string | null;
+  competencyId: string;
+  competencyName: string;
+  certStatus: CertStatus | "NOT_CERTIFIED";
+  achievedLevel?: number | null;
+  requiredLevel: number;
+  expiresAt?: string | null;
+}
+
+export interface ComplianceSummary {
+  totalMembers: number;
+  certified: number;
+  expiringSoon: number;
+  expired: number;
+  notCertified: number;
+}
+
+export interface ComplianceResponse {
+  summary: ComplianceSummary;
+  rows: ComplianceRow[];
+}
+
+export const issueCertificationsByCampaign = (
+  orgId: string,
+  campaignId: string,
+) =>
+  api
+    .post(
+      `/organizations/${orgId}/campaigns/${campaignId}/issue-certifications`,
+    )
+    .then((r) => r.data);
+
+export const getMemberCertifications = (
+  orgId: string,
+  memberId: string,
+  status?: string,
+) =>
+  api
+    .get(`/organizations/${orgId}/members/${memberId}/certifications`, {
+      params: { status },
+    })
+    .then((r) => r.data);
+
+export const getOrgCertifications = (
+  orgId: string,
+  filters?: {
+    competencyId?: string;
+    groupId?: string;
+    status?: string;
+    page?: number;
+    limit?: number;
+  },
+) =>
+  api
+    .get(`/organizations/${orgId}/certifications`, { params: filters })
+    .then((r) => r.data);
+
+export const getComplianceDashboard = (
+  orgId: string,
+  filters?: { competencyId?: string; groupId?: string; status?: string },
+): Promise<ComplianceResponse> =>
+  api
+    .get(`/organizations/${orgId}/certifications/compliance`, {
+      params: filters,
+    })
+    .then((r) => r.data);

--- a/src/services/executive-dashboard.ts
+++ b/src/services/executive-dashboard.ts
@@ -1,0 +1,41 @@
+import api from "./api";
+
+export interface ComplianceMetrics {
+  totalMembers: number;
+  certifiedMembers: number;
+  certRate: number;
+  certsByStatus: { active: number; expiringSoon: number; expired: number };
+}
+
+export interface HiringFunnel {
+  campaigns: number;
+  activeCampaigns: number;
+  totalCandidates: number;
+  started: number;
+  submitted: number;
+  passed: number;
+  conversionRate: number;
+  passRate: number;
+}
+
+export interface IntegrityMetrics {
+  totalSubmitted: number;
+  flaggedCount: number;
+  flagRate: number;
+  avgIntegrityScore: number | null;
+}
+
+export interface ExecutiveDashboard {
+  compliance: ComplianceMetrics;
+  funnel: HiringFunnel;
+  integrity: IntegrityMetrics;
+  generatedAt: string;
+}
+
+export const getExecutiveDashboard = (
+  orgId: string,
+): Promise<ExecutiveDashboard> =>
+  api.get(`/organizations/${orgId}/executive-dashboard`).then((r) => r.data);
+
+export const getExecutiveDashboardCsvUrl = (orgId: string) =>
+  `/api/v1/organizations/${orgId}/executive-dashboard/export/csv`;

--- a/src/services/idp.ts
+++ b/src/services/idp.ts
@@ -1,0 +1,88 @@
+import api from "./api";
+
+export interface IdpItem {
+  id: string;
+  competencyId: string;
+  competencyName: string;
+  trackId: string;
+  trackName: string;
+  targetLevel: number;
+  scaleMax: number;
+  dueDate?: string | null;
+  completedAt?: string | null;
+  status: "PENDING" | "COMPLETED" | "OVERDUE";
+}
+
+export interface CampaignReview {
+  memberId: string;
+  memberName: string;
+  memberEmail: string;
+  note: string;
+  direction?: string | null;
+  reviewedBy: string;
+  updatedAt: string;
+}
+
+export const getCampaignReviews = (orgId: string, campaignId: string) =>
+  api
+    .get(`/organizations/${orgId}/campaigns/${campaignId}/reviews`)
+    .then((r) => r.data);
+
+export const getCampaignMemberReview = (
+  orgId: string,
+  campaignId: string,
+  memberId: string,
+) =>
+  api
+    .get(`/organizations/${orgId}/campaigns/${campaignId}/reviews/${memberId}`)
+    .then((r) => r.data);
+
+export const upsertCampaignMemberReview = (
+  orgId: string,
+  campaignId: string,
+  memberId: string,
+  dto: { note: string; direction?: string },
+) =>
+  api
+    .post(
+      `/organizations/${orgId}/campaigns/${campaignId}/reviews/${memberId}`,
+      dto,
+    )
+    .then((r) => r.data);
+
+export const getMemberIdps = (orgId: string, memberId: string) =>
+  api
+    .get(`/organizations/${orgId}/members/${memberId}/idp`)
+    .then((r) => r.data);
+
+export const createMemberIdp = (
+  orgId: string,
+  memberId: string,
+  dto: {
+    competencyId: string;
+    trackId: string;
+    targetLevel: number;
+    dueDate?: string;
+  },
+) =>
+  api
+    .post(`/organizations/${orgId}/members/${memberId}/idp`, dto)
+    .then((r) => r.data);
+
+export const completeMemberIdp = (
+  orgId: string,
+  memberId: string,
+  idpId: string,
+) =>
+  api
+    .patch(`/organizations/${orgId}/members/${memberId}/idp/${idpId}/complete`)
+    .then((r) => r.data);
+
+export const deleteMemberIdp = (
+  orgId: string,
+  memberId: string,
+  idpId: string,
+) =>
+  api
+    .delete(`/organizations/${orgId}/members/${memberId}/idp/${idpId}`)
+    .then((r) => r.data);


### PR DESCRIPTION
## Summary

Sprint 3 implements the **Compliance & Integrity** feature set across 5 P1 user stories, followed by a thorough code review pass that resolved all critical, high, and medium findings.

### User Stories

| Story | Feature |
|---|---|
| **US-B3** | Competency Certification issuance — campaign → scorecard → cert with expiry and upgrade/revoke logic |
| **US-B4** | Manager Review & Individual Development Plans (IDP) — upsert reviews, create/complete/delete IDPs |
| **US-D1** | Unique Question Sets / Pool Stats — pool size, draw count, overlap %, least-used questions endpoint |
| **US-D2** | Advanced Proctoring / Risk Flagging — auto-flag on submit, manual flag/unflag, risk timeline, risk-config |
| **US-G1** | Executive Dashboard — compliance metrics, hiring funnel, integrity metrics, CSV export, 5-min Redis cache |

### New backend modules
- `CompetencyCertModule` — `issueByCampaign`, `findByMember`, `findByOrg`, `getCompliance`
- `IdpModule` — campaign member reviews + member IDPs (CRUD)
- `ExecutiveDashboardModule` — aggregated dashboard + CSV export

### New frontend pages
- `/org/:slug/competency/compliance` — cert compliance dashboard with status filter
- `/org/:slug/executive-dashboard` — executive summary with Progress bars and CSV export
- `/org/:slug/assessments/:aid/pool-stats` — pool diversity and least-used question table

### Schema additions (manual SQL migration)
New tables: `competency_certifications`, `campaign_member_reviews`, `member_idps`  
New fields: `competencies.validity_months`, `assessments.risk_threshold / auto_flag_risk`, `candidate_invites.is_flagged / flagged_at / flagged_reason / flagged_by`

---

## Code Review Fixes (commit 2)

All Critical, High, and Medium findings from the self-review were addressed:

**Performance / Correctness:**
- Removed broken `getAssessmentIdsForCatalog` (queried `Assessment.id = catalogItemId`, always `[]`); now uses org-wide assessment IDs
- `issueByCampaign`: batch-fetches member emails, submitted invites, existing certs, and scorecard competencies before the loop — eliminates 4-level nested N+1
- `getCompliance`: single bulk cert fetch + `Map<memberId:competencyId>` replaces N×M `findFirst` calls
- `findByOrg`: status filter pushed into Prisma `WHERE` with date predicates so pagination `total` is correct
- `getHiringFunnel`: eliminated duplicate `assessment.findMany`; per-assessment `passingScore` replaces hardcoded `>= 70`
- Revoke superseded cert before issuing upgrade in `issueByCampaign`

**Security / Correctness:**
- `getCompliance` `jobRoleCompetency` query now scoped to org via `jobRole: { orgId }` — prevents cross-org requirement leakage

**Type Safety / Validation:**
- `UpdateRiskConfigDto` and `PatchFlagDto` with `class-validator` decorators (replaces inline object types)
- `UpsertReviewDto` / `CreateIdpDto` converted from plain interfaces to class-validator classes
- `NOT_CERTIFIED` added to `CertStatus` union type

**Frontend Bugs:**
- `useOrgStore` destructuring fixed in `OrgPoolStats`, `OrgExecutiveDashboard`, `OrgCampaigns` (store exports `currentOrg`, not `org`)
- `org!.id` reference in `OrgCampaigns` corrected to `currentOrg!.id`
- `getPoolStats` moved from inline component function to `src/services/assessments.ts`

**Observability:**
- `autoFlagIfRisky` and `screeningService.evaluate` failures now log via `Logger.warn` instead of silently swallowing

---

## Test plan

- [ ] `POST /organizations/:orgId/campaigns/:id/issue-certifications` on a CLOSED campaign issues certs for all members with submitted invites
- [ ] Upgrade path: re-issuing at a higher level revokes the old cert and creates a new one
- [ ] `GET /organizations/:orgId/certifications/compliance` returns correct status breakdown, scoped to the org's own job roles
- [ ] `GET /organizations/:orgId/certifications?status=EXPIRING_SOON&page=2` returns correct total and rows
- [ ] `GET /organizations/:orgId/executive-dashboard` is served from Redis cache on second request
- [ ] `PATCH /organizations/:orgId/assessments/:aid/risk-config` rejects invalid body (non-integer `riskThreshold`)
- [ ] `GET /org/:slug/executive-dashboard` loads without error (was crashing with `org is undefined`)
- [ ] `GET /org/:slug/assessments/:aid/pool-stats` loads pool diversity stats
- [ ] Cert compliance sidebar link visible only to OWNER/ADMIN

🤖 Generated with [Claude Code](https://claude.ai/claude-code)